### PR TITLE
Proposal: Container Profile (corpus envelope) — spec §, example [draft]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Modeled Information Format**, the opinionated, OKF-compliant content model that
 fills OKF's deliberately empty envelope. AI memory becomes the first domain
 *profile* of MIF, not its identity.
 
+### Added (proposed)
+
+- **[Container Profile]**: corpus envelope (`*.corpus.json`) wrapping many MIF
+  memory units + source `document` records for transport (issue #77). Editorial
+  spec section + `examples/container-profile.corpus.json`. Reference converters
+  (Mem0, Letta, Cognee, Graphiti, MemPalace) ship separately. PROPOSED — pending
+  v1.0.0 incorporation.
+
 ### Breaking Changes
 
 - **[Format]**: Concept files use the `.md` extension only — the `.memory.md`

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -2173,6 +2173,63 @@ citations:
 
 ---
 
+## Container Profile (Corpus Envelope) — PROPOSED
+
+> **Status:** Proposed addition (see issue #77, "Adopt the MPF Corpus Envelope
+> as a MIF Container Profile"). Placement is editorial — slotted here for the
+> v1.0.0 review; promote/renumber into the body as fits the cut.
+
+The preceding sections define a single **memory unit**. Many tools need to move a
+*corpus* — many memories plus the source documents they derive from — as one
+artifact, with corpus-level metadata the unit does not carry. The **Container
+Profile** is a transport envelope *around* MIF memory units. It does not change
+the unit.
+
+### Envelope
+
+A container is a JSON object (file extension `.corpus.json`):
+
+```json
+{
+  "@context": "https://mif-spec.dev/schema/context.jsonld",
+  "@type": "MemoryCorpus",
+  "mif_version": "0.1.0",
+  "records": [ ],
+  "provenance": { },
+  "edit_chain": [ ]
+}
+```
+
+### Records
+
+Each `records[]` entry carries a `kind` discriminator:
+
+| `kind` | payload |
+|---|---|
+| `memory` | a MIF **memory unit**, validated against the MIF schema; conformance levels apply per record |
+| `document` | a source document (e.g. an unmodified DoclingDocument) the memories derive from, so provenance resolves within the corpus |
+
+`fact` and `event` are **not** separate kinds — they are MIF memories whose
+proposed `memoryCategory` term is `Fact` or `Event`. This avoids a parallel
+schema.
+
+### Corpus-level fields
+
+| field | meaning |
+|---|---|
+| `provenance` | W3C-PROV provenance for the corpus as a whole |
+| `edit_chain` / record `supersedes` | supersession / version history across records |
+| `compression_manifest` | (Level 3) which records are compressed summaries of which sources |
+| `federation_cursor` | cursor for incremental / federated corpus transfer |
+
+### Conformance
+
+The Container Profile is **orthogonal to conformance levels**: a container may
+hold Level-1 and Level-3 memories together. A container is valid when every
+`memory` record is a valid MIF memory and every `document` record is a recognized
+document type. Reference converters (Mem0, Letta, Cognee, Graphiti, MemPalace) and
+a validator are provided separately — see issue #77.
+
 ## Changelog
 
 ### 0.1.0-draft (2026-01-26)

--- a/examples/container-profile.corpus.json
+++ b/examples/container-profile.corpus.json
@@ -1,0 +1,42 @@
+{
+  "@context": "https://mif-spec.dev/schema/context.jsonld",
+  "@type": "MemoryCorpus",
+  "mif_version": "0.1.0",
+  "records": [
+    {
+      "kind": "document",
+      "payload": {
+        "schema_name": "DoclingDocument",
+        "version": "1.0.0",
+        "name": "ncp-requirements.pdf",
+        "texts": [{"text": "NCP GB300 NVL72 platform requirements.", "label": "text"}]
+      }
+    },
+    {
+      "kind": "memory",
+      "payload": {
+        "@context": "https://mif-spec.dev/schema/context.jsonld",
+        "@type": "Memory",
+        "@id": "urn:mif:11111111-1111-4111-8111-111111111111",
+        "memoryType": "semantic",
+        "namespace": "_semantic/requirements",
+        "content": "GB300 NVL72 compute nodes MUST meet NVQual and NVCert.",
+        "created": "2026-06-25T00:00:00Z"
+      }
+    },
+    {
+      "kind": "memory",
+      "memoryCategory": "Fact",
+      "payload": {
+        "@context": "https://mif-spec.dev/schema/context.jsonld",
+        "@type": "Memory",
+        "@id": "urn:mif:22222222-2222-4222-8222-222222222222",
+        "memoryType": "semantic",
+        "namespace": "_semantic/requirements",
+        "content": "Intra-NVL72 NCCL all-reduce baseline on GB200 is 900 GB/s+.",
+        "created": "2026-06-25T00:00:00Z"
+      }
+    }
+  ],
+  "provenance": { "@type": "prov:Entity", "prov:wasDerivedFrom": "ncp-requirements.pdf" }
+}


### PR DESCRIPTION
Draft spec PR for issue #77 — adds a **Container Profile** section: a transport envelope *around* MIF memory units, so a whole corpus (many memories + the source documents they derive from) moves as one artifact.

- `records[]` with `kind`: **memory** (a MIF memory unit, validated, levels apply) | **document** (e.g. an unmodified DoclingDocument).
- `fact`/`event` fold into MIF memories via a proposed `memoryCategory` term — **no parallel schema**.
- Corpus-level fields the unit doesn't carry: `provenance` (W3C-PROV), `edit_chain`/`supersedes`, `compression_manifest`, `federation_cursor`.
- Orthogonal to conformance levels. Adds `examples/container-profile.corpus.json` + CHANGELOG.

**Draft** — section number is editorial, and this is yours to shape/merge. The reference converters (mem0, letta, cognee, graphiti, mempalace) + docling import + validator are staged at perlowja/mif-converters (happy to transfer into the org — I'm a member but can't create public repos there; you'd need to accept the transfer). Closes nothing yet; pairs with #77.