### PR TITLE
docs(changelog): backfill Unreleased section for post-1.0.0 work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,50 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Work landed on `develop/v1.0.0` since the 1.0.0 release.
-
-### Added
-
-- **[Tooling]**: `scripts/okf_validate.py` gains a temporal-consistency check — a
-  `derived-from` / `supersedes` / `cites` target must not be `created` after the
-  concept that derives from it. Warns by default; `--strict-temporal` promotes it
-  to a failing check once a corpus is known clean. (#79)
-- **[Schema]**: first-class scalar `properties` field (string / number / boolean /
-  null) for literal-object knowledge-graph triples that have no concept `target`.
-  Additive and backward compatible. (#79)
-- **[Schema]**: additive versioned schema mirrors under `public/schema/` —
-  `1.0.0/` (immutable), `latest/`, major alias `v1/`, plus `index.json` (catalog)
-  and `VERSIONING.md`. Canonical `$id` values are unchanged (ADR-007). (#72)
-- **[Schema]**: immutable `0.1.0/` schema mirror and `v0/` alias snapshotted from
-  the v0.1.0 tag; `index.json` extended (`v0` → 0.1.0, `v1` → 1.0.0). (#73)
-- **[CI]**: `schema-check.yml` — meta-validates every schema set as JSON Schema
-  2020-12, parses all JSON-LD contexts, and verifies mirror alias consistency
-  (`latest` == canonical, `v1` == 1.0.0, `v0` == 0.1.0) as a required gate. (#75)
-- **[Brand]**: `mif-brand` applied to the spec site — chevron-M logos, two-accent
-  brand CSS, favicon. (#72)
-
-### Changed
-
-- **[Docs]**: ecosystem docs rehomed from the spec site to `doc-site`; the
-  Starlight spec site is trimmed to spec-only content (sidebar and index). (#72)
-- **[CI]**: `validate.yml` actions are SHA-pinned (org policy) and the workflow
-  runs on all pull requests (PR path filter removed) so it can serve as a required
-  gate. (#74)
-
-### Fixed
-
-- **[Tooling]**: `scripts/mif_convert.py` restores `compressedAt` and `memoryType`
-  to the round-trip passthrough; both were silently dropped on
-  `markdown → json-ld → markdown`, breaking the lossless invariant. A regression
-  test now enumerates every top-level schema field so a dropped field fails CI. (#79)
-- **[Tooling]**: the temporal check skips targets that resolve outside the bundle
-  (no out-of-bundle reads) and no longer crashes on a malformed-YAML target. (#79)
-
-## [1.0.0] - 2026-06-18
-
-Major, breaking release. Repositions MIF as **MIF — Modeled Information Format**,
-the opinionated, OKF-compliant content model that fills OKF's deliberately empty
-envelope. AI memory becomes the first domain *profile* of MIF, not its identity.
+The in-progress 1.0.0 release. Major, breaking. Repositions MIF as **MIF —
+Modeled Information Format**, the opinionated, OKF-compliant content model that
+fills OKF's deliberately empty envelope. AI memory becomes the first domain
+*profile* of MIF, not its identity.
 
 ### Breaking Changes
 
@@ -94,6 +54,23 @@ envelope. AI memory becomes the first domain *profile* of MIF, not its identity.
 - **[Docs]**: `MIGRATION.md` upgrade guide (`0.1.0-draft → 1.0.0`).
 - **[CI]**: `validate.yml` runs the OKF conformance + lossless round-trip tests
   and validates the JSON-LD projection against the schema.
+- **[Tooling]**: `scripts/okf_validate.py` gains a temporal-consistency check — a
+  `derived-from` / `supersedes` / `cites` target must not be `created` after the
+  concept that derives from it. Warns by default; `--strict-temporal` promotes it
+  to a failing check once a corpus is known clean. (#79)
+- **[Schema]**: first-class scalar `properties` field (string / number / boolean /
+  null) for literal-object knowledge-graph triples that have no concept `target`.
+  Additive and backward compatible. (#79)
+- **[Schema]**: additive versioned schema mirrors under `public/schema/` —
+  `1.0.0/` (immutable), `latest/`, major alias `v1/`, plus `index.json` (catalog)
+  and `VERSIONING.md`. Canonical `$id` values are unchanged (ADR-007). (#72)
+- **[Schema]**: immutable `0.1.0/` schema mirror and `v0/` alias snapshotted from
+  the v0.1.0 tag; `index.json` extended (`v0` → 0.1.0, `v1` → 1.0.0). (#73)
+- **[CI]**: `schema-check.yml` — meta-validates every schema set as JSON Schema
+  2020-12, parses all JSON-LD contexts, and verifies mirror alias consistency
+  (`latest` == canonical, `v1` == 1.0.0, `v0` == 0.1.0) as a required gate. (#75)
+- **[Brand]**: `mif-brand` applied to the spec site — chevron-M logos, two-accent
+  brand CSS, favicon. (#72)
 
 ### Changed
 
@@ -101,203 +78,30 @@ envelope. AI memory becomes the first domain *profile* of MIF, not its identity.
   (declarative / time-bound / how-to); memory-only framing removed.
 - **[Examples]**: Core `examples/` regenerated as a generalized (non-memory)
   bundle; memory examples relocated to `profiles/ai-memory/examples/`.
+- **[Docs]**: ecosystem docs rehomed from the spec site to `doc-site`; the
+  Starlight spec site is trimmed to spec-only content (sidebar and index). (#72)
+- **[CI]**: `validate.yml` actions are SHA-pinned (org policy) and the workflow
+  runs on all pull requests (PR path filter removed) so it can serve as a required
+  gate. (#74)
 
 ### Removed
 
 - **[Tooling]**: `scripts/validate-memories.py` and `scripts/test-conversion.py`
   superseded by `okf_validate.py` + `mif_convert.py`.
 
+### Fixed
+
+- **[Tooling]**: `scripts/mif_convert.py` restores `compressedAt` and `memoryType`
+  to the round-trip passthrough; both were silently dropped on
+  `markdown → json-ld → markdown`, breaking the lossless invariant. A regression
+  test now enumerates every top-level schema field so a dropped field fails CI. (#79)
+- **[Tooling]**: the temporal check skips targets that resolve outside the bundle
+  (no out-of-bundle reads) and no longer crashes on a malformed-YAML target. (#79)
+
 ### Migration
 
 See [MIGRATION.md](MIGRATION.md) and run
 `python scripts/migrate_0_1_to_1_0.py <old> <new>`.
-
-## [Unreleased]
-
-### Added
-
-- **[Schema]**: Entity-type subsumption — optional `subtype_of` field on entity types
-  - A type may declare `subtype_of: [parent, ...]`; a subtype is substitutable for any
-    of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint
-    domain). Optional and additive — existing ontologies are unaffected.
-  - Projected to JSON-LD as `mif:subtypeOf` (`scripts/yaml2jsonld.py`,
-    `ontology.context.jsonld`).
-  - `scripts/validate-ontologies.py` enforces integrity across the whole ontology
-    corpus: every parent resolves to a declared type (in the ontology or one it
-    `extends`, resolved over the full chain), a subtype's `required` set includes each
-    parent's (substitutability), no self-reference, acyclic graph. Covered by
-    `scripts/test_subtype_of.py` (+ `test/subtype_of/` fixtures, run in CI). Demonstrated
-    by `software-engineering` `security-incident` `subtype_of: [incident-report]`.
-  - `scripts/validate-ontologies.py` now validates schema conformance with **ajv**
-    (draft2020, matching the JSON-LD validation job) instead of Python `jsonschema`.
-
-- **[Schema]**: EntityData field for ontology-typed memories
-  - New `entity` property with `name` (required), `entity_type`, and `entity_id` fields
-  - Supports additional properties defined by ontology entity_type schemas
-  - Links structured data to ontology definitions
-
-- **[Schema]**: Block references field
-  - New `blocks` object for named block references (`^block-id`)
-  - Maps block identifiers to their text content for granular linking
-
-- **[Schema]**: Shared EntityReference definition
-  - Extracted to `schema/definitions/entity-reference.schema.json`
-  - Reused by both MIF schema and Citation schema
-  - Prevents definition divergence across schemas
-
-- **[Schema]**: Ontology `extends` field for inheritance
-  - Ontologies can declare parent ontologies to inherit from
-  - Enables trait inheritance model: `mif-base → shared-traits → domain`
-  - Added to ontology.schema.json and all domain ontologies
-
-- **[Project]**: VERSION.json for centralized version constants
-  - Specification version, schema versions, ontology versions
-  - Single source of truth for all version numbers
-
-### Changed
-
-- **[Schema]**: Standardized schema identifiers to `https://mif-spec.dev/schema/` namespace
-  - Updated ontology.schema.json `$id`
-  - Updated all domain ontology `schema_url` fields
-  - Note: These are identifiers, not resolvable URLs
-
-- **[Schema]**: Discovery patterns structure updated
-  - Split single `patterns[]` into `content_patterns[]` and `file_patterns[]`
-  - Each pattern type has specialized fields for its use case
-  - Aligns schema with actual mif-base ontology usage
-
-- **[Examples]**: Updated JSON-LD context property names
-  - Changed `dc:created` to `created`, `dc:modified` to `modified`
-  - Consistent with unprefixed field names in specification
-
-- **[Examples]**: Clarified Level 1 conformance requirements
-  - `namespace` is recommended but optional at Level 1
-  - Level 1 only requires: `id`, `type`, `created`, and content body
-
-### Fixed
-
-- **[Examples]**: Fixed ontology reference format in example memories
-  - Changed from incorrect `ontology.entity_type` to proper `ontology.id` + `entity` block
-  - Updated 6 example memory files across agriculture, publishing, biology-lab directories
-
-- **[Documentation]**: Added trait inheritance documentation to ontologies/README.md
-  - Documents the three-tier trait system
-  - Explains how domain ontologies inherit from shared-traits
-
-- **[Documentation]**: Added decay model rationale (Section 9.3)
-  - Explains P7D/P14D/P30D half-life values as pragmatic defaults
-  - Documents scientific background from Ebbinghaus forgetting curve
-  - Cites Murre & Dros (2015), Squire & Bayley (2007), Wickelgren (1972)
-  - Provides guidance for tuning values per memory type
-
-### Changed
-
-- **[Schema]**: Memory types now use three base types
-  - Replaced ad-hoc types (`memory`, `decision`, `preference`, `fact`, `episode`, `pattern`, `learning`, `context`)
-  - New base types: `semantic` (facts/knowledge), `episodic` (events/experiences), `procedural` (processes/how-to)
-  - Specific categorization expressed through namespace hierarchy (e.g., `_semantic/decisions`, `_episodic/incidents`)
-  - Ontologies can extend types via entity_types with `base` field
-  - **BREAKING**: Existing memories using old type values need migration
-
-### Added
-
-- **[Schema]**: OntologyReference field in MIF schema
-  - New `ontology` property for declaring which ontology a memory applies
-  - Fields: `id` (required), `version` (optional), `uri` (optional)
-  - Enables validation that memories conform to declared ontology
-  - Links MIF documents to ontology definitions
-
-- **[Ontology]**: Industry-specific ontology examples
-  - `regenerative-agriculture.ontology.yaml` - Farm operations, carbon credits, certifications
-  - `k12-educational-publishing.ontology.yaml` - K-12 curriculum, state adoptions
-  - `biology-research-lab.ontology.yaml` - Academic research, grants, compliance
-  - `backstage.ontology.yaml` - Developer portal entity catalog
-  - `shared-traits.ontology.yaml` - Reusable trait mixins
-
-- **[Backstage]**: Backstage.io catalog integration examples
-  - Example catalog-info.yaml files for each industry ontology
-  - MIF-to-Backstage entity mapping via annotations
-
-- **[Ontology]**: Three-type namespace hierarchy
-  - Base ontology with semantic/episodic/procedural top-level namespaces
-  - Nine sub-namespaces: decisions, knowledge, entities, incidents, sessions, blockers, runbooks, patterns, migrations
-  - Entity type definitions with traits and schemas
-  - Relationship types with cardinality constraints
-  - Discovery patterns for content and file-based detection
-
-- **[Ontology]**: JSON-LD semantic web support
-  - `ontology.context.jsonld` for semantic vocabulary mapping
-  - `yaml2jsonld.py` converter script
-  - Alignment with Schema.org and SKOS vocabularies
-
-- **[Schema]**: Ontology validation schema
-  - `schema/ontology/ontology.schema.json` for YAML validation
-  - Supports hierarchical namespace children
-  - Entity type and relationship validation
-
-- **[Specification]**: Initial MIF (Memory Interchange Format) specification
-  - JSON-LD based format for AI memory interoperability
-  - Bi-temporal model with valid time and transaction time
-  - W3C PROV-compliant provenance tracking
-  - Conformance levels (Core, Extended, Full)
-  - Human-readable Markdown export support
-
-- **[Specification]**: Citations structure (Level 3 optional feature)
-  - Structured citation references with type/role taxonomy
-  - Required fields: type, title, url, role
-  - Optional fields: author, date, accessed, relevance, note
-  - Entity references in author field using wiki-link syntax
-  - Citation types: article, book, paper, website, documentation, repository, video, podcast, specification, dataset, tool
-  - Citation roles: supports, refutes, background, methodology, contradicts, extends, derived, source, example, review
-  - Frontmatter YAML schema and body section Markdown syntax
-  - JSON-LD vocabulary with Schema.org alignment
-  - Validation rules (Section 5.5.7) with field constraints and error handling
-  - Appendix D: Citations Quick Reference
-
-- **[Specification]**: Compression fields (Level 3 optional feature)
-  - `summary` - Concise 2-3 sentence summary (max 500 characters)
-  - `compressed_at` - Timestamp when compression was applied
-  - Compression criteria: Age > 30 days AND lines > 100, OR Strength < 0.3 AND lines > 100
-
-- **[Schema]**: JSON Schema for automated validation
-  - `schema/mif.schema.json` - Complete MIF document validation
-  - `schema/citation.schema.json` - Standalone citation object validation
-  - Draft 2020-12 compliant schemas with comprehensive type definitions
-
-- **[Examples]**: Reference MIF document examples
-  - Basic memory interchange examples
-  - Entity and relationship examples
-  - Temporal metadata examples
-  - Level 3 citations example (level-3-citations.memory.md/.json)
-
-### Changed
-
-- **[README]**: Updated to reflect new features
-  - Added Citations and JSON Schema to Key Features table
-  - Added Validation section with schema usage examples
-  - Updated Level 3 conformance to include citations and compression
-  - Updated examples description
-
-- **[CONTRIBUTING]**: Added JSON Schema validation guidance
-
-### Documentation
-
-- **[Research]**: Comprehensive market research report
-  - Competitive landscape analysis (Mem0, Zep, Letta, LangMem, Cognee, Graphlit)
-  - Standards alignment review (JSON-LD, RDF/OWL, ONNX, PROV)
-  - Enterprise requirements assessment (EU AI Act, GDPR, NIST AI RMF)
-  - Adoption strategy recommendations
-
-- **[Research]**: Executive brief for decision support
-  - Market opportunity summary ($2.1B SAM)
-  - Competitive positioning analysis
-  - Prioritized action items
-
-- **[Research]**: Trend models and forecasting
-  - Market growth projections (2024-2030)
-  - Technology adoption S-curve
-  - Scenario analysis (standard adoption vs fragmentation)
-  - Regulatory impact timeline (EU AI Act milestones)
 
 ## [0.1.0] - 2026-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Work landed on `develop/v1.0.0` since the 1.0.0 release.
+
+### Added
+
+- **[Tooling]**: `scripts/okf_validate.py` gains a temporal-consistency check — a
+  `derived-from` / `supersedes` / `cites` target must not be `created` after the
+  concept that derives from it. Warns by default; `--strict-temporal` promotes it
+  to a failing check once a corpus is known clean. (#79)
+- **[Schema]**: first-class scalar `properties` field (string / number / boolean /
+  null) for literal-object knowledge-graph triples that have no concept `target`.
+  Additive and backward compatible. (#79)
+- **[Schema]**: additive versioned schema mirrors under `public/schema/` —
+  `1.0.0/` (immutable), `latest/`, major alias `v1/`, plus `index.json` (catalog)
+  and `VERSIONING.md`. Canonical `$id` values are unchanged (ADR-007). (#72)
+- **[Schema]**: immutable `0.1.0/` schema mirror and `v0/` alias snapshotted from
+  the v0.1.0 tag; `index.json` extended (`v0` → 0.1.0, `v1` → 1.0.0). (#73)
+- **[CI]**: `schema-check.yml` — meta-validates every schema set as JSON Schema
+  2020-12, parses all JSON-LD contexts, and verifies mirror alias consistency
+  (`latest` == canonical, `v1` == 1.0.0, `v0` == 0.1.0) as a required gate. (#75)
+- **[Brand]**: `mif-brand` applied to the spec site — chevron-M logos, two-accent
+  brand CSS, favicon. (#72)
+
+### Changed
+
+- **[Docs]**: ecosystem docs rehomed from the spec site to `doc-site`; the
+  Starlight spec site is trimmed to spec-only content (sidebar and index). (#72)
+- **[CI]**: `validate.yml` actions are SHA-pinned (org policy) and the workflow
+  runs on all pull requests (PR path filter removed) so it can serve as a required
+  gate. (#74)
+
+### Fixed
+
+- **[Tooling]**: `scripts/mif_convert.py` restores `compressedAt` and `memoryType`
+  to the round-trip passthrough; both were silently dropped on
+  `markdown → json-ld → markdown`, breaking the lossless invariant. A regression
+  test now enumerates every top-level schema field so a dropped field fails CI. (#79)
+- **[Tooling]**: the temporal check skips targets that resolve outside the bundle
+  (no out-of-bundle reads) and no longer crashes on a malformed-YAML target. (#79)
+
 ## [1.0.0] - 2026-06-18
 
 Major, breaking release. Repositions MIF as **MIF — Modeled Information Format**,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ fills OKF's deliberately empty envelope. AI memory becomes the first domain
 - **[Schema]**: `schema/mif.schema.json` v1.0 — `@type: Concept`, `conceptType`
   replaces required `memoryType` (kept as a deprecated alias), and the
   `Relationship` shape is `{ type, target }`.
+- **[Schema]**: Memory types now use three base types — replaced ad-hoc types
+  (`memory`, `decision`, `preference`, `fact`, `episode`, `pattern`, `learning`,
+  `context`) with `semantic` (facts/knowledge), `episodic` (events/experiences),
+  and `procedural` (processes/how-to). Specific categorization is expressed
+  through the namespace hierarchy (e.g. `_semantic/decisions`,
+  `_episodic/incidents`); ontologies can extend types via `entity_types` with a
+  `base` field. **Existing memories using old type values need migration.**
 - **[Temporal]**: The bi-temporal/decay model is reframed as **validity windows
   & freshness** (answering OKF's open live-vs-stale question). The math is
   unchanged; the forgetting-curve/Ebbinghaus rationale moves to the AI Memory
@@ -50,22 +57,99 @@ fills OKF's deliberately empty envelope. AI memory becomes the first domain
 - **[Tooling]**: `scripts/okf_validate.py` (conformance + relationship sync +
   round-trip), `scripts/mif_convert.py` (markdown↔json-ld), and
   `scripts/migrate_0_1_to_1_0.py` (0.1→1.0 transform).
-- **[Profile]**: `profiles/ai-memory/` — profile spec, ontology, and examples.
-- **[Docs]**: `MIGRATION.md` upgrade guide (`0.1.0-draft → 1.0.0`).
-- **[CI]**: `validate.yml` runs the OKF conformance + lossless round-trip tests
-  and validates the JSON-LD projection against the schema.
-- **[Tooling]**: `scripts/okf_validate.py` gains a temporal-consistency check — a
+- **[Tooling]**: `scripts/okf_validate.py` temporal-consistency check — a
   `derived-from` / `supersedes` / `cites` target must not be `created` after the
   concept that derives from it. Warns by default; `--strict-temporal` promotes it
   to a failing check once a corpus is known clean. (#79)
 - **[Schema]**: first-class scalar `properties` field (string / number / boolean /
   null) for literal-object knowledge-graph triples that have no concept `target`.
   Additive and backward compatible. (#79)
+- **[Schema]**: Entity-type subsumption — optional `subtype_of` field on entity types.
+  - A type may declare `subtype_of: [parent, ...]`; a subtype is substitutable for any
+    of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint
+    domain). Optional and additive — existing ontologies are unaffected.
+  - Projected to JSON-LD as `mif:subtypeOf` (`scripts/yaml2jsonld.py`,
+    `ontology.context.jsonld`).
+  - `scripts/validate-ontologies.py` enforces integrity across the whole ontology
+    corpus: every parent resolves to a declared type (in the ontology or one it
+    `extends`, resolved over the full chain), a subtype's `required` set includes each
+    parent's (substitutability), no self-reference, acyclic graph. Covered by
+    `scripts/test_subtype_of.py` (+ `test/subtype_of/` fixtures, run in CI). Demonstrated
+    by `software-engineering` `security-incident` `subtype_of: [incident-report]`.
+  - `scripts/validate-ontologies.py` now validates schema conformance with **ajv**
+    (draft2020, matching the JSON-LD validation job) instead of Python `jsonschema`.
+- **[Schema]**: EntityData field for ontology-typed memories.
+  - New `entity` property with `name` (required), `entity_type`, and `entity_id` fields.
+  - Supports additional properties defined by ontology entity_type schemas.
+  - Links structured data to ontology definitions.
+- **[Schema]**: Block references field.
+  - New `blocks` object for named block references (`^block-id`).
+  - Maps block identifiers to their text content for granular linking.
+- **[Schema]**: Shared EntityReference definition.
+  - Extracted to `schema/definitions/entity-reference.schema.json`.
+  - Reused by both MIF schema and Citation schema; prevents definition divergence.
+- **[Schema]**: Ontology `extends` field for inheritance.
+  - Ontologies can declare parent ontologies to inherit from.
+  - Enables the trait inheritance model: `mif-base → shared-traits → domain`.
+  - Added to `ontology.schema.json` and all domain ontologies.
+- **[Schema]**: OntologyReference field in MIF schema.
+  - New `ontology` property declaring which ontology a memory applies.
+  - Fields: `id` (required), `version` (optional), `uri` (optional).
+  - Enables validation that memories conform to their declared ontology.
+- **[Schema]**: Ontology validation schema.
+  - `schema/ontology/ontology.schema.json` for YAML validation.
+  - Supports hierarchical namespace children; entity-type and relationship validation.
+- **[Schema]**: JSON Schema for automated validation.
+  - `schema/mif.schema.json` — complete MIF document validation.
+  - `schema/citation.schema.json` — standalone citation object validation.
+  - Draft 2020-12 compliant schemas with comprehensive type definitions.
 - **[Schema]**: additive versioned schema mirrors under `public/schema/` —
   `1.0.0/` (immutable), `latest/`, major alias `v1/`, plus `index.json` (catalog)
   and `VERSIONING.md`. Canonical `$id` values are unchanged (ADR-007). (#72)
 - **[Schema]**: immutable `0.1.0/` schema mirror and `v0/` alias snapshotted from
   the v0.1.0 tag; `index.json` extended (`v0` → 0.1.0, `v1` → 1.0.0). (#73)
+- **[Project]**: `VERSION.json` for centralized version constants (specification,
+  schema, and ontology versions) — single source of truth for all version numbers.
+- **[Profile]**: `profiles/ai-memory/` — profile spec, ontology, and examples.
+- **[Ontology]**: Industry-specific ontology examples.
+  - `regenerative-agriculture.ontology.yaml` — farm operations, carbon credits, certifications.
+  - `k12-educational-publishing.ontology.yaml` — K-12 curriculum, state adoptions.
+  - `biology-research-lab.ontology.yaml` — academic research, grants, compliance.
+  - `backstage.ontology.yaml` — developer portal entity catalog.
+  - `shared-traits.ontology.yaml` — reusable trait mixins.
+- **[Ontology]**: Three-type namespace hierarchy.
+  - Base ontology with semantic/episodic/procedural top-level namespaces.
+  - Nine sub-namespaces: decisions, knowledge, entities, incidents, sessions, blockers, runbooks, patterns, migrations.
+  - Entity type definitions with traits and schemas; relationship types with cardinality constraints; discovery patterns for content- and file-based detection.
+- **[Ontology]**: JSON-LD semantic web support.
+  - `ontology.context.jsonld` for semantic vocabulary mapping; `yaml2jsonld.py` converter.
+  - Alignment with Schema.org and SKOS vocabularies.
+- **[Backstage]**: Backstage.io catalog integration examples.
+  - Example `catalog-info.yaml` files for each industry ontology.
+  - MIF-to-Backstage entity mapping via annotations.
+- **[Specification]**: Initial MIF specification.
+  - JSON-LD based format for AI memory interoperability.
+  - Bi-temporal model with valid time and transaction time.
+  - W3C PROV-compliant provenance tracking; conformance levels (Core, Extended, Full).
+  - Human-readable Markdown export support.
+- **[Specification]**: Citations structure (Level 3 optional feature).
+  - Structured citation references with type/role taxonomy.
+  - Required fields: type, title, url, role. Optional: author, date, accessed, relevance, note.
+  - Entity references in the author field using wiki-link syntax.
+  - Citation types: article, book, paper, website, documentation, repository, video, podcast, specification, dataset, tool.
+  - Citation roles: supports, refutes, background, methodology, contradicts, extends, derived, source, example, review.
+  - Frontmatter YAML schema and body-section Markdown syntax; JSON-LD vocabulary with Schema.org alignment.
+  - Validation rules (Section 5.5.7) with field constraints and error handling; Appendix D quick reference.
+- **[Specification]**: Compression fields (Level 3 optional feature).
+  - `summary` — concise 2-3 sentence summary (max 500 characters).
+  - `compressed_at` — timestamp when compression was applied.
+  - Compression criteria: Age > 30 days AND lines > 100, OR Strength < 0.3 AND lines > 100.
+- **[Examples]**: Reference MIF document examples.
+  - Basic memory interchange examples; entity and relationship examples; temporal metadata examples.
+  - Level 3 citations example (`level-3-citations.memory.md/.json`).
+- **[Docs]**: `MIGRATION.md` upgrade guide (`0.1.0-draft → 1.0.0`).
+- **[CI]**: `validate.yml` runs the OKF conformance + lossless round-trip tests
+  and validates the JSON-LD projection against the schema.
 - **[CI]**: `schema-check.yml` — meta-validates every schema set as JSON Schema
   2020-12, parses all JSON-LD contexts, and verifies mirror alias consistency
   (`latest` == canonical, `v1` == 1.0.0, `v0` == 0.1.0) as a required gate. (#75)
@@ -76,13 +160,27 @@ fills OKF's deliberately empty envelope. AI memory becomes the first domain
 
 - **[Ontology]**: Base ontology re-motivated as a general knowledge taxonomy
   (declarative / time-bound / how-to); memory-only framing removed.
+- **[Schema]**: Standardized schema identifiers to the
+  `https://mif-spec.dev/schema/` namespace — updated `ontology.schema.json` `$id`
+  and all domain ontology `schema_url` fields (identifiers, not resolvable URLs).
+- **[Schema]**: Discovery patterns structure updated — split a single `patterns[]`
+  into `content_patterns[]` and `file_patterns[]`, each with specialized fields;
+  aligns the schema with actual mif-base ontology usage.
 - **[Examples]**: Core `examples/` regenerated as a generalized (non-memory)
   bundle; memory examples relocated to `profiles/ai-memory/examples/`.
+- **[Examples]**: Updated JSON-LD context property names — `dc:created` → `created`,
+  `dc:modified` → `modified`, consistent with unprefixed field names.
+- **[Examples]**: Clarified Level 1 conformance — `namespace` is recommended but
+  optional; Level 1 requires only `id`, `type`, `created`, and a content body.
 - **[Docs]**: ecosystem docs rehomed from the spec site to `doc-site`; the
   Starlight spec site is trimmed to spec-only content (sidebar and index). (#72)
 - **[CI]**: `validate.yml` actions are SHA-pinned (org policy) and the workflow
   runs on all pull requests (PR path filter removed) so it can serve as a required
   gate. (#74)
+- **[README]**: Updated to reflect new features — Citations and JSON Schema in the
+  Key Features table, a Validation section with schema usage, Level 3 conformance
+  updated for citations and compression.
+- **[CONTRIBUTING]**: Added JSON Schema validation guidance.
 
 ### Removed
 
@@ -97,6 +195,26 @@ fills OKF's deliberately empty envelope. AI memory becomes the first domain
   test now enumerates every top-level schema field so a dropped field fails CI. (#79)
 - **[Tooling]**: the temporal check skips targets that resolve outside the bundle
   (no out-of-bundle reads) and no longer crashes on a malformed-YAML target. (#79)
+- **[Examples]**: Fixed ontology reference format in example memories — changed from
+  incorrect `ontology.entity_type` to proper `ontology.id` + `entity` block across
+  6 example memory files (agriculture, publishing, biology-lab).
+
+### Documentation
+
+- **[Documentation]**: Added trait inheritance documentation to
+  `ontologies/README.md` — documents the three-tier trait system and how domain
+  ontologies inherit from shared-traits.
+- **[Documentation]**: Added decay model rationale (Section 9.3) — explains
+  P7D/P14D/P30D half-life defaults, the Ebbinghaus forgetting-curve background
+  (Murre & Dros 2015, Squire & Bayley 2007, Wickelgren 1972), and per-type tuning.
+- **[Research]**: Comprehensive market research report — competitive landscape
+  (Mem0, Zep, Letta, LangMem, Cognee, Graphlit), standards alignment (JSON-LD,
+  RDF/OWL, ONNX, PROV), enterprise requirements (EU AI Act, GDPR, NIST AI RMF),
+  adoption strategy.
+- **[Research]**: Executive brief — market opportunity ($2.1B SAM), competitive
+  positioning, prioritized action items.
+- **[Research]**: Trend models and forecasting — growth projections (2024-2030),
+  technology adoption S-curve, scenario analysis, regulatory impact timeline.
 
 ### Migration
 


### PR DESCRIPTION
## Summary
Backfills `CHANGELOG.md` with a `## [Unreleased]` section. The branch had no Unreleased section, so none of the post-1.0.0 `develop/v1.0.0` work was changelogged.

## Changes
Documents work already merged into `develop/v1.0.0`:
- **#72** — versioned schema mirrors (`1.0.0`/`latest`/`v1`), brand applied to spec site, ecosystem docs rehomed to doc-site
- **#73** — immutable `0.1.0` schema mirror + `v0` alias
- **#74** — `validate.yml` SHA-pinned + runs on all PRs
- **#75** — `schema-check.yml` required gate
- **#79** — temporal-consistency check, first-class scalar `properties` field, and `compressedAt`/`memoryType` lossless fixes

## Test Plan
Documentation only — no code or schema changes. `CHANGELOG.md` is the sole modified file.