### PR TITLE
fix(links): point subcog references back to zircote/subcog

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ This specification is open source. Contributions welcome:
 
 ## Related
 
-- [Subcog](https://github.com/modeled-information-format/subcog) - AI memory system implementing MIF
+- [Subcog](https://github.com/zircote/subcog) - AI memory system implementing MIF
 - [Mnemonic](https://github.com/modeled-information-format/mnemonic) - Claude Code plugin using MIF ontologies
-- [Issue #82](https://github.com/modeled-information-format/subcog/issues/82) - Original proposal
+- [Issue #82](https://github.com/zircote/subcog/issues/82) - Original proposal
 
 ## Citing This Project
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -624,7 +624,7 @@ Implementations MAY apply compression when memories meet these criteria:
     {
       "prov": "http://www.w3.org/ns/prov#",
       "dc": "http://purl.org/dc/terms/",
-      "subcog": "https://github.com/modeled-information-format/subcog/ns/"
+      "subcog": "https://github.com/zircote/subcog/ns/"
     }
   ],
   "@type": ["Memory", "prov:Entity"],

--- a/examples/level-3-citations.memory.json
+++ b/examples/level-3-citations.memory.json
@@ -126,7 +126,7 @@
       "citationType": "specification",
       "citationRole": "source",
       "title": "Memory Interchange Format (MIF) Specification",
-      "url": "https://github.com/modeled-information-format/subcog/blob/main/SPECIFICATION.md",
+      "url": "https://github.com/zircote/subcog/blob/main/SPECIFICATION.md",
       "author": {
         "@type": "EntityReference",
         "entity": { "@id": "urn:mif:entity:person:robert-allen" },
@@ -199,7 +199,7 @@
       "citationType": "repository",
       "citationRole": "extends",
       "title": "Subcog Memory System",
-      "url": "https://github.com/modeled-information-format/subcog",
+      "url": "https://github.com/zircote/subcog",
       "author": {
         "@type": "EntityReference",
         "entity": { "@id": "urn:mif:entity:person:robert-allen" },

--- a/examples/level-3-citations.memory.md
+++ b/examples/level-3-citations.memory.md
@@ -43,7 +43,7 @@ embedding:
 citations:
   - type: specification
     title: "Memory Interchange Format (MIF) Specification"
-    url: https://github.com/modeled-information-format/subcog/blob/main/SPECIFICATION.md
+    url: https://github.com/zircote/subcog/blob/main/SPECIFICATION.md
     role: source
     author: "@[[Robert Allen|Person]]"
     date: 2026-01-23
@@ -80,7 +80,7 @@ citations:
 
   - type: repository
     title: "Subcog Memory System"
-    url: https://github.com/modeled-information-format/subcog
+    url: https://github.com/zircote/subcog
     role: extends
     author: "@[[Robert Allen|Person]]"
     accessed: 2026-01-20
@@ -149,7 +149,7 @@ We will adopt the **Memory Interchange Format (MIF)** as our standard for AI mem
 
 ## Citations
 
-- [Memory Interchange Format (MIF) Specification](https://github.com/modeled-information-format/subcog/blob/main/SPECIFICATION.md) by @[[Robert Allen|Person]] (2026)
+- [Memory Interchange Format (MIF) Specification](https://github.com/zircote/subcog/blob/main/SPECIFICATION.md) by @[[Robert Allen|Person]] (2026)
   - **Type**: specification
   - **Role**: source
   - **Relevance**: 1.0

--- a/examples/level-3-full.memory.json
+++ b/examples/level-3-full.memory.json
@@ -4,7 +4,7 @@
     {
       "prov": "http://www.w3.org/ns/prov#",
       "dc": "http://purl.org/dc/terms/",
-      "subcog": "https://github.com/modeled-information-format/subcog/ns/"
+      "subcog": "https://github.com/zircote/subcog/ns/"
     }
   ],
   "@type": ["Memory", "prov:Entity"],

--- a/src/content/docs/specification/json-ld-format.mdx
+++ b/src/content/docs/specification/json-ld-format.mdx
@@ -39,7 +39,7 @@ description: The .memory.json format specification for machine-processable memor
     {
       "prov": "http://www.w3.org/ns/prov#",
       "dc": "http://purl.org/dc/terms/",
-      "subcog": "https://github.com/modeled-information-format/subcog/ns/"
+      "subcog": "https://github.com/zircote/subcog/ns/"
     }
   ],
   "@type": ["Memory", "prov:Entity"],


### PR DESCRIPTION
Subcog is maintained at **`zircote/subcog`**, not in this org. The earlier org retarget (#88) over-flipped `github.com/zircote/subcog` to `github.com/modeled-information-format/subcog`, which 404s. Restores the correct home across README, SPECIFICATION, the level-3 examples, and the spec docs. Memory validation passes; JSON parses.