### PR TITLE
fix(adr-007): restore original raw URLs in the historical Decision block

### DIFF
--- a/adr/ADR-007-github-raw-urls-for-schema-ids.md
+++ b/adr/ADR-007-github-raw-urls-for-schema-ids.md
@@ -36,9 +36,9 @@ JSON Schema requires `$id` values to be URIs. Options considered:
 Use **GitHub raw content URLs** for all schema `$id` values:
 
 ```
-https://mif-spec.dev/schema/mif.schema.json
-https://mif-spec.dev/schema/ontology/ontology.schema.json
-https://mif-spec.dev/schema/context.jsonld
+https://raw.githubusercontent.com/zircote/MIF/main/schema/mif.schema.json
+https://raw.githubusercontent.com/zircote/MIF/main/schema/ontology/ontology.schema.json
+https://raw.githubusercontent.com/zircote/MIF/main/schema/context.jsonld
 ```
 
 ## Consequences


### PR DESCRIPTION
Follow-up to #88. The mechanical `zircote` -> `mif-spec.dev` rewrite modernized the URLs inside ADR-007's original-decision **Decision** block, leaving it self-contradictory ("Use **GitHub raw content URLs**" followed by `mif-spec.dev` URLs). This restores the historical raw URLs in that block; the **Amendment** section already documents the supersession to `mif-spec.dev`, so the record is accurate and internally consistent.