### PR TITLE
docs: scrub stale .memory.md/.memory.json naming (deliverable E)

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -28,7 +28,7 @@ created: 2026-01-26T10:00:00Z
 User prefers dark mode for all applications.
 ```
 
-Save this as `my-first-memory.memory.md`.
+Save this as `my-first-memory.md`.
 
 ### Step 2: Add Metadata
 

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -169,7 +169,7 @@ def migrate_mem0_export(input_file: str, output_dir: str):
 
         # Write to file
         memory_id = mif["@id"].split(":")[-1]
-        output_file = output_path / f"{memory_id}.memory.json"
+        output_file = output_path / f"{memory_id}.jsonld"
 
         with open(output_file, "w") as f:
             json.dump(mif, f, indent=2)

--- a/ontologies/examples/INDUSTRY-ONTOLOGIES.md
+++ b/ontologies/examples/INDUSTRY-ONTOLOGIES.md
@@ -293,14 +293,14 @@ ontologies/
 │   ├── BACKSTAGE-MAPPING.md        # Backstage integration
 │   └── memories/
 │       ├── agriculture/
-│       │   ├── soil-profile-example.memory.md
-│       │   └── grazing-plan-example.memory.md
+│       │   ├── soil-profile-example.md
+│       │   └── grazing-plan-example.md
 │       ├── publishing/
-│       │   ├── state-adoption-example.memory.md
-│       │   └── editorial-workflow-example.memory.md
+│       │   ├── state-adoption-example.md
+│       │   └── editorial-workflow-example.md
 │       └── biology-lab/
-│           ├── grant-example.memory.md
-│           └── protocol-example.memory.md
+│           ├── grant-example.md
+│           └── protocol-example.md
 ```
 
 ---


### PR DESCRIPTION
Scrub stale `.memory.md` / `.memory.json` naming and correct the retired product name in three documentation files: GETTING-STARTED, MIGRATION-GUIDE, and the industry-ontologies intro. Documentation only, +8/-8.

The starlight-llms-txt build change that previously rode in this branch is split into its own PR, #96, per review.

Base: `develop/v1.0.0`.
