### PR TITLE
SHA-pin validate.yml actions (unblock the schema/OKF validation gate)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,10 +35,10 @@ jobs:
     name: OKF Conformance + Lossless Round-Trip
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -63,10 +63,10 @@ jobs:
     name: Validate JSON-LD Projection Against Schema
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -74,7 +74,7 @@ jobs:
         run: pip install pyyaml
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -104,10 +104,10 @@ jobs:
     name: Build Docs Site (Astro)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 
@@ -121,15 +121,15 @@ jobs:
     name: Validate Ontology Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 'lts/*'
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,19 +15,11 @@ name: Validate MIF Bundles and Schemas
       - 'src/content/docs/**'
       - 'package.json'
       - 'astro.config.mjs'
+    # No path filter on PRs: this is a required branch-protection gate, so it
+    # must run on every PR (a path-filtered required check that doesn't run
+    # would block merges indefinitely).
   pull_request:
     branches: [main, "release/**", "develop/**"]
-    paths:
-      - 'schema/**'
-      - 'examples/**'
-      - 'profiles/**'
-      - 'ontologies/**'
-      - 'scripts/*.py'
-      - 'test/**'
-      - 'docs/**'
-      - 'src/content/docs/**'
-      - 'package.json'
-      - 'astro.config.mjs'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
validate.yml used tag-pinned actions (@v6) which startup-fail under the org SHA-pinning requirement. Pinned checkout->v7.0.0, setup-python->v6.3.0, setup-node->v6.4.0 (full SHAs). Unblocks the schema/OKF/round-trip validation so it can be a required branch-protection check.