### PR TITLE
fix(ontology): align ontology context IRIs onto mif-spec.dev

### DIFF
--- a/ontologies/examples/backstage.ontology.jsonld
+++ b/ontologies/examples/backstage.ontology.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://github.com/modeled-information-format/MIF/ontology#",
-    "mif": "https://github.com/modeled-information-format/MIF#",
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
     "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/ontologies/examples/biology-research-lab.ontology.jsonld
+++ b/ontologies/examples/biology-research-lab.ontology.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://github.com/modeled-information-format/MIF/ontology#",
-    "mif": "https://github.com/modeled-information-format/MIF#",
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
     "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/ontologies/examples/k12-educational-publishing.ontology.jsonld
+++ b/ontologies/examples/k12-educational-publishing.ontology.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://github.com/modeled-information-format/MIF/ontology#",
-    "mif": "https://github.com/modeled-information-format/MIF#",
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
     "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/ontologies/examples/regenerative-agriculture.ontology.jsonld
+++ b/ontologies/examples/regenerative-agriculture.ontology.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://github.com/modeled-information-format/MIF/ontology#",
-    "mif": "https://github.com/modeled-information-format/MIF#",
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
     "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/ontologies/examples/software-engineering.ontology.jsonld
+++ b/ontologies/examples/software-engineering.ontology.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://github.com/modeled-information-format/MIF/ontology#",
-    "mif": "https://github.com/modeled-information-format/MIF#",
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
     "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/ontologies/mif-base.ontology.jsonld
+++ b/ontologies/mif-base.ontology.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://github.com/modeled-information-format/MIF/ontology#",
-    "mif": "https://github.com/modeled-information-format/MIF#",
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
     "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/ontologies/shared-traits.ontology.jsonld
+++ b/ontologies/shared-traits.ontology.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://github.com/modeled-information-format/MIF/ontology#",
-    "mif": "https://github.com/modeled-information-format/MIF#",
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
     "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/public/schema/ontology/ontology.context.jsonld
+++ b/public/schema/ontology/ontology.context.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://github.com/modeled-information-format/MIF/ontology#",
-    "mif": "https://github.com/modeled-information-format/MIF#",
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
     "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "owl": "http://www.w3.org/2002/07/owl#",

--- a/schema/ontology/ontology.context.jsonld
+++ b/schema/ontology/ontology.context.jsonld
@@ -1,8 +1,8 @@
 {
   "@context": {
     "@version": 1.1,
-    "@vocab": "https://github.com/modeled-information-format/MIF/ontology#",
-    "mif": "https://github.com/modeled-information-format/MIF#",
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
     "schema": "https://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "owl": "http://www.w3.org/2002/07/owl#",


### PR DESCRIPTION
Follow-up to the org retarget (#88/#89). The ontology JSON-LD context expanded `mif:` and `@vocab` to `github.com` URLs while `context.jsonld` used `mif-spec.dev/ns/`, leaving two different `mif:` base IRIs across the shipped contexts (a pre-existing split). Aligns the ontology vocabulary onto the canonical domain:

- `@vocab`: `github.com/.../MIF/ontology#` -> `https://mif-spec.dev/ns/ontology#`
- `mif:`:   `github.com/.../MIF#` -> `https://mif-spec.dev/ns/`

Applied across both `ontology.context.jsonld` mirrors and all 7 ontology `.jsonld` files. Ontology validation passes; mirrors match; changed JSON parses.