### PR TITLE
ci: harden schema-check mirror diagnostics + align workflows to pin/LTS standard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: withastro/action@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26 # v6
 
   deploy:
     needs: build
@@ -29,4 +29,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -84,10 +84,14 @@ jobs:
             local a="public/schema/$1" s="$2"
             [ -d "$a" ] || { echo "skip $a (absent)"; return; }
             for f in $files; do
-              if [ -f "$s/$f" ] || [ -f "$a/$f" ]; then
-                if ! diff -q "$s/$f" "$a/$f" >/dev/null 2>&1; then
-                  echo "::error::$a/$f does not match $s/$f"; fail=1
-                fi
+              if [ ! -f "$s/$f" ] && [ ! -f "$a/$f" ]; then
+                continue  # neither side ships this file — nothing to mirror
+              elif [ ! -f "$s/$f" ]; then
+                echo "::error::missing mirror source $s/$f (present in $a/$f)"; fail=1
+              elif [ ! -f "$a/$f" ]; then
+                echo "::error::missing mirror file $a/$f (present in $s/$f)"; fail=1
+              elif ! diff -q "$s/$f" "$a/$f" >/dev/null 2>&1; then
+                echo "::error::$a/$f does not match $s/$f"; fail=1
               fi
             done
           }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,12 +23,12 @@ jobs:
     name: Validate JSON Examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: 'lts/*'
 
       - name: Install ajv-cli
         run: npm install -g ajv-cli ajv-formats
@@ -65,10 +65,10 @@ jobs:
     name: Validate Ontology Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
         with:
           python-version: '3.12'
 
@@ -83,10 +83,10 @@ jobs:
     name: Validate Memory Frontmatter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
         with:
           python-version: '3.12'
 
@@ -101,10 +101,10 @@ jobs:
     name: Validate Namespace Consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
         with:
           python-version: '3.12'
 
@@ -119,10 +119,10 @@ jobs:
     name: Test Format Conversion
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Follow-up to the merged #76, addressing both Copilot review comments.

- **schema-check.yml (L91)** — the mirror alias check reported `does not match` even when one side was missing, conflating a missing file with a content mismatch. Now emits a dedicated missing-source / missing-mirror error and skips the pair only when neither side ships the file.
- **validate.yml / deploy.yml (L28)** — the inconsistency Copilot flagged is real, but the fix is to align with the org standard, not unpin schema-check.yml: SHA-pin `actions/checkout`, `actions/setup-node`, `actions/setup-python`, `withastro/action`, `actions/deploy-pages` (enforced by the org `pin-check`), and replace Node 20 (EOL) with `node-version: lts/*`.

actionlint clean on all three.