### PR TITLE
Preserve 0.1.0 schema mirror (snapshot of the v0.1.0 tag)

### DIFF
--- a/public/schema/0.1.0/citation.schema.json
+++ b/public/schema/0.1.0/citation.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/citation.schema.json",
+  "title": "MIF Citation",
+  "description": "JSON Schema for validating MIF citation objects",
+  "type": "object",
+  "required": ["@type", "citationType", "citationRole", "title", "url"],
+  "properties": {
+    "@type": {
+      "const": "Citation",
+      "description": "Must be 'Citation'"
+    },
+    "citationType": {
+      "type": "string",
+      "description": "Source category - either a standard type or custom namespaced type",
+      "oneOf": [
+        {
+          "enum": [
+            "article",
+            "book",
+            "paper",
+            "website",
+            "documentation",
+            "repository",
+            "video",
+            "podcast",
+            "specification",
+            "dataset",
+            "tool",
+            "other"
+          ],
+          "description": "Standard citation types"
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+          "description": "Custom namespaced type (e.g., 'acme:memo')"
+        }
+      ]
+    },
+    "citationRole": {
+      "type": "string",
+      "description": "Relationship to memory - either a standard role or custom namespaced role",
+      "oneOf": [
+        {
+          "enum": [
+            "supports",
+            "refutes",
+            "background",
+            "methodology",
+            "contradicts",
+            "extends",
+            "derived",
+            "source",
+            "example",
+            "review"
+          ],
+          "description": "Standard citation roles"
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+          "description": "Custom namespaced role (e.g., 'legal:precedent')"
+        }
+      ]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Citation title (required, non-empty)"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Citation URL (required, valid URI)"
+    },
+    "author": {
+      "description": "Author(s) - can be entity reference object, array of entity references, or plain text string",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/EntityReference",
+          "description": "Single author entity reference"
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EntityReference" },
+          "minItems": 1,
+          "description": "Multiple author entity references"
+        },
+        {
+          "type": "string",
+          "description": "Plain text author name(s)"
+        }
+      ]
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "description": "Publication date in ISO 8601 format (YYYY-MM-DD)"
+    },
+    "accessed": {
+      "type": "string",
+      "format": "date",
+      "description": "Access date in ISO 8601 format (YYYY-MM-DD)"
+    },
+    "relevance": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Relevance score between 0.0 and 1.0"
+    },
+    "note": {
+      "type": "string",
+      "maxLength": 1000,
+      "description": "Free-form annotation (recommended under 1000 characters)"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "EntityReference": {
+      "$ref": "./definitions/entity-reference.schema.json"
+    }
+  },
+  "examples": [
+    {
+      "@type": "Citation",
+      "citationType": "article",
+      "citationRole": "supports",
+      "title": "Memory Systems in AI Agents",
+      "url": "https://arxiv.org/abs/2024.12345",
+      "author": {
+        "@type": "EntityReference",
+        "entity": { "@id": "urn:mif:entity:person:jane-smith" },
+        "entityType": "Person",
+        "name": "Jane Smith"
+      },
+      "date": "2024-06-15",
+      "accessed": "2026-01-20",
+      "relevance": 0.95,
+      "note": "Foundational paper on semantic memory"
+    },
+    {
+      "@type": "Citation",
+      "citationType": "documentation",
+      "citationRole": "background",
+      "title": "Obsidian Help",
+      "url": "https://help.obsidian.md/",
+      "accessed": "2026-01-18",
+      "relevance": 0.85
+    }
+  ]
+}

--- a/public/schema/0.1.0/context.jsonld
+++ b/public/schema/0.1.0/context.jsonld
@@ -1,0 +1,246 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "mif": "https://raw.githubusercontent.com/zircote/MIF/main/ns/",
+    "dc": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "schema": "https://schema.org/",
+
+    "Memory": "mif:Memory",
+    "Entity": "mif:Entity",
+    "Relationship": "mif:Relationship",
+    "TemporalMetadata": "mif:TemporalMetadata",
+    "EmbeddingReference": "mif:EmbeddingReference",
+    "EntityReference": "mif:EntityReference",
+    "OntologyReference": "mif:OntologyReference",
+    "EntityData": "mif:EntityData",
+    "Vector": "mif:Vector",
+
+    "Person": "mif:Person",
+    "Organization": "mif:Organization",
+    "Technology": "mif:Technology",
+    "Concept": "mif:Concept",
+    "File": "mif:File",
+
+    "id": "@id",
+    "type": "@type",
+
+    "content": {
+      "@id": "mif:content",
+      "@type": "xsd:string"
+    },
+    "memoryType": {
+      "@id": "mif:memoryType",
+      "@type": "@vocab"
+    },
+    "title": "dc:title",
+    "namespace": "mif:namespace",
+    "tags": {
+      "@id": "mif:tags",
+      "@container": "@set"
+    },
+    "aliases": {
+      "@id": "mif:aliases",
+      "@container": "@set"
+    },
+    "blocks": {
+      "@id": "mif:blocks",
+      "@container": "@index"
+    },
+
+    "created": {
+      "@id": "dc:created",
+      "@type": "xsd:dateTime"
+    },
+    "modified": {
+      "@id": "dc:modified",
+      "@type": "xsd:dateTime"
+    },
+
+    "entities": {
+      "@id": "mif:entities",
+      "@container": "@set"
+    },
+    "entity": {
+      "@id": "mif:entity",
+      "@type": "@id"
+    },
+    "entityType": "mif:entityType",
+    "entity_type": "mif:entity_type",
+    "entity_id": "mif:entity_id",
+    "name": "schema:name",
+    "role": "mif:role",
+
+    "ontology": "mif:ontology",
+    "version": "mif:version",
+    "uri": {
+      "@id": "mif:uri",
+      "@type": "@id"
+    },
+
+    "citations": {
+      "@id": "mif:citations",
+      "@container": "@set"
+    },
+    "Citation": "mif:Citation",
+    "citationType": {
+      "@id": "mif:citationType",
+      "@type": "@vocab"
+    },
+    "citationRole": {
+      "@id": "mif:citationRole",
+      "@type": "@vocab"
+    },
+    "url": {
+      "@id": "schema:url",
+      "@type": "@id"
+    },
+    "author": "schema:author",
+    "date": {
+      "@id": "schema:datePublished",
+      "@type": "xsd:date"
+    },
+    "accessed": {
+      "@id": "mif:accessed",
+      "@type": "xsd:dateTime"
+    },
+    "relevance": {
+      "@id": "mif:relevance",
+      "@type": "xsd:decimal"
+    },
+    "note": "mif:note",
+
+    "relationships": {
+      "@id": "mif:relationships",
+      "@container": "@set"
+    },
+    "relationshipType": {
+      "@id": "mif:relationshipType",
+      "@type": "@vocab"
+    },
+    "target": {
+      "@id": "mif:target",
+      "@type": "@id"
+    },
+    "strength": {
+      "@id": "mif:strength",
+      "@type": "xsd:decimal"
+    },
+
+    "RelatesTo": "mif:RelatesTo",
+    "DerivedFrom": "mif:DerivedFrom",
+    "Supersedes": "mif:Supersedes",
+    "ConflictsWith": "mif:ConflictsWith",
+    "PartOf": "mif:PartOf",
+    "Implements": "mif:Implements",
+    "Uses": "mif:Uses",
+    "Created": "mif:Created",
+    "MentionedIn": "mif:MentionedIn",
+
+    "temporal": "mif:temporal",
+    "validFrom": {
+      "@id": "mif:validFrom",
+      "@type": "xsd:dateTime"
+    },
+    "validUntil": {
+      "@id": "mif:validUntil",
+      "@type": "xsd:dateTime"
+    },
+    "recordedAt": {
+      "@id": "mif:recordedAt",
+      "@type": "xsd:dateTime"
+    },
+    "ttl": {
+      "@id": "mif:ttl",
+      "@type": "xsd:duration"
+    },
+    "decay": "mif:decay",
+    "model": "mif:model",
+    "halfLife": {
+      "@id": "mif:halfLife",
+      "@type": "xsd:duration"
+    },
+    "currentStrength": {
+      "@id": "mif:currentStrength",
+      "@type": "xsd:decimal"
+    },
+    "lastReinforced": {
+      "@id": "mif:lastReinforced",
+      "@type": "xsd:dateTime"
+    },
+    "accessCount": {
+      "@id": "mif:accessCount",
+      "@type": "xsd:integer"
+    },
+    "lastAccessed": {
+      "@id": "mif:lastAccessed",
+      "@type": "xsd:dateTime"
+    },
+    "reinforcementHistory": {
+      "@id": "mif:reinforcementHistory",
+      "@container": "@list"
+    },
+
+    "provenance": "mif:provenance",
+    "sourceType": {
+      "@id": "mif:sourceType",
+      "@type": "@vocab"
+    },
+    "sourceRef": {
+      "@id": "mif:sourceRef",
+      "@type": "@id"
+    },
+    "agent": "mif:agent",
+    "agentVersion": "mif:agentVersion",
+    "confidence": {
+      "@id": "mif:confidence",
+      "@type": "xsd:decimal"
+    },
+    "trustLevel": {
+      "@id": "mif:trustLevel",
+      "@type": "@vocab"
+    },
+
+    "user_explicit": "mif:UserExplicit",
+    "user_implicit": "mif:UserImplicit",
+    "agent_inferred": "mif:AgentInferred",
+    "external_import": "mif:ExternalImport",
+    "system_generated": "mif:SystemGenerated",
+
+    "verified": "mif:Verified",
+    "user_stated": "mif:UserStated",
+    "high_confidence": "mif:HighConfidence",
+    "moderate_confidence": "mif:ModerateConfidence",
+    "low_confidence": "mif:LowConfidence",
+    "uncertain": "mif:Uncertain",
+
+    "embedding": "mif:embedding",
+    "modelVersion": "mif:modelVersion",
+    "dimensions": {
+      "@id": "mif:dimensions",
+      "@type": "xsd:integer"
+    },
+    "sourceText": "mif:sourceText",
+    "normalized": {
+      "@id": "mif:normalized",
+      "@type": "xsd:boolean"
+    },
+    "vectorUri": {
+      "@id": "mif:vectorUri",
+      "@type": "@id"
+    },
+    "vector": "mif:vector",
+    "encoding": "mif:encoding",
+    "data": "mif:data",
+
+    "extensions": {
+      "@id": "mif:extensions",
+      "@container": "@index"
+    },
+
+    "semantic": "mif:SemanticType",
+    "episodic": "mif:EpisodicType",
+    "procedural": "mif:ProceduralType"
+  }
+}

--- a/public/schema/0.1.0/definitions/entity-reference.schema.json
+++ b/public/schema/0.1.0/definitions/entity-reference.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/definitions/entity-reference.schema.json",
+  "title": "MIF Entity Reference",
+  "description": "Reference to an entity (person, organization, technology, etc.) within a MIF memory",
+  "type": "object",
+  "required": ["@type", "entity"],
+  "properties": {
+    "@type": {
+      "const": "EntityReference"
+    },
+    "entity": {
+      "type": "object",
+      "description": "Entity identifier object",
+      "required": ["@id"],
+      "properties": {
+        "@id": {
+          "type": "string",
+          "pattern": "^urn:mif:entity:",
+          "description": "Entity URN identifier (e.g., urn:mif:entity:person:jane-smith)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "entityType": {
+      "type": "string",
+      "description": "Entity type classification",
+      "oneOf": [
+        {
+          "enum": ["Person", "Organization", "Technology", "Concept", "File"]
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Custom entity type from ontology (e.g., grazing-plan, soil-profile)"
+        }
+      ]
+    },
+    "name": {
+      "type": "string",
+      "description": "Display name for the entity"
+    },
+    "role": {
+      "type": "string",
+      "description": "Role of the entity in the memory context (e.g., author, subject, topic)"
+    }
+  },
+  "additionalProperties": false
+}

--- a/public/schema/0.1.0/mif.schema.json
+++ b/public/schema/0.1.0/mif.schema.json
@@ -1,0 +1,450 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/mif.schema.json",
+  "title": "Memory Interchange Format (MIF)",
+  "description": "JSON Schema for validating MIF memory documents",
+  "type": "object",
+  "required": ["@context", "@type", "@id", "memoryType", "content", "created"],
+  "properties": {
+    "@context": {
+      "description": "JSON-LD context",
+      "oneOf": [
+        { "type": "string", "format": "uri" },
+        { "type": "array", "items": { "type": ["string", "object"] } },
+        { "type": "object" }
+      ]
+    },
+    "@type": {
+      "description": "Type of the memory document",
+      "oneOf": [
+        { "const": "Memory" },
+        { "type": "array", "contains": { "const": "Memory" } }
+      ]
+    },
+    "@id": {
+      "type": "string",
+      "pattern": "^urn:mif:",
+      "description": "Unique identifier in URN format"
+    },
+    "memoryType": {
+      "type": "string",
+      "enum": ["semantic", "episodic", "procedural"],
+      "description": "Memory classification using cognitive triad: semantic (facts/knowledge), episodic (events/experiences), procedural (processes/how-to)"
+    },
+    "content": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The memory content in Markdown format"
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable title"
+    },
+    "created": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Creation timestamp (ISO 8601)"
+    },
+    "modified": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last modification timestamp (ISO 8601)"
+    },
+    "ontology": {
+      "$ref": "#/$defs/OntologyReference",
+      "description": "Reference to the ontology this memory conforms to"
+    },
+    "entity": {
+      "$ref": "#/$defs/EntityData",
+      "description": "Structured entity data for ontology-typed memories"
+    },
+    "namespace": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)*$",
+      "description": "Hierarchical namespace path"
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Classification tags"
+    },
+    "aliases": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Alternative names for the memory"
+    },
+    "entities": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/EntityReference" },
+      "description": "Referenced entities"
+    },
+    "relationships": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Relationship" },
+      "description": "Typed relationships to other memories"
+    },
+    "temporal": {
+      "$ref": "#/$defs/TemporalMetadata",
+      "description": "Temporal validity and decay data"
+    },
+    "provenance": {
+      "$ref": "#/$defs/Provenance",
+      "description": "Source and trust data"
+    },
+    "embedding": {
+      "$ref": "#/$defs/EmbeddingReference",
+      "description": "Embedding model reference"
+    },
+    "citations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Citation" },
+      "description": "Citation references (Level 3)"
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 500,
+      "description": "Compressed content summary (Level 3, max 500 chars)"
+    },
+    "compressedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When compression was applied (Level 3)"
+    },
+    "blocks": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Named block references (^block-id) with their text content for granular linking"
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Provider-specific extensions"
+    }
+  },
+  "$defs": {
+    "Citation": {
+      "type": "object",
+      "required": ["@type", "citationType", "citationRole", "title", "url"],
+      "properties": {
+        "@type": {
+          "const": "Citation"
+        },
+        "citationType": {
+          "type": "string",
+          "description": "Source category",
+          "oneOf": [
+            {
+              "enum": [
+                "article",
+                "book",
+                "paper",
+                "website",
+                "documentation",
+                "repository",
+                "video",
+                "podcast",
+                "specification",
+                "dataset",
+                "tool",
+                "other"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+              "description": "Custom namespaced type"
+            }
+          ]
+        },
+        "citationRole": {
+          "type": "string",
+          "description": "Relationship to memory",
+          "oneOf": [
+            {
+              "enum": [
+                "supports",
+                "refutes",
+                "background",
+                "methodology",
+                "contradicts",
+                "extends",
+                "derived",
+                "source",
+                "example",
+                "review"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+              "description": "Custom namespaced role"
+            }
+          ]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Citation title"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Citation URL"
+        },
+        "author": {
+          "description": "Author(s) as entity reference(s) or plain text",
+          "oneOf": [
+            { "$ref": "#/$defs/EntityReference" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/$defs/EntityReference" }
+            },
+            { "type": "string" }
+          ]
+        },
+        "date": {
+          "type": "string",
+          "format": "date",
+          "description": "Publication date (ISO 8601)"
+        },
+        "accessed": {
+          "type": "string",
+          "format": "date",
+          "description": "Access date (ISO 8601)"
+        },
+        "relevance": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Relevance score (0.0-1.0)"
+        },
+        "note": {
+          "type": "string",
+          "maxLength": 1000,
+          "description": "Free-form annotation"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EntityReference": {
+      "$ref": "./definitions/entity-reference.schema.json"
+    },
+    "Relationship": {
+      "type": "object",
+      "required": ["@type", "relationshipType", "target"],
+      "properties": {
+        "@type": {
+          "const": "Relationship"
+        },
+        "relationshipType": {
+          "type": "string",
+          "description": "Relationship type",
+          "oneOf": [
+            {
+              "enum": [
+                "RelatesTo",
+                "DerivedFrom",
+                "Supersedes",
+                "ConflictsWith",
+                "PartOf",
+                "Implements",
+                "Uses",
+                "Created",
+                "MentionedIn"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+              "description": "Custom namespaced relationship type (e.g., farm:BreedsWith)"
+            }
+          ]
+        },
+        "target": {
+          "type": "object",
+          "required": ["@id"],
+          "properties": {
+            "@id": {
+              "type": "string",
+              "pattern": "^urn:mif:"
+            }
+          }
+        },
+        "strength": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Relationship strength"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "TemporalMetadata": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "const": "TemporalMetadata"
+        },
+        "validFrom": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "validUntil": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "recordedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl": {
+          "type": "string",
+          "pattern": "^P",
+          "description": "ISO 8601 duration"
+        },
+        "decay": {
+          "type": "object",
+          "properties": {
+            "model": {
+              "type": "string",
+              "enum": ["none", "linear", "exponential", "step"]
+            },
+            "halfLife": {
+              "type": "string",
+              "pattern": "^P"
+            },
+            "currentStrength": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          }
+        },
+        "accessCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "lastAccessed": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Provenance": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        },
+        "sourceType": {
+          "type": "string",
+          "enum": [
+            "user_explicit",
+            "user_implicit",
+            "agent_inferred",
+            "external_import",
+            "system_generated"
+          ]
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "trustLevel": {
+          "type": "string",
+          "enum": [
+            "verified",
+            "user_stated",
+            "high_confidence",
+            "moderate_confidence",
+            "low_confidence",
+            "uncertain"
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "EmbeddingReference": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "const": "EmbeddingReference"
+        },
+        "model": {
+          "type": "string"
+        },
+        "modelVersion": {
+          "type": "string"
+        },
+        "dimensions": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "sourceText": {
+          "type": "string"
+        },
+        "vectorUri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "normalized": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "OntologyReference": {
+      "type": "object",
+      "description": "Reference to the ontology this memory conforms to",
+      "required": ["id"],
+      "properties": {
+        "@type": {
+          "const": "OntologyReference"
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Ontology identifier (must match ontology.id in ontology definition)"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+.*$",
+          "description": "Semantic version of the ontology"
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to the ontology definition"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EntityData": {
+      "type": "object",
+      "description": "Structured entity data for ontology-typed memories. Fields are defined by the entity_type schema in the referenced ontology.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the entity"
+        },
+        "entity_type": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Entity type from ontology (e.g., grazing-plan, soil-profile)"
+        },
+        "entity_id": {
+          "type": "string",
+          "description": "Unique identifier for this entity instance"
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/public/schema/0.1.0/ontology/ontology.context.jsonld
+++ b/public/schema/0.1.0/ontology/ontology.context.jsonld
@@ -1,0 +1,127 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "https://github.com/zircote/MIF/ontology#",
+    "mif": "https://github.com/zircote/MIF#",
+    "schema": "https://schema.org/",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "ontology": {
+      "@id": "mif:Ontology",
+      "@type": "@id"
+    },
+    "id": {
+      "@id": "@id"
+    },
+    "version": {
+      "@id": "schema:version",
+      "@type": "xsd:string"
+    },
+    "description": {
+      "@id": "schema:description",
+      "@type": "xsd:string"
+    },
+    "schema_url": {
+      "@id": "rdfs:isDefinedBy",
+      "@type": "@id"
+    },
+
+    "namespaces": {
+      "@id": "mif:hasNamespace",
+      "@container": "@id"
+    },
+    "type_hint": {
+      "@id": "mif:typeHint",
+      "@type": "xsd:string"
+    },
+    "replaces": {
+      "@id": "mif:replaces",
+      "@type": "@id"
+    },
+    "children": {
+      "@id": "mif:hasChildNamespace",
+      "@container": "@id"
+    },
+
+    "entity_types": {
+      "@id": "mif:definesEntityType",
+      "@container": "@list"
+    },
+    "name": {
+      "@id": "schema:name",
+      "@type": "xsd:string"
+    },
+    "base": {
+      "@id": "mif:baseType",
+      "@type": "@vocab"
+    },
+    "semantic": "mif:SemanticMemory",
+    "episodic": "mif:EpisodicMemory",
+    "procedural": "mif:ProceduralMemory",
+
+    "traits": {
+      "@id": "mif:definesTrait",
+      "@container": "@id"
+    },
+    "fields": {
+      "@id": "mif:hasField",
+      "@container": "@id"
+    },
+    "requires": {
+      "@id": "mif:requiresField",
+      "@container": "@list"
+    },
+
+    "relationships": {
+      "@id": "mif:definesRelationship",
+      "@container": "@id"
+    },
+    "from": {
+      "@id": "rdfs:domain",
+      "@container": "@set"
+    },
+    "to": {
+      "@id": "rdfs:range",
+      "@container": "@set"
+    },
+    "symmetric": {
+      "@id": "owl:SymmetricProperty",
+      "@type": "xsd:boolean"
+    },
+
+    "discovery": {
+      "@id": "mif:discoveryConfig"
+    },
+    "enabled": {
+      "@id": "mif:discoveryEnabled",
+      "@type": "xsd:boolean"
+    },
+    "patterns": {
+      "@id": "mif:hasDiscoveryPattern",
+      "@container": "@list"
+    },
+    "confidence_threshold": {
+      "@id": "mif:confidenceThreshold",
+      "@type": "xsd:decimal"
+    },
+    "content_pattern": {
+      "@id": "mif:contentPattern",
+      "@type": "xsd:string"
+    },
+    "file_pattern": {
+      "@id": "mif:filePattern",
+      "@type": "xsd:string"
+    },
+    "suggest_entity": {
+      "@id": "mif:suggestsEntityType",
+      "@type": "@id"
+    },
+    "suggest_namespace": {
+      "@id": "mif:suggestsNamespace",
+      "@type": "xsd:string"
+    }
+  }
+}

--- a/public/schema/0.1.0/ontology/ontology.schema.json
+++ b/public/schema/0.1.0/ontology/ontology.schema.json
@@ -1,0 +1,355 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/ontology/ontology.schema.json",
+  "title": "MIF Ontology Schema",
+  "description": "JSON Schema for validating ontology definition files with cognitive triad namespace hierarchy",
+  "type": "object",
+  "properties": {
+    "ontology": {
+      "type": "object",
+      "description": "Ontology metadata",
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the ontology",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "version": {
+          "type": "string",
+          "description": "Semantic version string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+.*$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "schema_url": {
+          "type": "string",
+          "description": "URL to external schema definition",
+          "format": "uri"
+        },
+        "extends": {
+          "type": "array",
+          "description": "List of ontology IDs this ontology extends (inherits traits and relationships)",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          }
+        }
+      }
+    },
+    "namespaces": {
+      "type": "object",
+      "description": "Hierarchical namespace definitions following cognitive triad",
+      "additionalProperties": {
+        "$ref": "#/$defs/namespace"
+      }
+    },
+    "entity_types": {
+      "type": "array",
+      "description": "Custom entity type definitions",
+      "items": {
+        "$ref": "#/$defs/entityType"
+      }
+    },
+    "traits": {
+      "type": "object",
+      "description": "Reusable trait/mixin definitions",
+      "additionalProperties": {
+        "$ref": "#/$defs/trait"
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "description": "Relationship type definitions",
+      "additionalProperties": {
+        "$ref": "#/$defs/relationship"
+      }
+    },
+    "discovery": {
+      "type": "object",
+      "description": "Entity discovery configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether discovery is enabled",
+          "default": false
+        },
+        "confidence_threshold": {
+          "type": "number",
+          "description": "Minimum confidence for suggestions",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.8
+        },
+        "content_patterns": {
+          "type": "array",
+          "description": "Patterns matched against user prompts and memory content",
+          "items": {
+            "$ref": "#/$defs/contentPattern"
+          }
+        },
+        "file_patterns": {
+          "type": "array",
+          "description": "Patterns matched against file paths being edited",
+          "items": {
+            "$ref": "#/$defs/filePattern"
+          }
+        },
+        "patterns": {
+          "type": "array",
+          "description": "Unified patterns array (alternative to separate content/file arrays)",
+          "items": {
+            "$ref": "#/$defs/unifiedPattern"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "namespace": {
+      "type": "object",
+      "description": "Namespace definition with optional children for hierarchical structure",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Namespace description"
+        },
+        "type_hint": {
+          "type": "string",
+          "description": "Default memory type for this namespace",
+          "enum": ["semantic", "episodic", "procedural"]
+        },
+        "replaces": {
+          "type": "string",
+          "description": "Base namespace this replaces (for migration)"
+        },
+        "children": {
+          "type": "object",
+          "description": "Child namespaces forming hierarchical structure",
+          "additionalProperties": {
+            "$ref": "#/$defs/namespace"
+          }
+        }
+      }
+    },
+    "entityType": {
+      "type": "object",
+      "description": "Entity type definition",
+      "required": ["name", "base"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Entity type name",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Entity type description"
+        },
+        "base": {
+          "type": "string",
+          "description": "Base memory type",
+          "enum": ["semantic", "episodic", "procedural"]
+        },
+        "traits": {
+          "type": "array",
+          "description": "Traits this entity type includes",
+          "items": {
+            "type": "string"
+          }
+        },
+        "schema": {
+          "type": "object",
+          "description": "JSON Schema for entity fields",
+          "properties": {
+            "required": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "properties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/propertySchema"
+              }
+            }
+          }
+        }
+      }
+    },
+    "trait": {
+      "type": "object",
+      "description": "Trait/mixin definition",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "extends": {
+          "type": "array",
+          "description": "List of trait names this trait extends (inherits fields from)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fields": {
+          "type": "object",
+          "description": "Fields provided by this trait",
+          "additionalProperties": {
+            "$ref": "#/$defs/propertySchema"
+          }
+        },
+        "requires": {
+          "type": "array",
+          "description": "MIF fields this trait requires",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "description": "Relationship type definition",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "from": {
+          "type": "array",
+          "description": "Entity types that can be the source",
+          "items": {
+            "type": "string"
+          }
+        },
+        "to": {
+          "type": "array",
+          "description": "Entity types that can be the target",
+          "items": {
+            "type": "string"
+          }
+        },
+        "symmetric": {
+          "type": "boolean",
+          "description": "Whether the relationship is symmetric",
+          "default": false
+        }
+      }
+    },
+    "contentPattern": {
+      "type": "object",
+      "description": "Pattern matched against user prompts and memory content",
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in content"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace to suggest (hierarchical path)"
+        },
+        "namespaces": {
+          "type": "array",
+          "description": "Multiple namespaces to suggest",
+          "items": { "type": "string" }
+        },
+        "suggest_entity": {
+          "type": "string",
+          "description": "Entity type to suggest when pattern matches"
+        },
+        "context": {
+          "type": "string",
+          "description": "Human-readable context hint"
+        }
+      }
+    },
+    "unifiedPattern": {
+      "type": "object",
+      "description": "Unified pattern with content_pattern or file_pattern discriminator",
+      "properties": {
+        "content_pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in content"
+        },
+        "file_pattern": {
+          "type": "string",
+          "description": "Glob pattern to match file paths"
+        },
+        "suggest_namespace": {
+          "type": "string",
+          "description": "Namespace to suggest"
+        },
+        "suggest_entity": {
+          "type": "string",
+          "description": "Entity type to suggest"
+        }
+      }
+    },
+    "filePattern": {
+      "type": "object",
+      "description": "Pattern matched against file paths being edited",
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in file paths"
+        },
+        "namespaces": {
+          "type": "array",
+          "description": "Namespaces to suggest (hierarchical paths)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context": {
+          "type": "string",
+          "description": "Human-readable context hint for this pattern"
+        },
+        "suggest_entity": {
+          "type": "string",
+          "description": "Entity type to suggest when pattern matches"
+        }
+      }
+    },
+    "propertySchema": {
+      "type": "object",
+      "description": "JSON Schema property definition",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array",
+            "object",
+            "null"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string",
+          "description": "Format hint (e.g., 'uri', 'date-time')"
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern for string validation"
+        },
+        "items": {
+          "type": "object",
+          "description": "Schema for array items"
+        },
+        "enum": {
+          "type": "array",
+          "description": "Allowed values"
+        }
+      }
+    }
+  }
+}

--- a/public/schema/VERSIONING.md
+++ b/public/schema/VERSIONING.md
@@ -22,9 +22,13 @@ Here `<file>` is a schema's actual filename — e.g. `mif.schema.json`,
 | Access | Path | Mutability |
 | --- | --- | --- |
 | Canonical (latest) | `/schema/<file>` | moves with releases |
-| Exact version | `/schema/1.0.0/<file>` | immutable |
+| Exact version | `/schema/0.1.0/<file>`, `/schema/1.0.0/<file>` | immutable |
 | Moving alias | `/schema/latest/<file>` | tracks newest release |
-| Major alias | `/schema/v1/<file>` | newest 1.x (`v2` reserved for 2.0.0) |
+| Major alias | `/schema/v0/<file>` (newest 0.x), `/schema/v1/<file>` (newest 1.x) | `v2` reserved for 2.0.0 |
+
+Every published version mirror is an exact, immutable snapshot of that release's
+git tag (e.g. `/schema/0.1.0/` ← tag `v0.1.0`, `/schema/1.0.0/` ← tag `v1.0.0`).
+Released versions: `0.1.0`, `1.0.0`.
 
 The internal `$id` of every mirrored copy remains the canonical unversioned URL;
 the version path is an additional access location, not a new schema identity.
@@ -46,8 +50,8 @@ hosts that can set it should serve `application/schema+json`.
 
 ## Cutting a new release
 
-1. Bump `VERSION.json`.
-2. Copy the current top-level schema set into `/schema/<new-version>/`.
+1. Bump `VERSION.json` and tag the release (`vMAJOR.MINOR.PATCH`).
+2. Snapshot that tag's schema set into `/schema/<version>/` (immutable; bytes
+   taken from the tag, `$id` unchanged).
 3. Refresh `/schema/latest/` and the matching major alias (`/schema/vN/`); update
    `aliases` + `versions` in `index.json`.
-4. Tag the release.

--- a/public/schema/VERSIONING.md
+++ b/public/schema/VERSIONING.md
@@ -50,7 +50,7 @@ hosts that can set it should serve `application/schema+json`.
 
 ## Cutting a new release
 
-1. Bump `VERSION.json` and tag the release (`vMAJOR.MINOR.PATCH`).
+1. Bump the repo-root `VERSION.json` and tag the release (`vMAJOR.MINOR.PATCH`).
 2. Snapshot that tag's schema set into `/schema/<version>/` (immutable; bytes
    taken from the tag, `$id` unchanged).
 3. Refresh `/schema/latest/` and the matching major alias (`/schema/vN/`); update

--- a/public/schema/index.json
+++ b/public/schema/index.json
@@ -10,19 +10,25 @@
   },
   "aliases": {
     "latest": "1.0.0",
+    "v0": "0.1.0",
     "v1": "1.0.0"
   },
   "reserved": {
     "v2": "first 2.x release (not yet published)"
   },
-  "versions": ["1.0.0"],
+  "versions": [
+    "0.1.0",
+    "1.0.0"
+  ],
   "schemas": [
     {
       "id": "mif",
       "canonical": "https://mif-spec.dev/schema/mif.schema.json",
       "versioned": {
+        "0.1.0": "https://mif-spec.dev/schema/0.1.0/mif.schema.json",
         "1.0.0": "https://mif-spec.dev/schema/1.0.0/mif.schema.json",
         "latest": "https://mif-spec.dev/schema/latest/mif.schema.json",
+        "v0": "https://mif-spec.dev/schema/v0/mif.schema.json",
         "v1": "https://mif-spec.dev/schema/v1/mif.schema.json"
       }
     },
@@ -30,8 +36,10 @@
       "id": "citation",
       "canonical": "https://mif-spec.dev/schema/citation.schema.json",
       "versioned": {
+        "0.1.0": "https://mif-spec.dev/schema/0.1.0/citation.schema.json",
         "1.0.0": "https://mif-spec.dev/schema/1.0.0/citation.schema.json",
         "latest": "https://mif-spec.dev/schema/latest/citation.schema.json",
+        "v0": "https://mif-spec.dev/schema/v0/citation.schema.json",
         "v1": "https://mif-spec.dev/schema/v1/citation.schema.json"
       }
     },
@@ -39,8 +47,10 @@
       "id": "entity-reference",
       "canonical": "https://mif-spec.dev/schema/definitions/entity-reference.schema.json",
       "versioned": {
+        "0.1.0": "https://mif-spec.dev/schema/0.1.0/definitions/entity-reference.schema.json",
         "1.0.0": "https://mif-spec.dev/schema/1.0.0/definitions/entity-reference.schema.json",
         "latest": "https://mif-spec.dev/schema/latest/definitions/entity-reference.schema.json",
+        "v0": "https://mif-spec.dev/schema/v0/definitions/entity-reference.schema.json",
         "v1": "https://mif-spec.dev/schema/v1/definitions/entity-reference.schema.json"
       }
     },
@@ -48,8 +58,10 @@
       "id": "ontology",
       "canonical": "https://mif-spec.dev/schema/ontology/ontology.schema.json",
       "versioned": {
+        "0.1.0": "https://mif-spec.dev/schema/0.1.0/ontology/ontology.schema.json",
         "1.0.0": "https://mif-spec.dev/schema/1.0.0/ontology/ontology.schema.json",
         "latest": "https://mif-spec.dev/schema/latest/ontology/ontology.schema.json",
+        "v0": "https://mif-spec.dev/schema/v0/ontology/ontology.schema.json",
         "v1": "https://mif-spec.dev/schema/v1/ontology/ontology.schema.json"
       }
     },
@@ -57,8 +69,10 @@
       "id": "context",
       "canonical": "https://mif-spec.dev/schema/context.jsonld",
       "versioned": {
+        "0.1.0": "https://mif-spec.dev/schema/0.1.0/context.jsonld",
         "1.0.0": "https://mif-spec.dev/schema/1.0.0/context.jsonld",
         "latest": "https://mif-spec.dev/schema/latest/context.jsonld",
+        "v0": "https://mif-spec.dev/schema/v0/context.jsonld",
         "v1": "https://mif-spec.dev/schema/v1/context.jsonld"
       }
     },
@@ -66,8 +80,10 @@
       "id": "ontology-context",
       "canonical": "https://mif-spec.dev/schema/ontology/ontology.context.jsonld",
       "versioned": {
+        "0.1.0": "https://mif-spec.dev/schema/0.1.0/ontology/ontology.context.jsonld",
         "1.0.0": "https://mif-spec.dev/schema/1.0.0/ontology/ontology.context.jsonld",
         "latest": "https://mif-spec.dev/schema/latest/ontology/ontology.context.jsonld",
+        "v0": "https://mif-spec.dev/schema/v0/ontology/ontology.context.jsonld",
         "v1": "https://mif-spec.dev/schema/v1/ontology/ontology.context.jsonld"
       }
     }

--- a/public/schema/v0/citation.schema.json
+++ b/public/schema/v0/citation.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/citation.schema.json",
+  "title": "MIF Citation",
+  "description": "JSON Schema for validating MIF citation objects",
+  "type": "object",
+  "required": ["@type", "citationType", "citationRole", "title", "url"],
+  "properties": {
+    "@type": {
+      "const": "Citation",
+      "description": "Must be 'Citation'"
+    },
+    "citationType": {
+      "type": "string",
+      "description": "Source category - either a standard type or custom namespaced type",
+      "oneOf": [
+        {
+          "enum": [
+            "article",
+            "book",
+            "paper",
+            "website",
+            "documentation",
+            "repository",
+            "video",
+            "podcast",
+            "specification",
+            "dataset",
+            "tool",
+            "other"
+          ],
+          "description": "Standard citation types"
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+          "description": "Custom namespaced type (e.g., 'acme:memo')"
+        }
+      ]
+    },
+    "citationRole": {
+      "type": "string",
+      "description": "Relationship to memory - either a standard role or custom namespaced role",
+      "oneOf": [
+        {
+          "enum": [
+            "supports",
+            "refutes",
+            "background",
+            "methodology",
+            "contradicts",
+            "extends",
+            "derived",
+            "source",
+            "example",
+            "review"
+          ],
+          "description": "Standard citation roles"
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+          "description": "Custom namespaced role (e.g., 'legal:precedent')"
+        }
+      ]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Citation title (required, non-empty)"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Citation URL (required, valid URI)"
+    },
+    "author": {
+      "description": "Author(s) - can be entity reference object, array of entity references, or plain text string",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/EntityReference",
+          "description": "Single author entity reference"
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EntityReference" },
+          "minItems": 1,
+          "description": "Multiple author entity references"
+        },
+        {
+          "type": "string",
+          "description": "Plain text author name(s)"
+        }
+      ]
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "description": "Publication date in ISO 8601 format (YYYY-MM-DD)"
+    },
+    "accessed": {
+      "type": "string",
+      "format": "date",
+      "description": "Access date in ISO 8601 format (YYYY-MM-DD)"
+    },
+    "relevance": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Relevance score between 0.0 and 1.0"
+    },
+    "note": {
+      "type": "string",
+      "maxLength": 1000,
+      "description": "Free-form annotation (recommended under 1000 characters)"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "EntityReference": {
+      "$ref": "./definitions/entity-reference.schema.json"
+    }
+  },
+  "examples": [
+    {
+      "@type": "Citation",
+      "citationType": "article",
+      "citationRole": "supports",
+      "title": "Memory Systems in AI Agents",
+      "url": "https://arxiv.org/abs/2024.12345",
+      "author": {
+        "@type": "EntityReference",
+        "entity": { "@id": "urn:mif:entity:person:jane-smith" },
+        "entityType": "Person",
+        "name": "Jane Smith"
+      },
+      "date": "2024-06-15",
+      "accessed": "2026-01-20",
+      "relevance": 0.95,
+      "note": "Foundational paper on semantic memory"
+    },
+    {
+      "@type": "Citation",
+      "citationType": "documentation",
+      "citationRole": "background",
+      "title": "Obsidian Help",
+      "url": "https://help.obsidian.md/",
+      "accessed": "2026-01-18",
+      "relevance": 0.85
+    }
+  ]
+}

--- a/public/schema/v0/context.jsonld
+++ b/public/schema/v0/context.jsonld
@@ -1,0 +1,246 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "mif": "https://raw.githubusercontent.com/zircote/MIF/main/ns/",
+    "dc": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "schema": "https://schema.org/",
+
+    "Memory": "mif:Memory",
+    "Entity": "mif:Entity",
+    "Relationship": "mif:Relationship",
+    "TemporalMetadata": "mif:TemporalMetadata",
+    "EmbeddingReference": "mif:EmbeddingReference",
+    "EntityReference": "mif:EntityReference",
+    "OntologyReference": "mif:OntologyReference",
+    "EntityData": "mif:EntityData",
+    "Vector": "mif:Vector",
+
+    "Person": "mif:Person",
+    "Organization": "mif:Organization",
+    "Technology": "mif:Technology",
+    "Concept": "mif:Concept",
+    "File": "mif:File",
+
+    "id": "@id",
+    "type": "@type",
+
+    "content": {
+      "@id": "mif:content",
+      "@type": "xsd:string"
+    },
+    "memoryType": {
+      "@id": "mif:memoryType",
+      "@type": "@vocab"
+    },
+    "title": "dc:title",
+    "namespace": "mif:namespace",
+    "tags": {
+      "@id": "mif:tags",
+      "@container": "@set"
+    },
+    "aliases": {
+      "@id": "mif:aliases",
+      "@container": "@set"
+    },
+    "blocks": {
+      "@id": "mif:blocks",
+      "@container": "@index"
+    },
+
+    "created": {
+      "@id": "dc:created",
+      "@type": "xsd:dateTime"
+    },
+    "modified": {
+      "@id": "dc:modified",
+      "@type": "xsd:dateTime"
+    },
+
+    "entities": {
+      "@id": "mif:entities",
+      "@container": "@set"
+    },
+    "entity": {
+      "@id": "mif:entity",
+      "@type": "@id"
+    },
+    "entityType": "mif:entityType",
+    "entity_type": "mif:entity_type",
+    "entity_id": "mif:entity_id",
+    "name": "schema:name",
+    "role": "mif:role",
+
+    "ontology": "mif:ontology",
+    "version": "mif:version",
+    "uri": {
+      "@id": "mif:uri",
+      "@type": "@id"
+    },
+
+    "citations": {
+      "@id": "mif:citations",
+      "@container": "@set"
+    },
+    "Citation": "mif:Citation",
+    "citationType": {
+      "@id": "mif:citationType",
+      "@type": "@vocab"
+    },
+    "citationRole": {
+      "@id": "mif:citationRole",
+      "@type": "@vocab"
+    },
+    "url": {
+      "@id": "schema:url",
+      "@type": "@id"
+    },
+    "author": "schema:author",
+    "date": {
+      "@id": "schema:datePublished",
+      "@type": "xsd:date"
+    },
+    "accessed": {
+      "@id": "mif:accessed",
+      "@type": "xsd:dateTime"
+    },
+    "relevance": {
+      "@id": "mif:relevance",
+      "@type": "xsd:decimal"
+    },
+    "note": "mif:note",
+
+    "relationships": {
+      "@id": "mif:relationships",
+      "@container": "@set"
+    },
+    "relationshipType": {
+      "@id": "mif:relationshipType",
+      "@type": "@vocab"
+    },
+    "target": {
+      "@id": "mif:target",
+      "@type": "@id"
+    },
+    "strength": {
+      "@id": "mif:strength",
+      "@type": "xsd:decimal"
+    },
+
+    "RelatesTo": "mif:RelatesTo",
+    "DerivedFrom": "mif:DerivedFrom",
+    "Supersedes": "mif:Supersedes",
+    "ConflictsWith": "mif:ConflictsWith",
+    "PartOf": "mif:PartOf",
+    "Implements": "mif:Implements",
+    "Uses": "mif:Uses",
+    "Created": "mif:Created",
+    "MentionedIn": "mif:MentionedIn",
+
+    "temporal": "mif:temporal",
+    "validFrom": {
+      "@id": "mif:validFrom",
+      "@type": "xsd:dateTime"
+    },
+    "validUntil": {
+      "@id": "mif:validUntil",
+      "@type": "xsd:dateTime"
+    },
+    "recordedAt": {
+      "@id": "mif:recordedAt",
+      "@type": "xsd:dateTime"
+    },
+    "ttl": {
+      "@id": "mif:ttl",
+      "@type": "xsd:duration"
+    },
+    "decay": "mif:decay",
+    "model": "mif:model",
+    "halfLife": {
+      "@id": "mif:halfLife",
+      "@type": "xsd:duration"
+    },
+    "currentStrength": {
+      "@id": "mif:currentStrength",
+      "@type": "xsd:decimal"
+    },
+    "lastReinforced": {
+      "@id": "mif:lastReinforced",
+      "@type": "xsd:dateTime"
+    },
+    "accessCount": {
+      "@id": "mif:accessCount",
+      "@type": "xsd:integer"
+    },
+    "lastAccessed": {
+      "@id": "mif:lastAccessed",
+      "@type": "xsd:dateTime"
+    },
+    "reinforcementHistory": {
+      "@id": "mif:reinforcementHistory",
+      "@container": "@list"
+    },
+
+    "provenance": "mif:provenance",
+    "sourceType": {
+      "@id": "mif:sourceType",
+      "@type": "@vocab"
+    },
+    "sourceRef": {
+      "@id": "mif:sourceRef",
+      "@type": "@id"
+    },
+    "agent": "mif:agent",
+    "agentVersion": "mif:agentVersion",
+    "confidence": {
+      "@id": "mif:confidence",
+      "@type": "xsd:decimal"
+    },
+    "trustLevel": {
+      "@id": "mif:trustLevel",
+      "@type": "@vocab"
+    },
+
+    "user_explicit": "mif:UserExplicit",
+    "user_implicit": "mif:UserImplicit",
+    "agent_inferred": "mif:AgentInferred",
+    "external_import": "mif:ExternalImport",
+    "system_generated": "mif:SystemGenerated",
+
+    "verified": "mif:Verified",
+    "user_stated": "mif:UserStated",
+    "high_confidence": "mif:HighConfidence",
+    "moderate_confidence": "mif:ModerateConfidence",
+    "low_confidence": "mif:LowConfidence",
+    "uncertain": "mif:Uncertain",
+
+    "embedding": "mif:embedding",
+    "modelVersion": "mif:modelVersion",
+    "dimensions": {
+      "@id": "mif:dimensions",
+      "@type": "xsd:integer"
+    },
+    "sourceText": "mif:sourceText",
+    "normalized": {
+      "@id": "mif:normalized",
+      "@type": "xsd:boolean"
+    },
+    "vectorUri": {
+      "@id": "mif:vectorUri",
+      "@type": "@id"
+    },
+    "vector": "mif:vector",
+    "encoding": "mif:encoding",
+    "data": "mif:data",
+
+    "extensions": {
+      "@id": "mif:extensions",
+      "@container": "@index"
+    },
+
+    "semantic": "mif:SemanticType",
+    "episodic": "mif:EpisodicType",
+    "procedural": "mif:ProceduralType"
+  }
+}

--- a/public/schema/v0/definitions/entity-reference.schema.json
+++ b/public/schema/v0/definitions/entity-reference.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/definitions/entity-reference.schema.json",
+  "title": "MIF Entity Reference",
+  "description": "Reference to an entity (person, organization, technology, etc.) within a MIF memory",
+  "type": "object",
+  "required": ["@type", "entity"],
+  "properties": {
+    "@type": {
+      "const": "EntityReference"
+    },
+    "entity": {
+      "type": "object",
+      "description": "Entity identifier object",
+      "required": ["@id"],
+      "properties": {
+        "@id": {
+          "type": "string",
+          "pattern": "^urn:mif:entity:",
+          "description": "Entity URN identifier (e.g., urn:mif:entity:person:jane-smith)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "entityType": {
+      "type": "string",
+      "description": "Entity type classification",
+      "oneOf": [
+        {
+          "enum": ["Person", "Organization", "Technology", "Concept", "File"]
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Custom entity type from ontology (e.g., grazing-plan, soil-profile)"
+        }
+      ]
+    },
+    "name": {
+      "type": "string",
+      "description": "Display name for the entity"
+    },
+    "role": {
+      "type": "string",
+      "description": "Role of the entity in the memory context (e.g., author, subject, topic)"
+    }
+  },
+  "additionalProperties": false
+}

--- a/public/schema/v0/mif.schema.json
+++ b/public/schema/v0/mif.schema.json
@@ -1,0 +1,450 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/mif.schema.json",
+  "title": "Memory Interchange Format (MIF)",
+  "description": "JSON Schema for validating MIF memory documents",
+  "type": "object",
+  "required": ["@context", "@type", "@id", "memoryType", "content", "created"],
+  "properties": {
+    "@context": {
+      "description": "JSON-LD context",
+      "oneOf": [
+        { "type": "string", "format": "uri" },
+        { "type": "array", "items": { "type": ["string", "object"] } },
+        { "type": "object" }
+      ]
+    },
+    "@type": {
+      "description": "Type of the memory document",
+      "oneOf": [
+        { "const": "Memory" },
+        { "type": "array", "contains": { "const": "Memory" } }
+      ]
+    },
+    "@id": {
+      "type": "string",
+      "pattern": "^urn:mif:",
+      "description": "Unique identifier in URN format"
+    },
+    "memoryType": {
+      "type": "string",
+      "enum": ["semantic", "episodic", "procedural"],
+      "description": "Memory classification using cognitive triad: semantic (facts/knowledge), episodic (events/experiences), procedural (processes/how-to)"
+    },
+    "content": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The memory content in Markdown format"
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable title"
+    },
+    "created": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Creation timestamp (ISO 8601)"
+    },
+    "modified": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last modification timestamp (ISO 8601)"
+    },
+    "ontology": {
+      "$ref": "#/$defs/OntologyReference",
+      "description": "Reference to the ontology this memory conforms to"
+    },
+    "entity": {
+      "$ref": "#/$defs/EntityData",
+      "description": "Structured entity data for ontology-typed memories"
+    },
+    "namespace": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)*$",
+      "description": "Hierarchical namespace path"
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Classification tags"
+    },
+    "aliases": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Alternative names for the memory"
+    },
+    "entities": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/EntityReference" },
+      "description": "Referenced entities"
+    },
+    "relationships": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Relationship" },
+      "description": "Typed relationships to other memories"
+    },
+    "temporal": {
+      "$ref": "#/$defs/TemporalMetadata",
+      "description": "Temporal validity and decay data"
+    },
+    "provenance": {
+      "$ref": "#/$defs/Provenance",
+      "description": "Source and trust data"
+    },
+    "embedding": {
+      "$ref": "#/$defs/EmbeddingReference",
+      "description": "Embedding model reference"
+    },
+    "citations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Citation" },
+      "description": "Citation references (Level 3)"
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 500,
+      "description": "Compressed content summary (Level 3, max 500 chars)"
+    },
+    "compressedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When compression was applied (Level 3)"
+    },
+    "blocks": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Named block references (^block-id) with their text content for granular linking"
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Provider-specific extensions"
+    }
+  },
+  "$defs": {
+    "Citation": {
+      "type": "object",
+      "required": ["@type", "citationType", "citationRole", "title", "url"],
+      "properties": {
+        "@type": {
+          "const": "Citation"
+        },
+        "citationType": {
+          "type": "string",
+          "description": "Source category",
+          "oneOf": [
+            {
+              "enum": [
+                "article",
+                "book",
+                "paper",
+                "website",
+                "documentation",
+                "repository",
+                "video",
+                "podcast",
+                "specification",
+                "dataset",
+                "tool",
+                "other"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+              "description": "Custom namespaced type"
+            }
+          ]
+        },
+        "citationRole": {
+          "type": "string",
+          "description": "Relationship to memory",
+          "oneOf": [
+            {
+              "enum": [
+                "supports",
+                "refutes",
+                "background",
+                "methodology",
+                "contradicts",
+                "extends",
+                "derived",
+                "source",
+                "example",
+                "review"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+              "description": "Custom namespaced role"
+            }
+          ]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Citation title"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Citation URL"
+        },
+        "author": {
+          "description": "Author(s) as entity reference(s) or plain text",
+          "oneOf": [
+            { "$ref": "#/$defs/EntityReference" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/$defs/EntityReference" }
+            },
+            { "type": "string" }
+          ]
+        },
+        "date": {
+          "type": "string",
+          "format": "date",
+          "description": "Publication date (ISO 8601)"
+        },
+        "accessed": {
+          "type": "string",
+          "format": "date",
+          "description": "Access date (ISO 8601)"
+        },
+        "relevance": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Relevance score (0.0-1.0)"
+        },
+        "note": {
+          "type": "string",
+          "maxLength": 1000,
+          "description": "Free-form annotation"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EntityReference": {
+      "$ref": "./definitions/entity-reference.schema.json"
+    },
+    "Relationship": {
+      "type": "object",
+      "required": ["@type", "relationshipType", "target"],
+      "properties": {
+        "@type": {
+          "const": "Relationship"
+        },
+        "relationshipType": {
+          "type": "string",
+          "description": "Relationship type",
+          "oneOf": [
+            {
+              "enum": [
+                "RelatesTo",
+                "DerivedFrom",
+                "Supersedes",
+                "ConflictsWith",
+                "PartOf",
+                "Implements",
+                "Uses",
+                "Created",
+                "MentionedIn"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+              "description": "Custom namespaced relationship type (e.g., farm:BreedsWith)"
+            }
+          ]
+        },
+        "target": {
+          "type": "object",
+          "required": ["@id"],
+          "properties": {
+            "@id": {
+              "type": "string",
+              "pattern": "^urn:mif:"
+            }
+          }
+        },
+        "strength": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Relationship strength"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "TemporalMetadata": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "const": "TemporalMetadata"
+        },
+        "validFrom": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "validUntil": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "recordedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl": {
+          "type": "string",
+          "pattern": "^P",
+          "description": "ISO 8601 duration"
+        },
+        "decay": {
+          "type": "object",
+          "properties": {
+            "model": {
+              "type": "string",
+              "enum": ["none", "linear", "exponential", "step"]
+            },
+            "halfLife": {
+              "type": "string",
+              "pattern": "^P"
+            },
+            "currentStrength": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          }
+        },
+        "accessCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "lastAccessed": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Provenance": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        },
+        "sourceType": {
+          "type": "string",
+          "enum": [
+            "user_explicit",
+            "user_implicit",
+            "agent_inferred",
+            "external_import",
+            "system_generated"
+          ]
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "trustLevel": {
+          "type": "string",
+          "enum": [
+            "verified",
+            "user_stated",
+            "high_confidence",
+            "moderate_confidence",
+            "low_confidence",
+            "uncertain"
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "EmbeddingReference": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "const": "EmbeddingReference"
+        },
+        "model": {
+          "type": "string"
+        },
+        "modelVersion": {
+          "type": "string"
+        },
+        "dimensions": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "sourceText": {
+          "type": "string"
+        },
+        "vectorUri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "normalized": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "OntologyReference": {
+      "type": "object",
+      "description": "Reference to the ontology this memory conforms to",
+      "required": ["id"],
+      "properties": {
+        "@type": {
+          "const": "OntologyReference"
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Ontology identifier (must match ontology.id in ontology definition)"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+.*$",
+          "description": "Semantic version of the ontology"
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to the ontology definition"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EntityData": {
+      "type": "object",
+      "description": "Structured entity data for ontology-typed memories. Fields are defined by the entity_type schema in the referenced ontology.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the entity"
+        },
+        "entity_type": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Entity type from ontology (e.g., grazing-plan, soil-profile)"
+        },
+        "entity_id": {
+          "type": "string",
+          "description": "Unique identifier for this entity instance"
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/public/schema/v0/ontology/ontology.context.jsonld
+++ b/public/schema/v0/ontology/ontology.context.jsonld
@@ -1,0 +1,127 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "https://github.com/zircote/MIF/ontology#",
+    "mif": "https://github.com/zircote/MIF#",
+    "schema": "https://schema.org/",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "ontology": {
+      "@id": "mif:Ontology",
+      "@type": "@id"
+    },
+    "id": {
+      "@id": "@id"
+    },
+    "version": {
+      "@id": "schema:version",
+      "@type": "xsd:string"
+    },
+    "description": {
+      "@id": "schema:description",
+      "@type": "xsd:string"
+    },
+    "schema_url": {
+      "@id": "rdfs:isDefinedBy",
+      "@type": "@id"
+    },
+
+    "namespaces": {
+      "@id": "mif:hasNamespace",
+      "@container": "@id"
+    },
+    "type_hint": {
+      "@id": "mif:typeHint",
+      "@type": "xsd:string"
+    },
+    "replaces": {
+      "@id": "mif:replaces",
+      "@type": "@id"
+    },
+    "children": {
+      "@id": "mif:hasChildNamespace",
+      "@container": "@id"
+    },
+
+    "entity_types": {
+      "@id": "mif:definesEntityType",
+      "@container": "@list"
+    },
+    "name": {
+      "@id": "schema:name",
+      "@type": "xsd:string"
+    },
+    "base": {
+      "@id": "mif:baseType",
+      "@type": "@vocab"
+    },
+    "semantic": "mif:SemanticMemory",
+    "episodic": "mif:EpisodicMemory",
+    "procedural": "mif:ProceduralMemory",
+
+    "traits": {
+      "@id": "mif:definesTrait",
+      "@container": "@id"
+    },
+    "fields": {
+      "@id": "mif:hasField",
+      "@container": "@id"
+    },
+    "requires": {
+      "@id": "mif:requiresField",
+      "@container": "@list"
+    },
+
+    "relationships": {
+      "@id": "mif:definesRelationship",
+      "@container": "@id"
+    },
+    "from": {
+      "@id": "rdfs:domain",
+      "@container": "@set"
+    },
+    "to": {
+      "@id": "rdfs:range",
+      "@container": "@set"
+    },
+    "symmetric": {
+      "@id": "owl:SymmetricProperty",
+      "@type": "xsd:boolean"
+    },
+
+    "discovery": {
+      "@id": "mif:discoveryConfig"
+    },
+    "enabled": {
+      "@id": "mif:discoveryEnabled",
+      "@type": "xsd:boolean"
+    },
+    "patterns": {
+      "@id": "mif:hasDiscoveryPattern",
+      "@container": "@list"
+    },
+    "confidence_threshold": {
+      "@id": "mif:confidenceThreshold",
+      "@type": "xsd:decimal"
+    },
+    "content_pattern": {
+      "@id": "mif:contentPattern",
+      "@type": "xsd:string"
+    },
+    "file_pattern": {
+      "@id": "mif:filePattern",
+      "@type": "xsd:string"
+    },
+    "suggest_entity": {
+      "@id": "mif:suggestsEntityType",
+      "@type": "@id"
+    },
+    "suggest_namespace": {
+      "@id": "mif:suggestsNamespace",
+      "@type": "xsd:string"
+    }
+  }
+}

--- a/public/schema/v0/ontology/ontology.schema.json
+++ b/public/schema/v0/ontology/ontology.schema.json
@@ -1,0 +1,355 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/ontology/ontology.schema.json",
+  "title": "MIF Ontology Schema",
+  "description": "JSON Schema for validating ontology definition files with cognitive triad namespace hierarchy",
+  "type": "object",
+  "properties": {
+    "ontology": {
+      "type": "object",
+      "description": "Ontology metadata",
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the ontology",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "version": {
+          "type": "string",
+          "description": "Semantic version string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+.*$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "schema_url": {
+          "type": "string",
+          "description": "URL to external schema definition",
+          "format": "uri"
+        },
+        "extends": {
+          "type": "array",
+          "description": "List of ontology IDs this ontology extends (inherits traits and relationships)",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          }
+        }
+      }
+    },
+    "namespaces": {
+      "type": "object",
+      "description": "Hierarchical namespace definitions following cognitive triad",
+      "additionalProperties": {
+        "$ref": "#/$defs/namespace"
+      }
+    },
+    "entity_types": {
+      "type": "array",
+      "description": "Custom entity type definitions",
+      "items": {
+        "$ref": "#/$defs/entityType"
+      }
+    },
+    "traits": {
+      "type": "object",
+      "description": "Reusable trait/mixin definitions",
+      "additionalProperties": {
+        "$ref": "#/$defs/trait"
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "description": "Relationship type definitions",
+      "additionalProperties": {
+        "$ref": "#/$defs/relationship"
+      }
+    },
+    "discovery": {
+      "type": "object",
+      "description": "Entity discovery configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether discovery is enabled",
+          "default": false
+        },
+        "confidence_threshold": {
+          "type": "number",
+          "description": "Minimum confidence for suggestions",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.8
+        },
+        "content_patterns": {
+          "type": "array",
+          "description": "Patterns matched against user prompts and memory content",
+          "items": {
+            "$ref": "#/$defs/contentPattern"
+          }
+        },
+        "file_patterns": {
+          "type": "array",
+          "description": "Patterns matched against file paths being edited",
+          "items": {
+            "$ref": "#/$defs/filePattern"
+          }
+        },
+        "patterns": {
+          "type": "array",
+          "description": "Unified patterns array (alternative to separate content/file arrays)",
+          "items": {
+            "$ref": "#/$defs/unifiedPattern"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "namespace": {
+      "type": "object",
+      "description": "Namespace definition with optional children for hierarchical structure",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Namespace description"
+        },
+        "type_hint": {
+          "type": "string",
+          "description": "Default memory type for this namespace",
+          "enum": ["semantic", "episodic", "procedural"]
+        },
+        "replaces": {
+          "type": "string",
+          "description": "Base namespace this replaces (for migration)"
+        },
+        "children": {
+          "type": "object",
+          "description": "Child namespaces forming hierarchical structure",
+          "additionalProperties": {
+            "$ref": "#/$defs/namespace"
+          }
+        }
+      }
+    },
+    "entityType": {
+      "type": "object",
+      "description": "Entity type definition",
+      "required": ["name", "base"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Entity type name",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Entity type description"
+        },
+        "base": {
+          "type": "string",
+          "description": "Base memory type",
+          "enum": ["semantic", "episodic", "procedural"]
+        },
+        "traits": {
+          "type": "array",
+          "description": "Traits this entity type includes",
+          "items": {
+            "type": "string"
+          }
+        },
+        "schema": {
+          "type": "object",
+          "description": "JSON Schema for entity fields",
+          "properties": {
+            "required": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "properties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/propertySchema"
+              }
+            }
+          }
+        }
+      }
+    },
+    "trait": {
+      "type": "object",
+      "description": "Trait/mixin definition",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "extends": {
+          "type": "array",
+          "description": "List of trait names this trait extends (inherits fields from)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fields": {
+          "type": "object",
+          "description": "Fields provided by this trait",
+          "additionalProperties": {
+            "$ref": "#/$defs/propertySchema"
+          }
+        },
+        "requires": {
+          "type": "array",
+          "description": "MIF fields this trait requires",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "description": "Relationship type definition",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "from": {
+          "type": "array",
+          "description": "Entity types that can be the source",
+          "items": {
+            "type": "string"
+          }
+        },
+        "to": {
+          "type": "array",
+          "description": "Entity types that can be the target",
+          "items": {
+            "type": "string"
+          }
+        },
+        "symmetric": {
+          "type": "boolean",
+          "description": "Whether the relationship is symmetric",
+          "default": false
+        }
+      }
+    },
+    "contentPattern": {
+      "type": "object",
+      "description": "Pattern matched against user prompts and memory content",
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in content"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace to suggest (hierarchical path)"
+        },
+        "namespaces": {
+          "type": "array",
+          "description": "Multiple namespaces to suggest",
+          "items": { "type": "string" }
+        },
+        "suggest_entity": {
+          "type": "string",
+          "description": "Entity type to suggest when pattern matches"
+        },
+        "context": {
+          "type": "string",
+          "description": "Human-readable context hint"
+        }
+      }
+    },
+    "unifiedPattern": {
+      "type": "object",
+      "description": "Unified pattern with content_pattern or file_pattern discriminator",
+      "properties": {
+        "content_pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in content"
+        },
+        "file_pattern": {
+          "type": "string",
+          "description": "Glob pattern to match file paths"
+        },
+        "suggest_namespace": {
+          "type": "string",
+          "description": "Namespace to suggest"
+        },
+        "suggest_entity": {
+          "type": "string",
+          "description": "Entity type to suggest"
+        }
+      }
+    },
+    "filePattern": {
+      "type": "object",
+      "description": "Pattern matched against file paths being edited",
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in file paths"
+        },
+        "namespaces": {
+          "type": "array",
+          "description": "Namespaces to suggest (hierarchical paths)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context": {
+          "type": "string",
+          "description": "Human-readable context hint for this pattern"
+        },
+        "suggest_entity": {
+          "type": "string",
+          "description": "Entity type to suggest when pattern matches"
+        }
+      }
+    },
+    "propertySchema": {
+      "type": "object",
+      "description": "JSON Schema property definition",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array",
+            "object",
+            "null"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string",
+          "description": "Format hint (e.g., 'uri', 'date-time')"
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern for string validation"
+        },
+        "items": {
+          "type": "object",
+          "description": "Schema for array items"
+        },
+        "enum": {
+          "type": "array",
+          "description": "Allowed values"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the missing immutable 0.1.0 mirror so existing consumers are not orphaned when 1.0.0 ships.

- `/schema/0.1.0/` + `/schema/v0/` snapshot the re-cut `v0.1.0` tag (which now carries the complete, live 0.1.0 schema set)
- `index.json`: `versions: [0.1.0, 1.0.0]`; aliases `v0->0.1.0`, `v1->1.0.0`, `latest->1.0.0`
- VERSIONING.md documents per-tag snapshots
- Canonical `$id` unchanged