### PR TITLE
fix(develop): zircote-resident links + retired product name in citations example

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ This specification is open source. Contributions welcome:
 
 ## Related
 
-- [Subcog](https://github.com/modeled-information-format/subcog) - AI memory system implementing MIF
+- [Subcog](https://github.com/zircote/subcog) - AI memory system implementing MIF
 - [Mnemonic](https://github.com/modeled-information-format/mnemonic) - Claude Code plugin using MIF ontologies
 
 ## Citing This Project

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -664,7 +664,7 @@ Implementations MAY apply compression when memories meet these criteria:
     {
       "prov": "http://www.w3.org/ns/prov#",
       "dc": "http://purl.org/dc/terms/",
-      "subcog": "https://github.com/modeled-information-format/subcog/ns/"
+      "subcog": "https://github.com/zircote/subcog/ns/"
     }
   ],
   "@type": ["Memory", "prov:Entity"],

--- a/profiles/ai-memory/examples/level-3-citations.md
+++ b/profiles/ai-memory/examples/level-3-citations.md
@@ -46,12 +46,12 @@ embedding:
   normalized: true
   '@type': EmbeddingReference
   modelVersion: 2024-01
-  sourceText: Decision to adopt MIF Memory Interchange Format for portable AI memory
+  sourceText: Decision to adopt MIF Modeled Information Format for portable AI memory
     representation
 citations:
 - '@type': Citation
   citationType: specification
-  title: Memory Interchange Format (MIF) Specification
+  title: Modeled Information Format (MIF) Specification
   url: https://github.com/zircote/subcog/blob/main/SPECIFICATION.md
   citationRole: source
   author: '@[[Robert Allen|Person]]'
@@ -108,7 +108,7 @@ Our AI systems currently use proprietary memory formats that are incompatible ac
 
 ## Decision
 
-We will adopt the **Memory Interchange Format (MIF)** as our standard for AI memory representation and interchange. ^decision
+We will adopt the **Modeled Information Format (MIF)** as our standard for AI memory representation and interchange. ^decision
 
 ### Key Factors
 
@@ -157,7 +157,7 @@ We will adopt the **Memory Interchange Format (MIF)** as our standard for AI mem
 
 ## Citations
 
-- [Memory Interchange Format (MIF) Specification](https://github.com/zircote/subcog/blob/main/SPECIFICATION.md) by @[[Robert Allen|Person]] (2026)
+- [Modeled Information Format (MIF) Specification](https://github.com/zircote/subcog/blob/main/SPECIFICATION.md) by @[[Robert Allen|Person]] (2026)
   - **Type**: specification
   - **Role**: source
   - **Relevance**: 1.0

--- a/profiles/ai-memory/examples/level-3-citations.md
+++ b/profiles/ai-memory/examples/level-3-citations.md
@@ -52,7 +52,7 @@ citations:
 - '@type': Citation
   citationType: specification
   title: Memory Interchange Format (MIF) Specification
-  url: https://github.com/modeled-information-format/subcog/blob/main/SPECIFICATION.md
+  url: https://github.com/zircote/subcog/blob/main/SPECIFICATION.md
   citationRole: source
   author: '@[[Robert Allen|Person]]'
   date: '2026-01-23'
@@ -89,7 +89,7 @@ citations:
 - '@type': Citation
   citationType: repository
   title: Subcog Memory System
-  url: https://github.com/modeled-information-format/subcog
+  url: https://github.com/zircote/subcog
   citationRole: extends
   author: '@[[Robert Allen|Person]]'
   accessed: '2026-01-20'
@@ -157,7 +157,7 @@ We will adopt the **Memory Interchange Format (MIF)** as our standard for AI mem
 
 ## Citations
 
-- [Memory Interchange Format (MIF) Specification](https://github.com/modeled-information-format/subcog/blob/main/SPECIFICATION.md) by @[[Robert Allen|Person]] (2026)
+- [Memory Interchange Format (MIF) Specification](https://github.com/zircote/subcog/blob/main/SPECIFICATION.md) by @[[Robert Allen|Person]] (2026)
   - **Type**: specification
   - **Role**: source
   - **Relevance**: 1.0

--- a/src/content/docs/specification/json-ld-format.mdx
+++ b/src/content/docs/specification/json-ld-format.mdx
@@ -41,7 +41,7 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
     {
       "prov": "http://www.w3.org/ns/prov#",
       "dc": "http://purl.org/dc/terms/",
-      "subcog": "https://github.com/modeled-information-format/subcog/ns/"
+      "subcog": "https://github.com/zircote/subcog/ns/"
     }
   ],
   "@type": ["Memory", "prov:Entity"],


### PR DESCRIPTION
Two link/name hygiene fixes on develop/v1.0.0:

1. **zircote-resident repos** (develop equivalent of #92): `subcog`/`rlm-rs`/`marketplace`/`rust-template` are under `zircote/*`, not the org; the #90 retarget over-flipped them to 404 `modeled-information-format/*`. Restored across README, SPECIFICATION, level-3 citations, json-ld-format.
2. **Product name**: replaced the retired "Memory Interchange Format" with "Modeled Information Format" in the current-use `level-3-citations.md` example.

Intentionally left as accurate history: ADR-010 (the rename record) and the frozen v0/0.1.0 schema mirrors keep the old name.