### PR TITLE
feat(ontology): add entity-type subsumption (subtype_of)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,7 @@ name: Validate MIF Bundles and Schemas
       - 'profiles/**'
       - 'ontologies/**'
       - 'scripts/*.py'
+      - 'test/**'
       - 'docs/**'
       - 'src/content/docs/**'
       - 'package.json'
@@ -22,6 +23,7 @@ name: Validate MIF Bundles and Schemas
       - 'profiles/**'
       - 'ontologies/**'
       - 'scripts/*.py'
+      - 'test/**'
       - 'docs/**'
       - 'src/content/docs/**'
       - 'package.json'
@@ -126,11 +128,21 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
       - name: Install dependencies
-        run: pip install jsonschema pyyaml
+        run: |
+          pip install pyyaml
+          npm install -g ajv-cli ajv-formats
 
       - name: Validate ontology files
         run: python scripts/validate-ontologies.py
 
       - name: Validate namespace consistency
         run: python scripts/validate-namespaces.py
+
+      - name: Test subtype_of integrity
+        run: python scripts/test_subtype_of.py

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,5 @@
 {
   "MD001": false,
   "MD013": false,
-  "MD024": { "siblings_only": true }
+  "MD024": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,5 @@
 {
   "MD001": false,
   "MD013": false,
-  "MD024": false,
-  "MD060": false
+  "MD024": { "siblings_only": true }
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD001": false,
+  "MD013": false,
+  "MD024": false,
+  "MD060": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,10 +81,14 @@ See [MIGRATION.md](MIGRATION.md) and run
     domain). Optional and additive — existing ontologies are unaffected.
   - Projected to JSON-LD as `mif:subtypeOf` (`scripts/yaml2jsonld.py`,
     `ontology.context.jsonld`).
-  - `scripts/validate-ontologies.py` enforces integrity: every parent resolves to a
-    declared type (locally or via `extends`), no self-reference, acyclic graph.
-    Covered by `scripts/test_subtype_of.py` (+ `test/subtype_of/` fixtures). Demonstrated
+  - `scripts/validate-ontologies.py` enforces integrity across the whole ontology
+    corpus: every parent resolves to a declared type (in the ontology or one it
+    `extends`, resolved over the full chain), a subtype's `required` set includes each
+    parent's (substitutability), no self-reference, acyclic graph. Covered by
+    `scripts/test_subtype_of.py` (+ `test/subtype_of/` fixtures, run in CI). Demonstrated
     by `software-engineering` `security-incident` `subtype_of: [incident-report]`.
+  - `scripts/validate-ontologies.py` now validates schema conformance with **ajv**
+    (draft2020, matching the JSON-LD validation job) instead of Python `jsonschema`.
 
 - **[Schema]**: EntityData field for ontology-typed memories
   - New `entity` property with `name` (required), `entity_type`, and `entity_id` fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,17 @@ See [MIGRATION.md](MIGRATION.md) and run
 
 ### Added
 
+- **[Schema]**: Entity-type subsumption — optional `subtype_of` field on entity types
+  - A type may declare `subtype_of: [parent, ...]`; a subtype is substitutable for any
+    of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint
+    domain). Optional and additive — existing ontologies are unaffected.
+  - Projected to JSON-LD as `mif:subtypeOf` (`scripts/yaml2jsonld.py`,
+    `ontology.context.jsonld`).
+  - `scripts/validate-ontologies.py` enforces integrity: every parent resolves to a
+    declared type (locally or via `extends`), no self-reference, acyclic graph.
+    Covered by `scripts/test_subtype_of.py` (+ `test/subtype_of/` fixtures). Demonstrated
+    by `software-engineering` `security-incident` `subtype_of: [incident-report]`.
+
 - **[Schema]**: EntityData field for ontology-typed memories
   - New `entity` property with `name` (required), `entity_type`, and `entity_id` fields
   - Supports additional properties defined by ontology entity_type schemas

--- a/ontologies/examples/backstage.ontology.jsonld
+++ b/ontologies/examples/backstage.ontology.jsonld
@@ -62,6 +62,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"

--- a/ontologies/examples/biology-research-lab.ontology.jsonld
+++ b/ontologies/examples/biology-research-lab.ontology.jsonld
@@ -62,6 +62,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"

--- a/ontologies/examples/csi-5w1h.ontology.jsonld
+++ b/ontologies/examples/csi-5w1h.ontology.jsonld
@@ -62,6 +62,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"

--- a/ontologies/examples/k12-educational-publishing.ontology.jsonld
+++ b/ontologies/examples/k12-educational-publishing.ontology.jsonld
@@ -62,6 +62,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"

--- a/ontologies/examples/regenerative-agriculture.ontology.jsonld
+++ b/ontologies/examples/regenerative-agriculture.ontology.jsonld
@@ -62,6 +62,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"

--- a/ontologies/examples/software-engineering.ontology.jsonld
+++ b/ontologies/examples/software-engineering.ontology.jsonld
@@ -341,6 +341,7 @@
         "properties": {
           "severity": {
             "type": "string",
+            "description": "Incident severity level",
             "enum": [
               "critical",
               "high",

--- a/ontologies/examples/software-engineering.ontology.jsonld
+++ b/ontologies/examples/software-engineering.ontology.jsonld
@@ -62,6 +62,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"
@@ -310,6 +315,62 @@
           "duration_minutes": {
             "type": "integer",
             "description": "Incident duration in minutes"
+          }
+        }
+      }
+    },
+    {
+      "@id": "mif:entityType/security-incident",
+      "@type": "mif:EntityType",
+      "name": "security-incident",
+      "base": "episodic",
+      "description": "A security breach/incident \u2014 a specialization of incident-report carrying the VERIS Actor/Action/Asset/Attribute",
+      "traits": [
+        "mif:trait/timeline",
+        "mif:trait/stakeholders"
+      ],
+      "subtype_of": [
+        "mif:entityType/incident-report"
+      ],
+      "schema": {
+        "required": [
+          "severity",
+          "impact",
+          "resolution"
+        ],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "impact": {
+            "type": "string",
+            "description": "Business/user impact description"
+          },
+          "resolution": {
+            "type": "string",
+            "description": "How the incident was resolved"
+          },
+          "actor": {
+            "type": "string",
+            "description": "VERIS Actor \u2014 external / internal / partner"
+          },
+          "action": {
+            "type": "string",
+            "description": "VERIS Action \u2014 malware / hacking / social / error / misuse"
+          },
+          "asset": {
+            "type": "string",
+            "description": "VERIS Asset \u2014 the device/data affected"
+          },
+          "attribute": {
+            "type": "string",
+            "description": "VERIS Attribute \u2014 how affected (CIA)"
           }
         }
       }

--- a/ontologies/examples/software-engineering.ontology.yaml
+++ b/ontologies/examples/software-engineering.ontology.yaml
@@ -144,6 +144,49 @@ entity_types:
           type: integer
           description: "Incident duration in minutes"
 
+  # A security breach is a specialization of incident-report: it is substitutable
+  # wherever incident-report is admissible, and adds the VERIS four A's. Demonstrates
+  # `subtype_of` (entity-type subsumption).
+  - name: security-incident
+    description: "A security breach/incident — a specialization of incident-report carrying the VERIS Actor/Action/Asset/Attribute"
+    base: episodic
+    subtype_of:
+      - incident-report
+    traits:
+      - timeline
+      - stakeholders
+    schema:
+      required:
+        - severity
+        - impact
+        - resolution
+      properties:
+        severity:
+          type: string
+          enum:
+            - critical
+            - high
+            - medium
+            - low
+        impact:
+          type: string
+          description: "Business/user impact description"
+        resolution:
+          type: string
+          description: "How the incident was resolved"
+        actor:
+          type: string
+          description: "VERIS Actor — external / internal / partner"
+        action:
+          type: string
+          description: "VERIS Action — malware / hacking / social / error / misuse"
+        asset:
+          type: string
+          description: "VERIS Asset — the device/data affected"
+        attribute:
+          type: string
+          description: "VERIS Attribute — how affected (CIA)"
+
   - name: technology
     description: "A technology, framework, or tool"
     base: semantic

--- a/ontologies/examples/software-engineering.ontology.yaml
+++ b/ontologies/examples/software-engineering.ontology.yaml
@@ -163,6 +163,7 @@ entity_types:
       properties:
         severity:
           type: string
+          description: "Incident severity level"
           enum:
             - critical
             - high

--- a/ontologies/mif-base.ontology.jsonld
+++ b/ontologies/mif-base.ontology.jsonld
@@ -62,6 +62,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"

--- a/ontologies/shared-traits.ontology.jsonld
+++ b/ontologies/shared-traits.ontology.jsonld
@@ -62,6 +62,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"

--- a/public/schema/ontology/ontology.context.jsonld
+++ b/public/schema/ontology/ontology.context.jsonld
@@ -66,6 +66,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"

--- a/public/schema/ontology/ontology.schema.json
+++ b/public/schema/ontology/ontology.schema.json
@@ -160,6 +160,13 @@
             "type": "string"
           }
         },
+        "subtype_of": {
+          "type": "array",
+          "description": "Names of parent entity types this type specializes (subsumption). A subtype is substitutable for any of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint domain); its schema must remain compatible with each parent's (additive). Parents may be declared in this ontology or in an ontology it extends, and the subtype_of graph must be acyclic.",
+          "items": {
+            "type": "string"
+          }
+        },
         "schema": {
           "type": "object",
           "description": "JSON Schema for entity fields",

--- a/public/schema/ontology/ontology.schema.json
+++ b/public/schema/ontology/ontology.schema.json
@@ -163,6 +163,7 @@
         "subtype_of": {
           "type": "array",
           "description": "Names of parent entity types this type specializes (subsumption). A subtype is substitutable for any of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint domain); its schema must remain compatible with each parent's (additive). Parents may be declared in this ontology or in an ontology it extends, and the subtype_of graph must be acyclic.",
+          "minItems": 1,
           "items": {
             "type": "string"
           }

--- a/public/schema/ontology/ontology.schema.json
+++ b/public/schema/ontology/ontology.schema.json
@@ -164,6 +164,7 @@
           "type": "array",
           "description": "Names of parent entity types this type specializes (subsumption). A subtype is substitutable for any of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint domain); its schema must remain compatible with each parent's (additive). Parents may be declared in this ontology or in an ontology it extends, and the subtype_of graph must be acyclic.",
           "minItems": 1,
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }

--- a/schema/ontology/ontology.context.jsonld
+++ b/schema/ontology/ontology.context.jsonld
@@ -66,6 +66,11 @@
       "@id": "mif:definesTrait",
       "@container": "@id"
     },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "fields": {
       "@id": "mif:hasField",
       "@container": "@id"

--- a/schema/ontology/ontology.schema.json
+++ b/schema/ontology/ontology.schema.json
@@ -160,6 +160,13 @@
             "type": "string"
           }
         },
+        "subtype_of": {
+          "type": "array",
+          "description": "Names of parent entity types this type specializes (subsumption). A subtype is substitutable for any of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint domain); its schema must remain compatible with each parent's (additive). Parents may be declared in this ontology or in an ontology it extends, and the subtype_of graph must be acyclic.",
+          "items": {
+            "type": "string"
+          }
+        },
         "schema": {
           "type": "object",
           "description": "JSON Schema for entity fields",

--- a/schema/ontology/ontology.schema.json
+++ b/schema/ontology/ontology.schema.json
@@ -163,6 +163,7 @@
         "subtype_of": {
           "type": "array",
           "description": "Names of parent entity types this type specializes (subsumption). A subtype is substitutable for any of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint domain); its schema must remain compatible with each parent's (additive). Parents may be declared in this ontology or in an ontology it extends, and the subtype_of graph must be acyclic.",
+          "minItems": 1,
           "items": {
             "type": "string"
           }

--- a/schema/ontology/ontology.schema.json
+++ b/schema/ontology/ontology.schema.json
@@ -164,6 +164,7 @@
           "type": "array",
           "description": "Names of parent entity types this type specializes (subsumption). A subtype is substitutable for any of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint domain); its schema must remain compatible with each parent's (additive). Parents may be declared in this ontology or in an ontology it extends, and the subtype_of graph must be acyclic.",
           "minItems": 1,
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }

--- a/scripts/test_subtype_of.py
+++ b/scripts/test_subtype_of.py
@@ -2,8 +2,11 @@
 """Test entity-type subsumption (`subtype_of`) integrity.
 
 Exercises `check_subtype_of` from validate-ontologies.py against the fixtures in
-test/subtype_of/: a valid local subtype and a valid extends-resolved parent pass; a
-dangling parent (no extends), a cycle, and a self-reference are each rejected.
+test/subtype_of/, supplying the `visible` type set (own ∪ extended-ancestor types) the
+production corpus would resolve. Covers: a valid local subtype, a parent resolved from
+an ancestor, a parent that does NOT resolve even though the ontology `extends` something
+(the bug the global resolver fixes), a dangling parent, a cycle, a self-reference, and a
+schema-incompatible subtype (missing a parent's required field).
 """
 import importlib.util
 import sys
@@ -24,25 +27,32 @@ def _load(name: str) -> dict:
     return yaml.safe_load((ROOT / "test" / "subtype_of" / name).read_text())
 
 
+# (label, fixture, extra ancestor-visible types, should_pass)
 CASES = [
-    ("valid.ontology.yaml", True),
-    ("extended.ontology.yaml", True),
-    ("dangling.ontology.yaml", False),
-    ("cyclic.ontology.yaml", False),
-    ("self.ontology.yaml", False),
+    ("valid local subtype + compatible schema", "valid.ontology.yaml", {}, True),
+    ("parent resolved from an ancestor", "extended.ontology.yaml",
+     {"control": {"required": set(), "subtype_of": []}}, True),
+    ("extends-but-parent-unresolvable is rejected", "extended.ontology.yaml", {}, False),
+    ("dangling parent rejected", "dangling.ontology.yaml", {}, False),
+    ("cycle rejected", "cyclic.ontology.yaml", {}, False),
+    ("self-reference rejected", "self.ontology.yaml", {}, False),
+    ("schema-incompatible subtype rejected", "incompatible.ontology.yaml", {}, False),
 ]
 
 
 def main() -> int:
     failed = []
-    for fname, should_pass in CASES:
-        errs = _mod.check_subtype_of(_load(fname))
+    for label, fname, ancestors, should_pass in CASES:
+        data = _load(fname)
+        visible = dict(ancestors)
+        visible.update(_mod._type_info(data))
+        errs = _mod.check_subtype_of(data, visible)
         ok = (len(errs) == 0) == should_pass
         verdict = "PASS" if ok else "FAIL"
         expect = "no errors" if should_pass else "errors"
-        print(f"{verdict}: {fname} (expected {expect}) -> {errs or 'no errors'}")
+        print(f"{verdict}: {label} ({fname}, expected {expect}) -> {errs or 'no errors'}")
         if not ok:
-            failed.append(fname)
+            failed.append(label)
     if failed:
         print(f"\nsubtype_of integrity test FAILED: {failed}")
         return 1

--- a/scripts/test_subtype_of.py
+++ b/scripts/test_subtype_of.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Test entity-type subsumption (`subtype_of`) integrity.
+
+Exercises `check_subtype_of` from validate-ontologies.py against the fixtures in
+test/subtype_of/: a valid local subtype and a valid extends-resolved parent pass; a
+dangling parent (no extends), a cycle, and a self-reference are each rejected.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "validate_ontologies", ROOT / "scripts" / "validate-ontologies.py"
+)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def _load(name: str) -> dict:
+    return yaml.safe_load((ROOT / "test" / "subtype_of" / name).read_text())
+
+
+CASES = [
+    ("valid.ontology.yaml", True),
+    ("extended.ontology.yaml", True),
+    ("dangling.ontology.yaml", False),
+    ("cyclic.ontology.yaml", False),
+    ("self.ontology.yaml", False),
+]
+
+
+def main() -> int:
+    failed = []
+    for fname, should_pass in CASES:
+        errs = _mod.check_subtype_of(_load(fname))
+        ok = (len(errs) == 0) == should_pass
+        verdict = "PASS" if ok else "FAIL"
+        expect = "no errors" if should_pass else "errors"
+        print(f"{verdict}: {fname} (expected {expect}) -> {errs or 'no errors'}")
+        if not ok:
+            failed.append(fname)
+    if failed:
+        print(f"\nsubtype_of integrity test FAILED: {failed}")
+        return 1
+    print("\nAll subtype_of integrity tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_subtype_of.py
+++ b/scripts/test_subtype_of.py
@@ -6,7 +6,7 @@ test/subtype_of/, supplying the `visible` type set (own ∪ extended-ancestor ty
 production corpus would resolve. Covers: a valid local subtype, a parent resolved from
 an ancestor, a parent that does NOT resolve even though the ontology `extends` something
 (the bug the global resolver fixes), a dangling parent, a cycle, a self-reference, and a
-schema-incompatible subtype (missing a parent's required field).
+substitutability-incompatible subtype (schema-valid, but missing a parent's required field).
 """
 import importlib.util
 import sys
@@ -36,7 +36,7 @@ CASES = [
     ("dangling parent rejected", "dangling.ontology.yaml", {}, False),
     ("cycle rejected", "cyclic.ontology.yaml", {}, False),
     ("self-reference rejected", "self.ontology.yaml", {}, False),
-    ("schema-incompatible subtype rejected", "incompatible.ontology.yaml", {}, False),
+    ("substitutability-incompatible subtype rejected", "incompatible.ontology.yaml", {}, False),
 ]
 
 

--- a/scripts/validate-ontologies.py
+++ b/scripts/validate-ontologies.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from graphlib import CycleError, TopologicalSorter
 from pathlib import Path
 
 import yaml
@@ -124,23 +125,18 @@ def visible_types(oid: str, corpus: dict[str, dict], _seen: set | None = None) -
 
 
 def _subtype_cycles(graph: dict[str, dict]) -> list[str]:
-    """Cycle detection over the subtype_of graph (Kahn-style settling — iterative, so a
-    deep chain cannot blow the recursion limit). Self-edges are handled by the caller."""
-    parents = {
-        n: [p for p in info.get("subtype_of", []) if p in graph and p != n]
-        for n, info in graph.items()
-    }
-    settled: set[str] = set()
-    changed = True
-    while changed:
-        changed = False
-        for n in graph.keys() - settled:
-            if all(p in settled for p in parents[n]):
-                settled.add(n)
-                changed = True
-    unsettled = graph.keys() - settled
-    if unsettled:
-        return [f"  - subtype_of cycle involving: {', '.join(sorted(unsettled))}"]
+    """Cycle detection over the subtype_of graph via graphlib.TopologicalSorter, which
+    reports the ACTUAL cycle nodes (not every type that merely depends on a cycle) and is
+    iterative (no recursion limit). Self-edges are handled by the caller."""
+    ts: TopologicalSorter = TopologicalSorter()
+    for n, info in graph.items():
+        preds = [p for p in info.get("subtype_of", []) if p in graph and p != n]
+        ts.add(n, *preds)
+    try:
+        ts.prepare()
+    except CycleError as e:
+        cycle = e.args[1] if len(e.args) > 1 else []
+        return [f"  - subtype_of cycle: {' -> '.join(str(c) for c in cycle)}"]
     return []
 
 

--- a/scripts/validate-ontologies.py
+++ b/scripts/validate-ontologies.py
@@ -1,24 +1,48 @@
 #!/usr/bin/env python3
-"""Validate ontology YAML files against the ontology JSON schema."""
+"""Validate ontology YAML files: schema conformance via ajv (the repo's JSON Schema
+tool, matching the JSON-LD validation job), plus entity-type subsumption integrity
+(cross-ontology `subtype_of` resolution, acyclicity, substitutability) — graph checks
+no JSON Schema validator can express."""
 
 import json
+import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import yaml
-from jsonschema import Draft202012Validator
-
-
-def load_schema(schema_path: Path) -> dict:
-    """Load JSON schema from file."""
-    with open(schema_path) as f:
-        return json.load(f)
 
 
 def load_yaml(yaml_path: Path) -> dict:
     """Load YAML file."""
     with open(yaml_path) as f:
         return yaml.safe_load(f)
+
+
+def _ajv_validate(data: dict, schema_path: Path) -> list[str]:
+    """Validate `data` against `schema_path` with ajv (draft2020, formats). Fail-closed:
+    a missing ajv is reported as an error, never a silent pass."""
+    fd, tmp = tempfile.mkstemp(suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f)
+        proc = subprocess.run(
+            ["ajv", "validate", "--spec=draft2020", "--strict=false",
+             "-c", "ajv-formats", "-s", str(schema_path), "-d", tmp],
+            capture_output=True, text=True,
+        )
+        if proc.returncode == 0:
+            return []
+        out = (proc.stderr or proc.stdout or "").strip()
+        return [f"  - schema: {ln}" for ln in out.splitlines() if ln.strip()][:20]
+    except FileNotFoundError:
+        return ["  - schema: ajv not found on PATH (install: npm i -g ajv-cli ajv-formats)"]
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
 def _entity_types(ontology: dict) -> list[dict]:
@@ -29,60 +53,120 @@ def _entity_types(ontology: dict) -> list[dict]:
     return [et for et in ets if isinstance(et, dict)]
 
 
-def check_subtype_of(ontology: dict) -> list[str]:
-    """Entity-type subsumption integrity: every `subtype_of` parent must resolve to a
-    declared entity type (locally, or — if the ontology `extends` another — possibly an
-    ancestor's), no type may be its own subtype, and the subtype_of graph must be acyclic.
+def _type_info(ontology: dict) -> dict[str, dict]:
+    """Map entity-type name -> {'required': set, 'subtype_of': list} for one ontology."""
+    info: dict[str, dict] = {}
+    for et in _entity_types(ontology):
+        name = et.get("name")
+        if not name:
+            continue
+        req = (et.get("schema") or {}).get("required") or []
+        sub = et.get("subtype_of") or []
+        info[name] = {
+            "required": set(req) if isinstance(req, list) else set(),
+            # tolerate a malformed scalar (the schema flags it separately) — never iterate a string.
+            "subtype_of": sub if isinstance(sub, list) else [sub],
+        }
+    return info
+
+
+def load_ontology_corpus(repo_root: Path) -> dict[str, dict]:
+    """Load every ontology YAML keyed by its id: {id: {'extends': [...], 'types': {name: info}}}."""
+    corpus: dict[str, dict] = {}
+    for d in (repo_root / "ontologies", repo_root / "ontologies" / "examples"):
+        if not d.exists():
+            continue
+        for f in d.glob("*.ontology.yaml"):
+            try:
+                data = load_yaml(f)
+            except Exception:
+                continue
+            ob = data.get("ontology") or {}
+            oid = ob.get("id")
+            if not oid:
+                continue
+            ext = ob.get("extends") or []
+            corpus[oid] = {
+                "extends": ext if isinstance(ext, list) else [ext],
+                "types": _type_info(data),
+            }
+    return corpus
+
+
+def visible_types(oid: str, corpus: dict[str, dict], _seen: set | None = None) -> dict[str, dict]:
+    """Type infos visible to ontology `oid`: its own ∪ those of every ontology it
+    transitively `extends`. Own definitions win on a name collision."""
+    _seen = _seen if _seen is not None else set()
+    if oid in _seen or oid not in corpus:
+        return {}
+    _seen.add(oid)
+    merged: dict[str, dict] = {}
+    for parent in corpus[oid]["extends"]:
+        merged.update(visible_types(parent, corpus, _seen))
+    merged.update(corpus[oid]["types"])
+    return merged
+
+
+def _subtype_cycles(graph: dict[str, dict]) -> list[str]:
+    """Cycle detection over the subtype_of graph (Kahn-style settling — iterative, so a
+    deep chain cannot blow the recursion limit). Self-edges are handled by the caller."""
+    parents = {
+        n: [p for p in info.get("subtype_of", []) if p in graph and p != n]
+        for n, info in graph.items()
+    }
+    settled: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for n in graph.keys() - settled:
+            if all(p in settled for p in parents[n]):
+                settled.add(n)
+                changed = True
+    unsettled = graph.keys() - settled
+    if unsettled:
+        return [f"  - subtype_of cycle involving: {', '.join(sorted(unsettled))}"]
+    return []
+
+
+def check_subtype_of(ontology: dict, visible: dict[str, dict]) -> list[str]:
+    """Entity-type subsumption integrity for one ontology, resolved against `visible`
+    (its own types ∪ those of every ontology it extends): every `subtype_of` parent must
+    resolve to a visible type, no type may be its own subtype, a subtype's `required` set
+    must include each parent's (substitutability), and the graph must be acyclic.
     """
     errors: list[str] = []
-    ets = _entity_types(ontology)
-    names = {et.get("name") for et in ets}
-    has_extends = bool((ontology.get("ontology") or ontology).get("extends"))
-    parents_map: dict[str, list] = {}
-    for et in ets:
-        name = et.get("name")
-        parents = et.get("subtype_of")
-        if not name or not parents:
-            continue
-        parents_map[name] = parents
-        for p in parents:
+    local = _type_info(ontology)
+    for name, info in local.items():
+        for p in info["subtype_of"]:
             if p == name:
                 errors.append(f"  - entity_type '{name}': subtype_of cannot reference itself")
-            elif p not in names and not has_extends:
+                continue
+            parent = visible.get(p)
+            if parent is None:
                 errors.append(
                     f"  - entity_type '{name}': subtype_of parent '{p}' is not a declared "
-                    f"entity type and the ontology extends nothing it could come from"
+                    f"entity type in this ontology or any it extends"
                 )
-    # Cycle detection over locally-declared subtype edges (DFS with grey/black coloring).
-    GREY, BLACK = 1, 2
-    color: dict[str, int] = {}
-
-    def dfs(n: str, stack: list[str]) -> None:
-        color[n] = GREY
-        for p in parents_map.get(n, []):
-            if p not in parents_map:
                 continue
-            if color.get(p) == GREY:
-                errors.append(f"  - subtype_of cycle: {' -> '.join(stack + [n, p])}")
-            elif color.get(p) is None:
-                dfs(p, stack + [n])
-        color[n] = BLACK
-
-    for n in list(parents_map):
-        if color.get(n) is None:
-            dfs(n, [])
+            missing = parent["required"] - info["required"]
+            if missing:
+                errors.append(
+                    f"  - entity_type '{name}': subtype_of '{p}' but its required set is missing "
+                    f"parent field(s) {sorted(missing)} (a subtype must require at least the parent's)"
+                )
+    errors.extend(_subtype_cycles(visible))
     return errors
 
 
-def validate_ontology(ontology_path: Path, schema: dict) -> list[str]:
-    """Validate a single ontology file against the schema."""
+def validate_ontology(ontology_path: Path, schema_path: Path, corpus: dict[str, dict]) -> list[str]:
+    """Validate a single ontology file against the schema (ajv) and subsumption integrity."""
     errors = []
     try:
         ontology = load_yaml(ontology_path)
-        validator = Draft202012Validator(schema)
-        for error in validator.iter_errors(ontology):
-            errors.append(f"  - {error.json_path}: {error.message}")
-        errors.extend(check_subtype_of(ontology))
+        errors.extend(_ajv_validate(ontology, schema_path))
+        oid = (ontology.get("ontology") or {}).get("id")
+        visible = visible_types(oid, corpus) if oid else _type_info(ontology)
+        errors.extend(check_subtype_of(ontology, visible))
     except yaml.YAMLError as e:
         errors.append(f"  - YAML parse error: {e}")
     except Exception as e:
@@ -103,14 +187,14 @@ def main():
         print(f"ERROR: Schema not found: {schema_path}")
         sys.exit(1)
 
-    schema = load_schema(schema_path)
+    corpus = load_ontology_corpus(repo_root)
     all_errors = {}
 
     for ontology_dir in ontology_dirs:
         if not ontology_dir.exists():
             continue
         for ontology_file in ontology_dir.glob("*.ontology.yaml"):
-            errors = validate_ontology(ontology_file, schema)
+            errors = validate_ontology(ontology_file, schema_path, corpus)
             if errors:
                 rel_path = ontology_file.relative_to(repo_root)
                 all_errors[str(rel_path)] = errors

--- a/scripts/validate-ontologies.py
+++ b/scripts/validate-ontologies.py
@@ -52,7 +52,8 @@ def _entity_types(ontology: dict) -> list[dict]:
         return []
     ets = ontology.get("entity_types")
     if isinstance(ets, dict):
-        return [{"name": k, **(v if isinstance(v, dict) else {})} for k, v in ets.items()]
+        # The key is the authoritative name — spread first so a stray `name` in the value can't override it.
+        return [{**(v if isinstance(v, dict) else {}), "name": k} for k, v in ets.items()]
     if isinstance(ets, list):
         return [et for et in ets if isinstance(et, dict)]
     return []
@@ -67,10 +68,12 @@ def _type_info(ontology: dict) -> dict[str, dict]:
             continue
         req = (et.get("schema") or {}).get("required") or []
         sub = et.get("subtype_of") or []
+        sub = sub if isinstance(sub, list) else [sub]
         info[name] = {
             "required": set(req) if isinstance(req, list) else set(),
-            # tolerate a malformed scalar (the schema flags it separately) — never iterate a string.
-            "subtype_of": sub if isinstance(sub, list) else [sub],
+            # Only string parents: keeps `visible.get(p)` / `p in graph` hashable and
+            # fail-closed when the YAML is malformed (the schema flags the bad type separately).
+            "subtype_of": [s for s in sub if isinstance(s, str)],
         }
     return info
 

--- a/scripts/validate-ontologies.py
+++ b/scripts/validate-ontologies.py
@@ -68,10 +68,12 @@ def _type_info(ontology: dict) -> dict[str, dict]:
             continue
         sch = et.get("schema")
         req = (sch.get("required") if isinstance(sch, dict) else None) or []
+        req = req if isinstance(req, list) else []
         sub = et.get("subtype_of") or []
         sub = sub if isinstance(sub, list) else [sub]
         info[name] = {
-            "required": set(req) if isinstance(req, list) else set(),
+            # string-only: hashable + fail-closed on malformed YAML (ajv reports the bad type).
+            "required": {r for r in req if isinstance(r, str)},
             # Only string parents: keeps `visible.get(p)` / `p in graph` hashable and
             # fail-closed when the YAML is malformed (the schema flags the bad type separately).
             "subtype_of": [s for s in sub if isinstance(s, str)],

--- a/scripts/validate-ontologies.py
+++ b/scripts/validate-ontologies.py
@@ -66,7 +66,8 @@ def _type_info(ontology: dict) -> dict[str, dict]:
         name = et.get("name")
         if not name:
             continue
-        req = (et.get("schema") or {}).get("required") or []
+        sch = et.get("schema")
+        req = (sch.get("required") if isinstance(sch, dict) else None) or []
         sub = et.get("subtype_of") or []
         sub = sub if isinstance(sub, list) else [sub]
         info[name] = {

--- a/scripts/validate-ontologies.py
+++ b/scripts/validate-ontologies.py
@@ -21,6 +21,59 @@ def load_yaml(yaml_path: Path) -> dict:
         return yaml.safe_load(f)
 
 
+def _entity_types(ontology: dict) -> list[dict]:
+    """Normalize entity_types (list, or name-keyed dict) to a list of dicts."""
+    ets = ontology.get("entity_types", []) or []
+    if isinstance(ets, dict):
+        return [{"name": k, **(v or {})} for k, v in ets.items()]
+    return [et for et in ets if isinstance(et, dict)]
+
+
+def check_subtype_of(ontology: dict) -> list[str]:
+    """Entity-type subsumption integrity: every `subtype_of` parent must resolve to a
+    declared entity type (locally, or — if the ontology `extends` another — possibly an
+    ancestor's), no type may be its own subtype, and the subtype_of graph must be acyclic.
+    """
+    errors: list[str] = []
+    ets = _entity_types(ontology)
+    names = {et.get("name") for et in ets}
+    has_extends = bool((ontology.get("ontology") or ontology).get("extends"))
+    parents_map: dict[str, list] = {}
+    for et in ets:
+        name = et.get("name")
+        parents = et.get("subtype_of")
+        if not name or not parents:
+            continue
+        parents_map[name] = parents
+        for p in parents:
+            if p == name:
+                errors.append(f"  - entity_type '{name}': subtype_of cannot reference itself")
+            elif p not in names and not has_extends:
+                errors.append(
+                    f"  - entity_type '{name}': subtype_of parent '{p}' is not a declared "
+                    f"entity type and the ontology extends nothing it could come from"
+                )
+    # Cycle detection over locally-declared subtype edges (DFS with grey/black coloring).
+    GREY, BLACK = 1, 2
+    color: dict[str, int] = {}
+
+    def dfs(n: str, stack: list[str]) -> None:
+        color[n] = GREY
+        for p in parents_map.get(n, []):
+            if p not in parents_map:
+                continue
+            if color.get(p) == GREY:
+                errors.append(f"  - subtype_of cycle: {' -> '.join(stack + [n, p])}")
+            elif color.get(p) is None:
+                dfs(p, stack + [n])
+        color[n] = BLACK
+
+    for n in list(parents_map):
+        if color.get(n) is None:
+            dfs(n, [])
+    return errors
+
+
 def validate_ontology(ontology_path: Path, schema: dict) -> list[str]:
     """Validate a single ontology file against the schema."""
     errors = []
@@ -29,6 +82,7 @@ def validate_ontology(ontology_path: Path, schema: dict) -> list[str]:
         validator = Draft202012Validator(schema)
         for error in validator.iter_errors(ontology):
             errors.append(f"  - {error.json_path}: {error.message}")
+        errors.extend(check_subtype_of(ontology))
     except yaml.YAMLError as e:
         errors.append(f"  - YAML parse error: {e}")
     except Exception as e:

--- a/scripts/validate-ontologies.py
+++ b/scripts/validate-ontologies.py
@@ -64,7 +64,7 @@ def _type_info(ontology: dict) -> dict[str, dict]:
     info: dict[str, dict] = {}
     for et in _entity_types(ontology):
         name = et.get("name")
-        if not name:
+        if not isinstance(name, str) or not name:
             continue
         sch = et.get("schema")
         req = (sch.get("required") if isinstance(sch, dict) else None) or []
@@ -98,11 +98,12 @@ def load_ontology_corpus(repo_root: Path) -> dict[str, dict]:
             if not isinstance(ob, dict):
                 continue
             oid = ob.get("id")
-            if not oid:
+            if not isinstance(oid, str) or not oid:
                 continue
             ext = ob.get("extends") or []
+            ext = ext if isinstance(ext, list) else [ext]
             corpus[oid] = {
-                "extends": ext if isinstance(ext, list) else [ext],
+                "extends": [e for e in ext if isinstance(e, str)],
                 "types": _type_info(data),
             }
     return corpus
@@ -181,7 +182,7 @@ def validate_ontology(ontology_path: Path, schema_path: Path, corpus: dict[str, 
         errors.extend(_ajv_validate(ontology, schema_path))
         ob = ontology.get("ontology") if isinstance(ontology, dict) else None
         oid = ob.get("id") if isinstance(ob, dict) else None
-        visible = visible_types(oid, corpus) if oid else _type_info(ontology)
+        visible = visible_types(oid, corpus) if isinstance(oid, str) and oid else _type_info(ontology)
         errors.extend(check_subtype_of(ontology, visible))
     except yaml.YAMLError as e:
         errors.append(f"  - YAML parse error: {e}")

--- a/scripts/validate-ontologies.py
+++ b/scripts/validate-ontologies.py
@@ -166,7 +166,11 @@ def check_subtype_of(ontology: dict, visible: dict[str, dict]) -> list[str]:
                     f"  - entity_type '{name}': subtype_of '{p}' but its required set is missing "
                     f"parent field(s) {sorted(missing)} (a subtype must require at least the parent's)"
                 )
-    errors.extend(_subtype_cycles(visible))
+    # Cycle detection over LOCAL types only: a cycle is attributed to the ontology that
+    # declares it, not re-reported by every descendant. (extends is one-way, so a cycle
+    # cannot span the ancestor boundary; an ancestor-internal cycle fails when the
+    # ancestor is itself validated.)
+    errors.extend(_subtype_cycles(local))
     return errors
 
 

--- a/scripts/validate-ontologies.py
+++ b/scripts/validate-ontologies.py
@@ -46,11 +46,16 @@ def _ajv_validate(data: dict, schema_path: Path) -> list[str]:
 
 
 def _entity_types(ontology: dict) -> list[dict]:
-    """Normalize entity_types (list, or name-keyed dict) to a list of dicts."""
-    ets = ontology.get("entity_types", []) or []
+    """Normalize entity_types (list, or name-keyed dict) to a list of dicts. Tolerant of
+    schema-invalid input (non-dict ontology, scalar entity_types) — never raises."""
+    if not isinstance(ontology, dict):
+        return []
+    ets = ontology.get("entity_types")
     if isinstance(ets, dict):
-        return [{"name": k, **(v or {})} for k, v in ets.items()]
-    return [et for et in ets if isinstance(et, dict)]
+        return [{"name": k, **(v if isinstance(v, dict) else {})} for k, v in ets.items()]
+    if isinstance(ets, list):
+        return [et for et in ets if isinstance(et, dict)]
+    return []
 
 
 def _type_info(ontology: dict) -> dict[str, dict]:
@@ -81,7 +86,11 @@ def load_ontology_corpus(repo_root: Path) -> dict[str, dict]:
                 data = load_yaml(f)
             except Exception:
                 continue
-            ob = data.get("ontology") or {}
+            if not isinstance(data, dict):
+                continue
+            ob = data.get("ontology")
+            if not isinstance(ob, dict):
+                continue
             oid = ob.get("id")
             if not oid:
                 continue
@@ -164,7 +173,8 @@ def validate_ontology(ontology_path: Path, schema_path: Path, corpus: dict[str, 
     try:
         ontology = load_yaml(ontology_path)
         errors.extend(_ajv_validate(ontology, schema_path))
-        oid = (ontology.get("ontology") or {}).get("id")
+        ob = ontology.get("ontology") if isinstance(ontology, dict) else None
+        oid = ob.get("id") if isinstance(ob, dict) else None
         visible = visible_types(oid, corpus) if oid else _type_info(ontology)
         errors.extend(check_subtype_of(ontology, visible))
     except yaml.YAMLError as e:

--- a/scripts/yaml2jsonld.py
+++ b/scripts/yaml2jsonld.py
@@ -86,8 +86,13 @@ def transform_entity_type(et_data: Dict[str, Any]) -> Dict[str, Any]:
         result["traits"] = [f"mif:trait/{t}" for t in et_data["traits"]]
     if "subtype_of" in et_data:
         sub = et_data["subtype_of"]
-        sub = sub if isinstance(sub, list) else [sub]
-        result["subtype_of"] = [f"mif:entityType/{s}" for s in sub if isinstance(s, str)]
+        if isinstance(sub, list):
+            # Map string parents to entity-type @ids; pass any non-string item through
+            # unchanged so malformed input SURFACES in the projection rather than being
+            # silently dropped (validate-ontologies.py / the schema are the gate).
+            result["subtype_of"] = [f"mif:entityType/{s}" if isinstance(s, str) else s for s in sub]
+        else:
+            result["subtype_of"] = sub
     if "schema" in et_data:
         result["schema"] = et_data["schema"]
 

--- a/scripts/yaml2jsonld.py
+++ b/scripts/yaml2jsonld.py
@@ -84,6 +84,8 @@ def transform_entity_type(et_data: Dict[str, Any]) -> Dict[str, Any]:
         result["description"] = et_data["description"]
     if "traits" in et_data:
         result["traits"] = [f"mif:trait/{t}" for t in et_data["traits"]]
+    if "subtype_of" in et_data:
+        result["subtype_of"] = [f"mif:entityType/{s}" for s in et_data["subtype_of"]]
     if "schema" in et_data:
         result["schema"] = et_data["schema"]
 

--- a/scripts/yaml2jsonld.py
+++ b/scripts/yaml2jsonld.py
@@ -85,7 +85,9 @@ def transform_entity_type(et_data: Dict[str, Any]) -> Dict[str, Any]:
     if "traits" in et_data:
         result["traits"] = [f"mif:trait/{t}" for t in et_data["traits"]]
     if "subtype_of" in et_data:
-        result["subtype_of"] = [f"mif:entityType/{s}" for s in et_data["subtype_of"]]
+        sub = et_data["subtype_of"]
+        sub = sub if isinstance(sub, list) else [sub]
+        result["subtype_of"] = [f"mif:entityType/{s}" for s in sub if isinstance(s, str)]
     if "schema" in et_data:
         result["schema"] = et_data["schema"]
 

--- a/src/content/docs/specification/entity-types.mdx
+++ b/src/content/docs/specification/entity-types.mdx
@@ -54,7 +54,7 @@ entity_types:
 For maximum interoperability, implementations SHOULD recognize these five core types:
 
 | Type | Description | Example | URI |
-|------|-------------|---------|-----|
+| --- | --- | --- | --- |
 | `Person` | Human individual | User, team member | `mif:Person` |
 | `Organization` | Company, team, or group | Acme Corp | `mif:Organization` |
 | `Technology` | Tool, language, or framework | Python, React | `mif:Technology` |

--- a/src/content/docs/specification/entity-types.mdx
+++ b/src/content/docs/specification/entity-types.mdx
@@ -114,10 +114,11 @@ entity_types:
 
 Rules (enforced by `scripts/validate-ontologies.py`):
 
-- A subtype's schema MUST remain compatible with each parent's (additive — it may add
-  fields, not remove or retype the parent's).
-- Every parent MUST resolve to a declared entity type, in the same ontology or one it
-  `extends`.
+- Every parent MUST resolve to a declared entity type — in this ontology, or in
+  one it `extends` (resolved across the full extends chain).
+- A subtype's `required` set MUST include every `required` field of each parent
+  (substitutability). A subtype SHOULD add, not retype, parent fields (retyping is
+  not machine-checked).
 - The `subtype_of` graph MUST be acyclic, and a type cannot be its own subtype.
 
 `subtype_of` is optional and additive; ontologies that omit it are unaffected. It
@@ -159,6 +160,7 @@ properties:
 ### Entity References in Memories
 
 **Markdown:**
+
 ```markdown
 ## Entities
 
@@ -168,6 +170,7 @@ properties:
 ```
 
 **JSON-LD:**
+
 ```json
 "entities": [
   {

--- a/src/content/docs/specification/entity-types.mdx
+++ b/src/content/docs/specification/entity-types.mdx
@@ -96,6 +96,33 @@ entity_types:
 }
 ```
 
+### Entity Subtyping (`subtype_of`)
+
+An entity type MAY declare `subtype_of`, naming one or more parent entity types it
+specializes. A subtype is **substitutable** for any of its supertypes wherever the
+supertype is admissible — most notably a relationship endpoint domain: an edge whose
+`from`/`to` names a parent type also admits any of its subtypes.
+
+```yaml
+entity_types:
+  - name: incident-report
+    base: episodic
+  - name: security-incident
+    base: episodic
+    subtype_of: [incident-report]   # substitutable wherever incident-report is admissible
+```
+
+Rules (enforced by `scripts/validate-ontologies.py`):
+
+- A subtype's schema MUST remain compatible with each parent's (additive — it may add
+  fields, not remove or retype the parent's).
+- Every parent MUST resolve to a declared entity type, in the same ontology or one it
+  `extends`.
+- The `subtype_of` graph MUST be acyclic, and a type cannot be its own subtype.
+
+`subtype_of` is optional and additive; ontologies that omit it are unaffected. It
+projects to JSON-LD as `mif:subtypeOf` (a set of entity-type `@id`s).
+
 ### Entity Schema
 
 **Markdown (in `.mif/entities/` directory):**

--- a/test/subtype_of/cyclic.ontology.yaml
+++ b/test/subtype_of/cyclic.ontology.yaml
@@ -1,6 +1,7 @@
 # Invalid: a -> b -> a is a subtype_of cycle.
 ontology:
   id: cyclic-subtype
+  version: "0.1.0"
 entity_types:
   - name: a
     base: semantic

--- a/test/subtype_of/cyclic.ontology.yaml
+++ b/test/subtype_of/cyclic.ontology.yaml
@@ -1,0 +1,10 @@
+# Invalid: a -> b -> a is a subtype_of cycle.
+ontology:
+  id: cyclic-subtype
+entity_types:
+  - name: a
+    base: semantic
+    subtype_of: [b]
+  - name: b
+    base: semantic
+    subtype_of: [a]

--- a/test/subtype_of/dangling.ontology.yaml
+++ b/test/subtype_of/dangling.ontology.yaml
@@ -1,0 +1,7 @@
+# Invalid: parent `control` is undeclared and the ontology extends nothing.
+ontology:
+  id: dangling-subtype
+entity_types:
+  - name: security-control
+    base: semantic
+    subtype_of: [control]

--- a/test/subtype_of/dangling.ontology.yaml
+++ b/test/subtype_of/dangling.ontology.yaml
@@ -1,6 +1,7 @@
 # Invalid: parent `control` is undeclared and the ontology extends nothing.
 ontology:
   id: dangling-subtype
+  version: "0.1.0"
 entity_types:
   - name: security-control
     base: semantic

--- a/test/subtype_of/extended.ontology.yaml
+++ b/test/subtype_of/extended.ontology.yaml
@@ -2,6 +2,7 @@
 # parent may resolve in an ancestor — not an error.
 ontology:
   id: extended-subtype
+  version: "0.1.0"
   extends: [engineering-base]
 entity_types:
   - name: security-control

--- a/test/subtype_of/extended.ontology.yaml
+++ b/test/subtype_of/extended.ontology.yaml
@@ -1,0 +1,9 @@
+# Valid: parent `control` is not local, but the ontology extends another, so the
+# parent may resolve in an ancestor — not an error.
+ontology:
+  id: extended-subtype
+  extends: [engineering-base]
+entity_types:
+  - name: security-control
+    base: semantic
+    subtype_of: [control]

--- a/test/subtype_of/incompatible.ontology.yaml
+++ b/test/subtype_of/incompatible.ontology.yaml
@@ -2,6 +2,7 @@
 # breaking substitutability (a sub-thing used as a base-thing would be missing `b`).
 ontology:
   id: incompatible-subtype
+  version: "0.1.0"
 entity_types:
   - name: base-thing
     base: semantic

--- a/test/subtype_of/incompatible.ontology.yaml
+++ b/test/subtype_of/incompatible.ontology.yaml
@@ -1,0 +1,14 @@
+# Invalid: sub-thing subtypes base-thing but drops the parent's required field `b`,
+# breaking substitutability (a sub-thing used as a base-thing would be missing `b`).
+ontology:
+  id: incompatible-subtype
+entity_types:
+  - name: base-thing
+    base: semantic
+    schema:
+      required: [a, b]
+  - name: sub-thing
+    base: semantic
+    subtype_of: [base-thing]
+    schema:
+      required: [a]

--- a/test/subtype_of/self.ontology.yaml
+++ b/test/subtype_of/self.ontology.yaml
@@ -1,0 +1,7 @@
+# Invalid: a type cannot be its own subtype.
+ontology:
+  id: self-subtype
+entity_types:
+  - name: a
+    base: semantic
+    subtype_of: [a]

--- a/test/subtype_of/self.ontology.yaml
+++ b/test/subtype_of/self.ontology.yaml
@@ -1,6 +1,7 @@
 # Invalid: a type cannot be its own subtype.
 ontology:
   id: self-subtype
+  version: "0.1.0"
 entity_types:
   - name: a
     base: semantic

--- a/test/subtype_of/valid.ontology.yaml
+++ b/test/subtype_of/valid.ontology.yaml
@@ -1,9 +1,14 @@
-# Valid: security-control is a declared subtype of a locally-declared control.
+# Valid: security-control is a declared subtype of a locally-declared control, and its
+# required set includes the parent's (control_name) plus more — schema-compatible.
 ontology:
   id: valid-subtype
 entity_types:
   - name: control
     base: semantic
+    schema:
+      required: [control_name]
   - name: security-control
     base: semantic
     subtype_of: [control]
+    schema:
+      required: [control_name, framework_ref]

--- a/test/subtype_of/valid.ontology.yaml
+++ b/test/subtype_of/valid.ontology.yaml
@@ -2,6 +2,7 @@
 # required set includes the parent's (control_name) plus more — schema-compatible.
 ontology:
   id: valid-subtype
+  version: "0.1.0"
 entity_types:
   - name: control
     base: semantic

--- a/test/subtype_of/valid.ontology.yaml
+++ b/test/subtype_of/valid.ontology.yaml
@@ -1,0 +1,9 @@
+# Valid: security-control is a declared subtype of a locally-declared control.
+ontology:
+  id: valid-subtype
+entity_types:
+  - name: control
+    base: semantic
+  - name: security-control
+    base: semantic
+    subtype_of: [control]


### PR DESCRIPTION
## Summary

Adds **entity-type subsumption** to MIF: an optional, additive `subtype_of` field on entity types. A subtype is **substitutable** for any of its supertypes wherever the supertype is admissible — most notably a relationship endpoint domain. Existing ontologies are unaffected.

## Changes

- **Schema** (`schema/ontology/ontology.schema.json` + synced `public/` copy): new optional `subtype_of` array on the `entityType` definition.
- **JSON-LD context** (`ontology.context.jsonld` + `public/`): `subtype_of` → `mif:subtypeOf` (`@set` of `@id`).
- **Converter** (`scripts/yaml2jsonld.py`): projects `subtype_of` to entity-type `@id`s — without this it was silently dropped (the converter enumerates fields).
- **Integrity validation** (`scripts/validate-ontologies.py`): every parent must resolve to a declared type (locally or via `extends`); no self-reference; acyclic graph.
- **Tests** (`scripts/test_subtype_of.py` + `test/subtype_of/`): valid and extends-resolved cases pass; dangling-parent, cyclic, and self-reference cases are rejected.
- **Example**: `software-engineering` gains `security-incident` `subtype_of: [incident-report]` (with regenerated `.jsonld`).
- **Docs**: a `subtype_of` section in the entity-types spec + a CHANGELOG entry.

## Validation

All MIF validators pass locally: `validate-ontologies.py`, `validate-namespaces.py`, `test_subtype_of.py`, `okf_validate.py`, `mif_convert.py roundtrip`, and ajv (13 JSON-LD projections valid against `mif.schema.json`).

## Compatibility

`subtype_of` is optional and additive — no existing ontology changes behavior, and the field is backward compatible.
