### PR TITLE
docs(spec): align published spec examples with the canonical schema (epic #102)

### DIFF
--- a/src/content/docs/specification/appendices.mdx
+++ b/src/content/docs/specification/appendices.mdx
@@ -26,29 +26,29 @@ tags: [tag1, tag2]
 aliases: ["Alt Name 1", "Alt Name 2"]
 
 temporal:
-  valid_from: ISO-8601-datetime
-  valid_until: ISO-8601-datetime | null
-  recorded_at: ISO-8601-datetime
+  validFrom: ISO-8601-datetime
+  validUntil: ISO-8601-datetime | null
+  recordedAt: ISO-8601-datetime
   ttl: ISO-8601-duration
   decay:
     model: none|linear|exponential|step
     halfLife: ISO-8601-duration
     strength: 0.0-1.0
-  access_count: integer
-  last_accessed: ISO-8601-datetime
+  accessCount: integer
+  lastAccessed: ISO-8601-datetime
 
 provenance:
-  source_type: user_explicit|user_implicit|agent_inferred|external_import|system_generated
-  source_ref: uri
+  sourceType: user_explicit|user_implicit|agent_inferred|external_import|system_generated
+  sourceRef: uri
   agent: string
   confidence: 0.0-1.0
-  trust_level: verified|user_stated|high_confidence|moderate_confidence|low_confidence|uncertain
+  trustLevel: verified|user_stated|high_confidence|moderate_confidence|low_confidence|uncertain
 
 embedding:
   model: string
-  model_version: string
+  modelVersion: string
   dimensions: integer
-  source_text: string
+  sourceText: string
 
 extensions:
   provider_name:
@@ -62,17 +62,17 @@ extensions:
 
 Relationships appear in a `## Relationships` body section as `- <type> [Text](/path/target.md)`, mirroring the authoritative frontmatter `relationships[]`.
 
-| Body Markdown Syntax | JSON-LD relationshipType | Description |
-|----------------------|-------------------------|-------------|
-| `- relates-to [X](/path/x.md)` | `RelatesTo` | General relationship |
-| `- derived-from [X](/path/x.md)` | `DerivedFrom` | Created from source |
-| `- supersedes [X](/path/x.md)` | `Supersedes` | Replaces older |
-| `- conflicts-with [X](/path/x.md)` | `ConflictsWith` | Contradicts |
-| `- part-of [X](/path/x.md)` | `PartOf` | Component of |
-| `- implements [X](/path/x.md)` | `Implements` | Realizes |
-| `- uses [X](/path/x.md)` | `Uses` | Utilizes |
-| `- created-by [X](/path/x.md)` | `Created` | Authored by |
-| `- mentioned-in [X](/path/x.md)` | `MentionedIn` | Referenced in |
+| Body Markdown Syntax | JSON-LD `type` | Description |
+|----------------------|----------------|-------------|
+| `- relates-to [X](/path/x.md)` | `relates-to` | General relationship |
+| `- derived-from [X](/path/x.md)` | `derived-from` | Created from source |
+| `- supersedes [X](/path/x.md)` | `supersedes` | Replaces older |
+| `- conflicts-with [X](/path/x.md)` | `conflicts-with` | Contradicts |
+| `- part-of [X](/path/x.md)` | `part-of` | Component of |
+| `- implements [X](/path/x.md)` | `implements` | Realizes |
+| `- uses [X](/path/x.md)` | `uses` | Utilizes |
+| `- created-by [X](/path/x.md)` | `created-by` | Authored by |
+| `- mentioned-in [X](/path/x.md)` | `mentioned-in` | Referenced in |
 
 ---
 
@@ -158,4 +158,3 @@ citations:
 - [W3C PROV-DM](https://www.w3.org/TR/prov-dm/)
 - [ISO 8601: Date and Time Format](https://www.iso.org/iso-8601-date-and-time-format.html)
 - [Obsidian Help](https://help.obsidian.md/)
-- [JSON Canvas Specification](https://jsoncanvas.org/)

--- a/src/content/docs/specification/conversion.mdx
+++ b/src/content/docs/specification/conversion.mdx
@@ -32,9 +32,10 @@ Markdown is canonical; the JSON-LD projection is regenerated from it. The round 
   "@context": "https://mif-spec.dev/schema/context.jsonld",
   "@type": "Concept",
   "conceptType": "semantic",
-  "@id": "urn:mif:550e8400",
+  "@id": "urn:mif:550e8400-e29b-41d4-a716-446655440000",
   "title": "Dark Mode",
   "content": "User prefers dark mode",
+  "created": "2026-01-15T10:30:00Z",
   "relationships": [
     {"type": "relates-to", "target": "urn:mif:ui-prefs"}
   ]
@@ -47,6 +48,7 @@ Markdown is canonical; the JSON-LD projection is regenerated from it. The round 
 id: 550e8400-e29b-41d4-a716-446655440000
 type: semantic
 title: Dark Mode
+created: 2026-01-15T10:30:00Z
 relationships:
   - type: relates-to
     target: /semantic/ui-prefs.md

--- a/src/content/docs/specification/conversion.mdx
+++ b/src/content/docs/specification/conversion.mdx
@@ -30,12 +30,13 @@ Markdown is canonical; the JSON-LD projection is regenerated from it. The round 
 ```json
 {
   "@context": "https://mif-spec.dev/schema/context.jsonld",
-  "@type": "Memory",
+  "@type": "Concept",
+  "conceptType": "semantic",
   "@id": "urn:mif:550e8400",
   "title": "Dark Mode",
   "content": "User prefers dark mode",
   "relationships": [
-    {"relationshipType": "RelatesTo", "target": {"@id": "urn:mif:ui-prefs"}}
+    {"type": "relates-to", "target": "urn:mif:ui-prefs"}
   ]
 }
 ```

--- a/src/content/docs/specification/conversion.mdx
+++ b/src/content/docs/specification/conversion.mdx
@@ -18,11 +18,11 @@ Markdown is canonical; the JSON-LD projection is regenerated from it. The round 
 ### JSON-LD to Markdown
 
 1. Generate YAML frontmatter from JSON-LD properties, including `relationships[]`
-2. Set first `title` or H1 from `dc:title`
+2. Set the `title` and H1 from the `title` field
 3. Convert `content` to Markdown body
 4. Append "## Relationships" section as bundle-relative markdown links mirroring frontmatter
 5. Append "## Entities" section from `entities`
-6. Convert relationship `@id` targets to bundle-relative `.md` links
+6. Convert the `@id` (`urn:mif:<uuid>`) to the frontmatter `id` (`<uuid>`)
 
 ### Example Conversion
 
@@ -37,7 +37,7 @@ Markdown is canonical; the JSON-LD projection is regenerated from it. The round 
   "content": "User prefers dark mode",
   "created": "2026-01-15T10:30:00Z",
   "relationships": [
-    {"type": "relates-to", "target": "urn:mif:ui-prefs"}
+    {"type": "relates-to", "target": "/semantic/ui-prefs.md"}
   ]
 }
 ```

--- a/src/content/docs/specification/conversion.mdx
+++ b/src/content/docs/specification/conversion.mdx
@@ -7,22 +7,14 @@ Markdown is canonical; the JSON-LD projection is regenerated from it. The round 
 
 ### Markdown to JSON-LD
 
-1. Parse YAML frontmatter as structured data, including authoritative `relationships[]`
-2. Map frontmatter properties to JSON-LD using context
-3. Parse Markdown content for:
-   - `## Relationships` body links → reconciled against frontmatter `relationships` array
-   - Entity references (@[[...]]) → `entities` array
-   - Block references (^id) → fragment identifiers
-4. Convert body content to `content` field
+1. Parse the YAML frontmatter, including the authoritative `relationships[]`, and map each property into the JSON-LD projection: `id` becomes `@id` (`urn:mif:<id>`), `type` becomes `conceptType`, and the remaining fields pass through under the context.
+2. Take the full Markdown body, verbatim, as the `content` field. The OKF-legible `## Relationships` body mirror is part of the body, so it is carried inside `content`.
+3. Add the projection mirror fields the converter always emits: `timestamp` (= `modified`, else `created`) and, when `summary` is present, `description` (= `summary`).
 
 ### JSON-LD to Markdown
 
-1. Generate YAML frontmatter from JSON-LD properties, including `relationships[]`
-2. Set the `title` and H1 from the `title` field
-3. Convert `content` to Markdown body
-4. Append "## Relationships" section as bundle-relative markdown links mirroring frontmatter
-5. Append "## Entities" section from `entities`
-6. Convert the `@id` (`urn:mif:<uuid>`) to the frontmatter `id` (`<uuid>`)
+1. Recover the frontmatter from the JSON-LD properties: `@id` (`urn:mif:<uuid>`) becomes `id` (`<uuid>`), `conceptType` becomes `type`, and the remaining properties (including `relationships[]`) pass through.
+2. Write the `content` field back as the Markdown body, verbatim. Any `## Relationships`/`## Entities` body mirror is authored content preserved unchanged, which is what keeps the round trip lossless.
 
 ### Example Conversion
 
@@ -34,7 +26,7 @@ Markdown is canonical; the JSON-LD projection is regenerated from it. The round 
   "conceptType": "semantic",
   "@id": "urn:mif:550e8400-e29b-41d4-a716-446655440000",
   "title": "Dark Mode",
-  "content": "User prefers dark mode",
+  "content": "User prefers dark mode\n\n## Relationships\n\n- relates-to [UI Preferences](/semantic/ui-prefs.md)",
   "created": "2026-01-15T10:30:00Z",
   "relationships": [
     {"type": "relates-to", "target": "/semantic/ui-prefs.md"}
@@ -47,14 +39,12 @@ Markdown is canonical; the JSON-LD projection is regenerated from it. The round 
 ---
 id: 550e8400-e29b-41d4-a716-446655440000
 type: semantic
-title: Dark Mode
 created: 2026-01-15T10:30:00Z
+title: Dark Mode
 relationships:
   - type: relates-to
     target: /semantic/ui-prefs.md
 ---
-
-# Dark Mode
 
 User prefers dark mode
 
@@ -65,53 +55,19 @@ User prefers dark mode
 
 ### Citations Conversion
 
-**Markdown to JSON-LD:**
+`citations` is authored in frontmatter in its final shape and passes through to the JSON-LD projection verbatim (it is part of the converter's passthrough set, so the frontmatter and projection forms are identical). Each entry is a `Citation` object: `@type`, `citationType`, `citationRole`, `title`, and `url` are required; `author`, `date`, `accessed`, `relevance`, and `note` are optional. The `author` value is a wiki-link string and is preserved as written. Any `## Citations` body mirror is authored content carried inside `content`.
 
-1. Parse frontmatter `citations` array
-2. For each citation:
-   - Map `type` → `citationType` vocabulary term
-   - Map `role` → `citationRole` vocabulary term
-   - Resolve `@[[Entity|Type]]` author refs → entity URIs
-   - For multiple authors (comma-separated), convert to array of author objects
-   - Convert dates to ISO 8601 format
-3. If `## Citations` body section exists:
-   - Parse markdown links for title/url
-   - Extract metadata from `**Key**: value` patterns
-   - Merge with frontmatter (frontmatter takes precedence)
-4. Build `Citation` objects array
-
-**JSON-LD to Markdown:**
-
-1. Generate frontmatter `citations` array from JSON-LD
-2. Convert entity URIs to wiki-link syntax
-3. If any citation has `note` exceeding 100 characters:
-   - Create `## Citations` body section
-   - Format as markdown list with metadata
-
-**Example:**
+**Example (frontmatter, identical in the JSON-LD projection):**
 
 ```yaml
-# Frontmatter
 citations:
-  - type: article
+  - "@type": Citation
+    citationType: article
+    citationRole: supports
     title: "Research Paper"
     url: https://example.com/paper
-    role: supports
     author: "@[[Jane Smith|Person]]"
-```
-
-Converts to:
-
-```json
-"citations": [{
-  "@type": "Citation",
-  "citationType": "article",
-  "citationRole": "supports",
-  "title": "Research Paper",
-  "url": "https://example.com/paper",
-  "author": {
-    "@type": "EntityReference",
-    "entity": {"@id": "urn:mif:entity:person:jane-smith"}
-  }
-}]
+    date: "2025-11-15"
+    accessed: "2026-01-18"
+    relevance: 0.92
 ```

--- a/src/content/docs/specification/data-model.mdx
+++ b/src/content/docs/specification/data-model.mdx
@@ -27,7 +27,7 @@ A concept is the atomic element of MIF — a single `.md` file in a bundle. It c
 | `compressedAt` | OPTIONAL | DateTime | When compression was applied (Level 3) |
 | `extensions` | OPTIONAL | Object | Provider-specific data |
 
-The frontmatter `type` field holds the base knowledge classification; in the JSON-LD projection produced by `mif_convert.py`, this value is surfaced as `conceptType`.
+The frontmatter `type` field holds the base knowledge classification; in the JSON-LD projection produced by `scripts/mif_convert.py`, this value is surfaced as `conceptType`.
 
 ### Knowledge Types
 

--- a/src/content/docs/specification/data-model.mdx
+++ b/src/content/docs/specification/data-model.mdx
@@ -24,8 +24,10 @@ A concept is the atomic element of MIF — a single `.md` file in a bundle. It c
 | `embedding` | OPTIONAL | Object | Embedding reference |
 | `citations` | OPTIONAL | Array | Citation references (Level 3) |
 | `summary` | OPTIONAL | String | Compressed content summary (Level 3) |
-| `compressed_at` | OPTIONAL | DateTime | When compression was applied (Level 3) |
+| `compressedAt` | OPTIONAL | DateTime | When compression was applied (Level 3) |
 | `extensions` | OPTIONAL | Object | Provider-specific data |
+
+The frontmatter `type` field holds the base knowledge classification; in the JSON-LD projection produced by `mif_convert.py`, this value is surfaced as `conceptType`.
 
 ### Knowledge Types
 
@@ -94,7 +96,7 @@ A concept MAY declare which ontology it conforms to using the `ontology` field:
 ontology:
   id: regenerative-agriculture
   version: "1.0.0"
-  uri: https://github.com/modeled-information-format/MIF/ontologies/examples/regenerative-agriculture.ontology.yaml
+  uri: https://raw.githubusercontent.com/modeled-information-format/MIF/main/ontologies/examples/regenerative-agriculture.ontology.yaml
 ```
 
 The `ontology.id` MUST match the `ontology.id` field in the referenced ontology definition file. This enables:

--- a/src/content/docs/specification/embeddings.mdx
+++ b/src/content/docs/specification/embeddings.mdx
@@ -10,11 +10,10 @@ MIF stores embedding metadata, not raw vectors:
 ```yaml
 embedding:
   model: text-embedding-3-small
-  model_version: "2024-01"
+  modelVersion: "2024-01"
   dimensions: 1536
-  source_text: "The text that was embedded"
+  sourceText: "The text that was embedded"
   normalized: true
-  quantization: null  # or "float16", "int8"
 ```
 
 This allows:
@@ -30,19 +29,15 @@ For providers that need vector portability:
 ```yaml
 embedding:
   model: text-embedding-3-small
-  source_text: "..."
-  vector_uri: "vectors/550e8400.bin"
+  sourceText: "..."
+  vectorUri: "vectors/550e8400.bin"
 ```
 
-**Inline (JSON-LD only):**
+**JSON-LD with external vector URI:**
 ```json
 "embedding": {
   "model": "text-embedding-3-small",
   "sourceText": "...",
-  "vector": {
-    "@type": "Vector",
-    "encoding": "base64-float32",
-    "data": "SGVsbG8gV29ybGQh..."
-  }
+  "vectorUri": "urn:mif:vector:550e8400-e29b-41d4-a716-446655440000"
 }
 ```

--- a/src/content/docs/specification/embeddings.mdx
+++ b/src/content/docs/specification/embeddings.mdx
@@ -30,7 +30,7 @@ For providers that need vector portability:
 embedding:
   model: text-embedding-3-small
   sourceText: "..."
-  vectorUri: "vectors/550e8400.bin"
+  vectorUri: "urn:mif:vector:550e8400-e29b-41d4-a716-446655440000"
 ```
 
 **JSON-LD with external vector URI:**

--- a/src/content/docs/specification/json-ld-context.mdx
+++ b/src/content/docs/specification/json-ld-context.mdx
@@ -11,11 +11,14 @@ https://mif-spec.dev/schema/context.jsonld
 
 ### Context Definition
 
+The following is a representative subset of `schema/context.jsonld`; the full context includes additional term definitions.
+
 ```json
 {
   "@context": {
     "@version": 1.1,
     "mif": "https://mif-spec.dev/ns/",
+    "schema": "https://schema.org/",
     "dc": "http://purl.org/dc/terms/",
     "prov": "http://www.w3.org/ns/prov#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
@@ -113,11 +116,9 @@ https://mif-spec.dev/schema/context.jsonld
       "@id": "schema:url",
       "@type": "@id"
     },
-    "author": {
-      "@id": "dc:creator"
-    },
+    "author": "schema:author",
     "date": {
-      "@id": "dc:date",
+      "@id": "schema:datePublished",
       "@type": "xsd:date"
     },
     "relevance": {
@@ -125,10 +126,10 @@ https://mif-spec.dev/schema/context.jsonld
       "@type": "xsd:decimal"
     },
     "accessed": {
-      "@id": "schema:accessDate",
-      "@type": "xsd:date"
+      "@id": "mif:accessed",
+      "@type": "xsd:dateTime"
     },
-    "note": "schema:description",
+    "note": "mif:note",
 
     "summary": "mif:summary",
     "compressedAt": {

--- a/src/content/docs/specification/json-ld-format.mdx
+++ b/src/content/docs/specification/json-ld-format.mdx
@@ -40,7 +40,6 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
     "https://mif-spec.dev/schema/context.jsonld",
     {
       "prov": "http://www.w3.org/ns/prov#",
-      "dc": "http://purl.org/dc/terms/",
       "subcog": "https://github.com/zircote/subcog/ns/"
     }
   ],
@@ -51,8 +50,8 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
   "conceptType": "semantic",
   "title": "Dark Mode Preference",
 
-  "dc:created": "2026-01-15T10:30:00Z",
-  "dc:modified": "2026-01-20T14:22:00Z",
+  "created": "2026-01-15T10:30:00Z",
+  "modified": "2026-01-20T14:22:00Z",
 
   "ontology": {
     "@type": "OntologyReference",

--- a/src/content/docs/specification/json-ld-format.mdx
+++ b/src/content/docs/specification/json-ld-format.mdx
@@ -10,11 +10,11 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
 ```json
 {
   "@context": "https://mif-spec.dev/schema/context.jsonld",
-  "@type": "Memory",
+  "@type": "Concept",
   "@id": "urn:mif:550e8400-e29b-41d4-a716-446655440000",
 
   "content": "User prefers dark mode for all applications",
-  "memoryType": "semantic",
+  "conceptType": "semantic",
   "title": "Dark Mode Preference",
 
   "created": "2026-01-15T10:30:00Z",
@@ -44,11 +44,11 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
       "subcog": "https://github.com/zircote/subcog/ns/"
     }
   ],
-  "@type": ["Memory", "prov:Entity"],
+  "@type": ["Concept", "prov:Entity"],
   "@id": "urn:mif:550e8400-e29b-41d4-a716-446655440000",
 
   "content": "User prefers dark mode for all applications. This applies to:\n- IDE themes\n- Terminal colors\n- Web applications\n- Mobile apps",
-  "memoryType": "semantic",
+  "conceptType": "semantic",
   "title": "Dark Mode Preference",
 
   "dc:created": "2026-01-15T10:30:00Z",
@@ -79,15 +79,13 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
 
   "relationships": [
     {
-      "@type": "Relationship",
-      "relationshipType": "RelatesTo",
-      "target": {"@id": "urn:mif:memory:ui-preferences"},
+      "type": "relates-to",
+      "target": "urn:mif:memory:ui-preferences",
       "strength": 0.85
     },
     {
-      "@type": "Relationship",
-      "relationshipType": "Supersedes",
-      "target": {"@id": "urn:mif:memory:old-theme-preference"}
+      "type": "supersedes",
+      "target": "urn:mif:memory:old-theme-preference"
     }
   ],
 

--- a/src/content/docs/specification/markdown-format.mdx
+++ b/src/content/docs/specification/markdown-format.mdx
@@ -49,7 +49,7 @@ modified: 2026-01-20T14:22:00Z             # Last modification
 ontology:                                   # Applied ontology reference
   id: mif-base                             # Ontology identifier
   version: "1.0.0"                         # Ontology version
-  uri: https://mif-spec.dev/ontologies/mif-base  # Ontology identifier (not a resolvable URL)
+  uri: https://mif-spec.dev/ontologies/mif-base  # Ontology URI
 namespace: org/user/project                 # Hierarchical scope
 title: "Human-readable title"               # Display title
 tags:                                       # Classification
@@ -58,32 +58,32 @@ tags:                                       # Classification
 
 # === OPTIONAL: Temporal ===
 temporal:
-  valid_from: 2026-01-15T00:00:00Z         # When fact becomes valid
-  valid_until: null                         # When fact expires (null = indefinite)
-  recorded_at: 2026-01-15T10:30:00Z        # When recorded (transaction time)
+  validFrom: 2026-01-15T00:00:00Z          # When fact becomes valid
+  validUntil: null                          # When fact expires (null = indefinite)
+  recordedAt: 2026-01-15T10:30:00Z         # When recorded (transaction time)
   ttl: P90D                                 # Time-to-live (ISO 8601 duration)
   decay:
     model: exponential                      # Decay model
     halfLife: P7D                          # Half-life duration
     strength: 0.85                          # Current strength (0-1)
-  access_count: 5                           # Times accessed
-  last_accessed: 2026-01-20T14:22:00Z      # Last access time
+  accessCount: 5                            # Times accessed
+  lastAccessed: 2026-01-20T14:22:00Z       # Last access time
 
 # === OPTIONAL: Provenance ===
 provenance:
-  source_type: user_explicit                # How memory was created
-  source_ref: conversation:conv_456         # Reference to source
+  sourceType: user_explicit                 # How memory was created
+  sourceRef: conversation:conv_456          # Reference to source
   agent: claude-3-opus                      # Creating agent
   confidence: 0.95                          # Confidence score (0-1)
-  trust_level: user_stated                  # Trust classification
+  trustLevel: user_stated                   # Trust classification
 
 # === OPTIONAL: Embedding ===
 embedding:
   model: text-embedding-3-small             # Embedding model
-  model_version: "2024-01"                  # Model version
+  modelVersion: "2024-01"                   # Model version
   dimensions: 1536                          # Vector dimensions
-  source_text: "User prefers dark mode"     # Text that was embedded
-  # Note: Actual vectors stored externally or in JSON-LD format
+  sourceText: "User prefers dark mode"      # Text that was embedded
+  # Note: Actual vectors stored externally via vectorUri
 
 # === OPTIONAL: Aliases ===
 aliases:
@@ -288,14 +288,14 @@ Compression allows large memories to be summarized while preserving the original
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
 | `summary` | OPTIONAL | String | Concise 2-3 sentence summary (max 500 characters) |
-| `compressed_at` | OPTIONAL | DateTime | When compression was applied (ISO 8601) |
+| `compressedAt` | OPTIONAL | DateTime | When compression was applied (ISO 8601) |
 
 **Frontmatter Schema:**
 
 ```yaml
 # === OPTIONAL: Compression (Level 3) ===
 summary: "User prefers dark mode for reduced eye strain during extended coding sessions. Applies to IDE, terminal, and web applications."
-compressed_at: 2026-01-24T10:00:00Z
+compressedAt: 2026-01-24T10:00:00Z
 ```
 
 #### Compression Criteria
@@ -312,7 +312,7 @@ Implementations MAY apply compression when memories meet these criteria:
 - The `content` field SHOULD be replaced with the compressed summary
 - The original `content` MAY be preserved in `extensions.original_content`
 - The `summary` field contains the generated summary text
-- The `compressed_at` timestamp indicates when compression occurred
+- The `compressedAt` timestamp indicates when compression occurred
 - Compressed memories retain all other metadata (relationships, entities, etc.)
 
 #### Compression Validation
@@ -320,4 +320,4 @@ Implementations MAY apply compression when memories meet these criteria:
 | Field | Constraint |
 |-------|------------|
 | `summary` | MUST be 500 characters or fewer |
-| `compressed_at` | MUST be ISO 8601 datetime format |
+| `compressedAt` | MUST be ISO 8601 datetime format |

--- a/src/content/docs/specification/provenance.mdx
+++ b/src/content/docs/specification/provenance.mdx
@@ -30,14 +30,14 @@ MIF uses W3C PROV vocabulary for provenance tracking.
 
 ```yaml
 provenance:
-  source_type: user_explicit
-  source_ref: conversation:conv-456
+  sourceType: user_explicit
+  sourceRef: conversation:conv-456
   agent: claude-3-opus
-  agent_version: "20240229"
+  agentVersion: "20240229"
   confidence: 0.95
-  trust_level: user_stated
-  derived_from:
+  trustLevel: user_stated
+  wasDerivedFrom:
     - memory:parent-memory-id
-  attribution:
+  wasAttributedTo:
     - entity:person:jane-doe
 ```

--- a/src/content/docs/specification/provenance.mdx
+++ b/src/content/docs/specification/provenance.mdx
@@ -38,6 +38,5 @@ provenance:
   trustLevel: user_stated
   wasDerivedFrom:
     - memory:parent-memory-id
-  wasAttributedTo:
-    - entity:person:jane-doe
+  wasAttributedTo: entity:person:jane-doe
 ```

--- a/src/content/docs/specification/relationship-types.mdx
+++ b/src/content/docs/specification/relationship-types.mdx
@@ -13,44 +13,44 @@ Relationship types are **not hard-coded**. They are defined in vault configurati
 # .mif/config.yaml
 relationship_types:
   # Core types (RECOMMENDED for interoperability)
-  - name: RelatesTo
+  - name: relates-to
     description: General semantic relationship
     symmetric: true
-  - name: DerivedFrom
+  - name: derived-from
     description: Memory created based on source
-    inverse: Derives
-  - name: Supersedes
+    inverse: derives
+  - name: supersedes
     description: Replaces an older memory
-    inverse: SupersededBy
-  - name: ConflictsWith
+    inverse: superseded-by
+  - name: conflicts-with
     description: Contradicts another memory
     symmetric: true
-  - name: PartOf
+  - name: part-of
     description: Component of a larger whole
-    inverse: Contains
-  - name: Implements
+    inverse: contains
+  - name: implements
     description: Realizes a concept or pattern
-    inverse: ImplementedBy
-  - name: Uses
+    inverse: implemented-by
+  - name: uses
     description: Utilizes a technology or tool
-    inverse: UsedBy
-  - name: Created
+    inverse: used-by
+  - name: created-by
     description: Authored by an entity
-    inverse: CreatedBy
-  - name: MentionedIn
+    inverse: creates
+  - name: mentioned-in
     description: Referenced within a memory
-    inverse: Mentions
+    inverse: mentions
 
   # Custom types (domain-specific)
-  - name: Reinforces
+  - name: reinforces
     namespace: subcog
     description: Strengthens confidence in another memory
-    inverse: ReinforcedBy
-  - name: Contradicts
+    inverse: reinforced-by
+  - name: contradicts
     namespace: subcog
     description: Provides evidence against another memory
-    inverse: ContradictedBy
-  - name: BreedsWith
+    inverse: contradicted-by
+  - name: breeds-with
     namespace: farm
     description: Animal breeding relationship
     symmetric: false
@@ -67,15 +67,15 @@ For maximum interoperability, implementations SHOULD recognize these nine core t
 
 | Type | Description | Inverse | Symmetric |
 |------|-------------|---------|-----------|
-| `RelatesTo` | General relationship | `RelatesTo` | Yes |
-| `DerivedFrom` | Created based on source | `Derives` | No |
-| `Supersedes` | Replaces older memory | `SupersededBy` | No |
-| `ConflictsWith` | Contradicts another memory | `ConflictsWith` | Yes |
-| `PartOf` | Component of larger whole | `Contains` | No |
-| `Implements` | Realizes a concept/pattern | `ImplementedBy` | No |
-| `Uses` | Utilizes a technology/tool | `UsedBy` | No |
-| `Created` | Authored by entity | `CreatedBy` | No |
-| `MentionedIn` | Referenced in memory | `Mentions` | No |
+| `relates-to` | General relationship | `relates-to` | Yes |
+| `derived-from` | Created based on source | `derives` | No |
+| `supersedes` | Replaces older memory | `superseded-by` | No |
+| `conflicts-with` | Contradicts another memory | `conflicts-with` | Yes |
+| `part-of` | Component of larger whole | `contains` | No |
+| `implements` | Realizes a concept/pattern | `implemented-by` | No |
+| `uses` | Utilizes a technology/tool | `used-by` | No |
+| `created-by` | Authored by entity | `creates` | No |
+| `mentioned-in` | Referenced in memory | `mentions` | No |
 
 ### Custom Relationship Types
 
@@ -84,10 +84,10 @@ Providers MAY define additional relationship types using namespaced URIs:
 ```yaml
 # Custom relationship type definition
 relationship_types:
-  - name: Contradicts
+  - name: contradicts
     namespace: farm           # Results in type token: farm:contradicts
     description: Provides conflicting evidence
-    inverse: ContradictedBy
+    inverse: contradicted-by
     properties:
       - name: contradiction_type
         type: string

--- a/src/content/docs/specification/relationship-types.mdx
+++ b/src/content/docs/specification/relationship-types.mdx
@@ -85,7 +85,7 @@ Providers MAY define additional relationship types using namespaced URIs:
 # Custom relationship type definition
 relationship_types:
   - name: Contradicts
-    namespace: farm           # Results in URI: farm:Contradicts
+    namespace: farm           # Results in type token: farm:contradicts
     description: Provides conflicting evidence
     inverse: ContradictedBy
     properties:
@@ -107,7 +107,7 @@ relationship_types:
   ],
   "relationships": [
     {
-      "type": "breeds-with",
+      "type": "farm:breeds-with",
       "target": "urn:mif:entity:animal:ram-001",
       "strength": 1.0,
       "metadata": {

--- a/src/content/docs/specification/relationship-types.mdx
+++ b/src/content/docs/specification/relationship-types.mdx
@@ -107,12 +107,13 @@ relationship_types:
   ],
   "relationships": [
     {
-      "@type": "Relationship",
-      "relationshipType": "farm:BreedsWith",
-      "target": {"@id": "urn:mif:entity:animal:ram-001"},
+      "type": "breeds-with",
+      "target": "urn:mif:entity:animal:ram-001",
       "strength": 1.0,
-      "farm:breeding_date": "2025-10-15",
-      "farm:success": true
+      "metadata": {
+        "farm:breeding_date": "2025-10-15",
+        "farm:success": true
+      }
     }
   ]
 }
@@ -155,9 +156,8 @@ relationships:
 ```json
 "relationships": [
   {
-    "@type": "Relationship",
-    "relationshipType": "DerivedFrom",
-    "target": {"@id": "urn:mif:memory:source-memory"},
+    "type": "derived-from",
+    "target": "urn:mif:memory:source-memory",
     "strength": 0.9,
     "metadata": {
       "reason": "Extracted key insight",
@@ -171,8 +171,7 @@ relationships:
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `@type` | String | Yes | Always `"Relationship"` |
-| `relationshipType` | URI/Vocab | Yes | Type identifier (core or custom) |
-| `target` | URI Reference | Yes | Target memory or entity URI |
+| `type` | String | Yes | Relationship type in kebab-case (e.g. `derived-from`) |
+| `target` | String | Yes | Target memory or entity path/URN |
 | `strength` | Decimal | No | Relationship strength (0.0-1.0) |
 | `metadata` | Object | No | Additional relationship metadata |

--- a/src/content/docs/specification/security.mdx
+++ b/src/content/docs/specification/security.mdx
@@ -20,7 +20,7 @@ description: Security considerations and IANA media type registrations.
 
 ### Provenance Trust
 
-- `provenance.trust_level` indicates data reliability
+- `provenance.trustLevel` indicates data reliability
 - Implementations SHOULD NOT elevate trust levels on import
 - External sources SHOULD be marked as `external_import`
 

--- a/src/content/docs/specification/temporal-model.mdx
+++ b/src/content/docs/specification/temporal-model.mdx
@@ -57,15 +57,15 @@ The cognitive-memory rationale that originally motivated this exponential curve 
 
 ```yaml
 temporal:
-  valid_from: 2026-01-15T00:00:00Z
-  valid_until: null
-  recorded_at: 2026-01-15T10:30:00Z
+  validFrom: 2026-01-15T00:00:00Z
+  validUntil: null
+  recordedAt: 2026-01-15T10:30:00Z
   ttl: P90D
   decay:
     model: exponential
     halfLife: P7D
     strength: 0.85
-    last_reinforced: 2026-01-18T09:00:00Z
-  access_count: 5
-  last_accessed: 2026-01-20T14:22:00Z
+    lastReinforced: 2026-01-18T09:00:00Z
+  accessCount: 5
+  lastAccessed: 2026-01-20T14:22:00Z
 ```


### PR DESCRIPTION
Epic #102: align the published spec (`src/content/docs/specification/*.mdx`) with the canonical schema and the converter's validated output.

## Changes
- `conceptType` (not deprecated `memoryType`) and `@type: Concept` in JSON-LD examples.
- Relationship objects use `type` (kebab) + `target` (string), not `relationshipType`/`@type:"Relationship"`/object `target`.
- camelCase `TemporalMetadata` and `EmbeddingReference` keys (both schemas are closed, so snake_case there fails validation).
- Canonical PROV/provenance field names (`wasDerivedFrom`, `wasAttributedTo`, `sourceType`, `sourceRef`, `trustLevel`, `agentVersion`).
- Drop the non-schema embedding `quantization` field and inline `vector` block (vectors are external via `vectorUri`).
- `compressed_at` -> `compressedAt`; fix the `ontology.uri` example to a valid raw URL (file verified to exist).
- `security.mdx` `provenance.trustLevel`; `appendices.mdx` drop the unrelated JSON Canvas reference; `appendices` relationship table uses `type` (kebab).
- Added `conversion.mdx` (the audit missed it; same error class) per maintainer decision.

Builds clean (`npm run build` -> Complete!).

## Verification-driven scope notes
- Closed as false positives (two-surface conflation): **#116** (`@context` is added by the projection, never authored, so Level 1 correctly lists `id`/`type`/`content`/`created`) and **#119** (`tree/main` is correct for docs served from `main`). The `@context`/`type` parts of **#108** were likewise dismissed; its real parts (`compressedAt`, `ontology.uri`) are fixed here.
- `json-ld-context.mdx` is left documenting the current `schema/context.jsonld`, which is itself out of sync with the schema (`conceptType` missing; `memoryType`/`relationshipType` present; `type` aliased to `@type`). That reconciliation is tracked as a separate epic and is a prerequisite in #144.

Closes #108, #109, #110, #111, #112, #113, #114, #115, #117, #118
