### PR TITLE
ci+docs: enable deploy dispatch; document build-generated llms.txt

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ name: Deploy to GitHub Pages
 "on":
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ See [ontologies/](./ontologies/) for base ontology and examples.
 
 See [SPECIFICATION.md](./SPECIFICATION.md) for the complete technical specification.
 
+## LLM-friendly documentation
+
+The spec site publishes [`llms.txt`](https://mif-spec.dev/llms.txt) for large
+language models, following the [llms.txt convention](https://llmstxt.org/). It is
+generated at build time by the `starlight-llms-txt` plugin (never hand-edited),
+alongside `llms-full.txt` (full corpus) and `llms-small.txt` (condensed):
+
+- <https://mif-spec.dev/llms.txt>
+- <https://mif-spec.dev/llms-full.txt>
+- <https://mif-spec.dev/llms-small.txt>
+
 ## Validation
 
 JSON Schema files are available for automated validation:


### PR DESCRIPTION
Adds `workflow_dispatch` to the Pages deploy and documents the build-generated `llms.txt`/`llms-full.txt`/`llms-small.txt` (via `starlight-llms-txt`, served from mif-spec.dev). **Merging re-triggers the deploy** (now that `withastro/action` is allow-listed), which publishes the plugin output to mif-spec.dev — i.e. merge = production deploy.