### PR TITLE
docs(spec): align reference docs + profile spec with the canonical schema (epic #103)

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1170,7 +1170,6 @@ The relationship type name is converted to kebab-case in Markdown. The target us
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `@type` | String | Yes | Always `"Relationship"` |
 | `type` | String | Yes | Type identifier (kebab-case; optional `ns:` prefix) |
 | `target` | URI Reference | Yes | Target memory or entity URI |
 | `strength` | Decimal | No | Relationship strength (0.0-1.0) |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -350,8 +350,8 @@ carry `temporal` validity to bound when they hold (see 9):
 type: episodic
 namespace: episodic/sessions
 temporal:
-  valid_from: 2026-01-15T00:00:00Z
-  valid_until: 2026-01-15T11:00:00Z
+  validFrom: 2026-01-15T00:00:00Z
+  validUntil: 2026-01-15T11:00:00Z
 ---
 ```
 
@@ -421,31 +421,31 @@ tags:                                       # Classification
 
 # === OPTIONAL: Temporal ===
 temporal:
-  valid_from: 2026-01-15T00:00:00Z         # When fact becomes valid
-  valid_until: null                         # When fact expires (null = indefinite)
-  recorded_at: 2026-01-15T10:30:00Z        # When recorded (transaction time)
+  validFrom: 2026-01-15T00:00:00Z          # When fact becomes valid
+  validUntil: null                          # When fact expires (null = indefinite)
+  recordedAt: 2026-01-15T10:30:00Z         # When recorded (transaction time)
   ttl: P90D                                 # Time-to-live (ISO 8601 duration)
   decay:
     model: exponential                      # Decay model
     halfLife: P7D                          # Half-life duration
     strength: 0.85                          # Current strength (0-1)
-  access_count: 5                           # Times accessed
-  last_accessed: 2026-01-20T14:22:00Z      # Last access time
+  accessCount: 5                            # Times accessed
+  lastAccessed: 2026-01-20T14:22:00Z       # Last access time
 
 # === OPTIONAL: Provenance ===
 provenance:
-  source_type: user_explicit                # How memory was created
-  source_ref: conversation:conv_456         # Reference to source
+  sourceType: user_explicit                 # How memory was created
+  sourceRef: conversation:conv_456          # Reference to source
   agent: claude-3-opus                      # Creating agent
   confidence: 0.95                          # Confidence score (0-1)
-  trust_level: user_stated                  # Trust classification
+  trustLevel: user_stated                   # Trust classification
 
 # === OPTIONAL: Embedding ===
 embedding:
   model: text-embedding-3-small             # Embedding model
-  model_version: "2024-01"                  # Model version
+  modelVersion: "2024-01"                   # Model version
   dimensions: 1536                          # Vector dimensions
-  source_text: "User prefers dark mode"     # Text that was embedded
+  sourceText: "User prefers dark mode"      # Text that was embedded
   # Note: Actual vectors stored externally or in JSON-LD format
 
 # === OPTIONAL: Aliases ===
@@ -698,11 +698,11 @@ Implementations MAY apply compression when memories meet these criteria:
 ```json
 {
   "@context": "https://mif-spec.dev/schema/context.jsonld",
-  "@type": "Memory",
+  "@type": "Concept",
   "@id": "urn:mif:550e8400-e29b-41d4-a716-446655440000",
 
   "content": "User prefers dark mode for all applications",
-  "memoryType": "semantic",
+  "conceptType": "semantic",
   "title": "Dark Mode Preference",
 
   "created": "2026-01-15T10:30:00Z",
@@ -732,11 +732,11 @@ Implementations MAY apply compression when memories meet these criteria:
       "subcog": "https://github.com/zircote/subcog/ns/"
     }
   ],
-  "@type": ["Memory", "prov:Entity"],
+  "@type": ["Concept", "prov:Entity"],
   "@id": "urn:mif:550e8400-e29b-41d4-a716-446655440000",
 
   "content": "User prefers dark mode for all applications. This applies to:\n- IDE themes\n- Terminal colors\n- Web applications\n- Mobile apps",
-  "memoryType": "semantic",
+  "conceptType": "semantic",
   "title": "Dark Mode Preference",
 
   "dc:created": "2026-01-15T10:30:00Z",
@@ -767,15 +767,13 @@ Implementations MAY apply compression when memories meet these criteria:
 
   "relationships": [
     {
-      "@type": "Relationship",
-      "relationshipType": "RelatesTo",
-      "target": {"@id": "urn:mif:memory:ui-preferences"},
+      "type": "relates-to",
+      "target": "urn:mif:memory:ui-preferences",
       "strength": 0.85
     },
     {
-      "@type": "Relationship",
-      "relationshipType": "Supersedes",
-      "target": {"@id": "urn:mif:memory:old-theme-preference"}
+      "type": "supersedes",
+      "target": "urn:mif:memory:old-theme-preference"
     }
   ],
 
@@ -1122,12 +1120,13 @@ relationship_types:
   ],
   "relationships": [
     {
-      "@type": "Relationship",
-      "relationshipType": "farm:BreedsWith",
-      "target": {"@id": "urn:mif:entity:animal:ram-001"},
+      "type": "farm:breeds-with",
+      "target": "urn:mif:entity:animal:ram-001",
       "strength": 1.0,
-      "farm:breeding_date": "2025-10-15",
-      "farm:success": true
+      "metadata": {
+        "farm:breeding_date": "2025-10-15",
+        "farm:success": true
+      }
     }
   ]
 }
@@ -1156,9 +1155,8 @@ The relationship type name is converted to kebab-case in Markdown. The target us
 ```json
 "relationships": [
   {
-    "@type": "Relationship",
-    "relationshipType": "DerivedFrom",
-    "target": {"@id": "urn:mif:memory:source-memory"},
+    "type": "derived-from",
+    "target": "urn:mif:memory:source-memory",
     "strength": 0.9,
     "metadata": {
       "reason": "Extracted key insight",
@@ -1173,7 +1171,7 @@ The relationship type name is converted to kebab-case in Markdown. The target us
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `@type` | String | Yes | Always `"Relationship"` |
-| `relationshipType` | URI/Vocab | Yes | Type identifier (core or custom) |
+| `type` | String | Yes | Type identifier (kebab-case; optional `ns:` prefix) |
 | `target` | URI Reference | Yes | Target memory or entity URI |
 | `strength` | Decimal | No | Relationship strength (0.0-1.0) |
 | `metadata` | Object | No | Additional relationship metadata |
@@ -1248,17 +1246,17 @@ reinforcement — each access can reset or slow the freshness decay.
 
 ```yaml
 temporal:
-  valid_from: 2026-01-15T00:00:00Z
-  valid_until: null
-  recorded_at: 2026-01-15T10:30:00Z
+  validFrom: 2026-01-15T00:00:00Z
+  validUntil: null
+  recordedAt: 2026-01-15T10:30:00Z
   ttl: P90D
   decay:
     model: exponential
     halfLife: P7D
     strength: 0.85
-    last_reinforced: 2026-01-18T09:00:00Z
-  access_count: 5
-  last_accessed: 2026-01-20T14:22:00Z
+    lastReinforced: 2026-01-18T09:00:00Z
+  accessCount: 5
+  lastAccessed: 2026-01-20T14:22:00Z
 ```
 
 ---
@@ -1583,9 +1581,9 @@ MIF stores embedding metadata, not raw vectors:
 ```yaml
 embedding:
   model: text-embedding-3-small
-  model_version: "2024-01"
+  modelVersion: "2024-01"
   dimensions: 1536
-  source_text: "The text that was embedded"
+  sourceText: "The text that was embedded"
   normalized: true
   quantization: null  # or "float16", "int8"
 ```
@@ -1603,8 +1601,8 @@ For providers that need vector portability:
 ```yaml
 embedding:
   model: text-embedding-3-small
-  source_text: "..."
-  vector_uri: "vectors/550e8400.bin"
+  sourceText: "..."
+  vectorUri: "urn:mif:vector:550e8400-e29b-41d4-a716-446655440000"
 ```
 
 **Inline (JSON-LD only):**
@@ -1731,7 +1729,7 @@ Implementations SHOULD declare their conformance level:
 
 ```yaml
 # .mif/config.yaml
-mif_version: "0.1.0"
+mif_version: "1.0.0"
 conformance_level: 2
 extensions:
   - subcog
@@ -1750,151 +1748,17 @@ https://mif-spec.dev/schema/context.jsonld
 
 ### 14.2 Context Definition
 
-```json
-{
-  "@context": {
-    "@version": 1.1,
-    "mif": "https://mif-spec.dev/ns/",
-    "dc": "http://purl.org/dc/terms/",
-    "prov": "http://www.w3.org/ns/prov#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
+The canonical JSON-LD context is maintained in `schema/context.jsonld` at the
+root of this repository and is served at:
 
-    "Memory": "mif:Memory",
-    "Entity": "mif:Entity",
-    "Relationship": "mif:Relationship",
-    "TemporalMetadata": "mif:TemporalMetadata",
-    "EmbeddingReference": "mif:EmbeddingReference",
-    "EntityReference": "mif:EntityReference",
-    "OntologyReference": "mif:OntologyReference",
-
-    "Person": "mif:Person",
-    "Organization": "mif:Organization",
-    "Technology": "mif:Technology",
-    "Concept": "mif:Concept",
-    "File": "mif:File",
-
-    "id": "@id",
-    "type": "@type",
-    "content": "mif:content",
-    "memoryType": "mif:memoryType",
-    "title": "dc:title",
-    "namespace": "mif:namespace",
-    "tags": "mif:tags",
-    "aliases": "mif:aliases",
-
-    "created": {
-      "@id": "dc:created",
-      "@type": "xsd:dateTime"
-    },
-    "modified": {
-      "@id": "dc:modified",
-      "@type": "xsd:dateTime"
-    },
-
-    "ontology": "mif:ontology",
-    "entities": "mif:entities",
-    "relationships": "mif:relationships",
-    "temporal": "mif:temporal",
-    "provenance": "mif:provenance",
-    "embedding": "mif:embedding",
-    "extensions": "mif:extensions",
-
-    "relationshipType": "mif:relationshipType",
-    "target": "mif:target",
-    "strength": "mif:strength",
-
-    "validFrom": {
-      "@id": "mif:validFrom",
-      "@type": "xsd:dateTime"
-    },
-    "validUntil": {
-      "@id": "mif:validUntil",
-      "@type": "xsd:dateTime"
-    },
-    "recordedAt": {
-      "@id": "mif:recordedAt",
-      "@type": "xsd:dateTime"
-    },
-    "ttl": "mif:ttl",
-    "decay": "mif:decay",
-    "accessCount": "mif:accessCount",
-    "lastAccessed": {
-      "@id": "mif:lastAccessed",
-      "@type": "xsd:dateTime"
-    },
-
-    "sourceType": "mif:sourceType",
-    "sourceRef": "mif:sourceRef",
-    "agent": "mif:agent",
-    "agentVersion": "mif:agentVersion",
-    "confidence": "mif:confidence",
-    "trustLevel": "mif:trustLevel",
-
-    "wasGeneratedBy": {
-      "@id": "prov:wasGeneratedBy",
-      "@type": "@id"
-    },
-    "wasAttributedTo": {
-      "@id": "prov:wasAttributedTo",
-      "@type": "@id"
-    },
-    "wasDerivedFrom": {
-      "@id": "prov:wasDerivedFrom",
-      "@type": "@id"
-    },
-    "wasAssociatedWith": {
-      "@id": "prov:wasAssociatedWith",
-      "@type": "@id"
-    },
-
-    "model": "mif:model",
-    "modelVersion": "mif:modelVersion",
-    "dimensions": "mif:dimensions",
-    "sourceText": "mif:sourceText",
-    "vectorUri": "mif:vectorUri",
-
-    "citations": {
-      "@id": "mif:citations",
-      "@container": "@set"
-    },
-    "Citation": "mif:Citation",
-    "citationType": {
-      "@id": "mif:citationType",
-      "@type": "@vocab"
-    },
-    "citationRole": {
-      "@id": "mif:citationRole",
-      "@type": "@vocab"
-    },
-    "url": {
-      "@id": "schema:url",
-      "@type": "@id"
-    },
-    "author": {
-      "@id": "dc:creator"
-    },
-    "date": {
-      "@id": "dc:date",
-      "@type": "xsd:date"
-    },
-    "relevance": {
-      "@id": "mif:relevance",
-      "@type": "xsd:decimal"
-    },
-    "accessed": {
-      "@id": "schema:accessDate",
-      "@type": "xsd:date"
-    },
-    "note": "schema:description",
-
-    "summary": "mif:summary",
-    "compressedAt": {
-      "@id": "mif:compressedAt",
-      "@type": "xsd:dateTime"
-    }
-  }
-}
 ```
+https://mif-spec.dev/schema/context.jsonld
+```
+
+That file is the normative definition of all term mappings for MIF documents.
+Implementations MUST dereference the context URL rather than inlining a local
+copy. The context is versioned alongside the schema; breaking changes to term
+mappings require a new major version of the specification.
 
 ---
 
@@ -1925,12 +1789,12 @@ https://mif-spec.dev/schema/context.jsonld
 ```json
 {
   "@context": "https://mif-spec.dev/schema/context.jsonld",
-  "@type": "Memory",
+  "@type": "Concept",
   "@id": "urn:mif:550e8400",
   "title": "Dark Mode",
   "content": "User prefers dark mode",
   "relationships": [
-    {"relationshipType": "RelatesTo", "target": {"@id": "urn:mif:ui-prefs"}}
+    {"type": "relates-to", "target": "urn:mif:ui-prefs"}
   ]
 }
 ```
@@ -2026,9 +1890,9 @@ User prefers dark mode for all applications.
 ```json
 {
   "@context": "https://mif-spec.dev/schema/context.jsonld",
-  "@type": "Memory",
+  "@type": "Concept",
   "@id": "urn:mif:550e8400-e29b-41d4-a716-446655440000",
-  "memoryType": "semantic",
+  "conceptType": "semantic",
   "content": "User prefers dark mode for all applications.",
   "created": "2026-01-15T10:30:00Z"
 }
@@ -2115,7 +1979,7 @@ see [`profiles/ai-memory/SPECIFICATION.md`](profiles/ai-memory/SPECIFICATION.md)
 
 ### 18.3 Provenance Trust
 
-- `provenance.trust_level` indicates data reliability
+- `provenance.trustLevel` indicates data reliability
 - Implementations SHOULD NOT elevate trust levels on import
 - External sources SHOULD be marked as `external_import`
 
@@ -2168,16 +2032,16 @@ tags: [tag1, tag2]
 aliases: ["Alt Name 1", "Alt Name 2"]
 
 temporal:
-  valid_from: ISO-8601-datetime
-  valid_until: ISO-8601-datetime | null
-  recorded_at: ISO-8601-datetime
+  validFrom: ISO-8601-datetime
+  validUntil: ISO-8601-datetime | null
+  recordedAt: ISO-8601-datetime
   ttl: ISO-8601-duration
   decay:
     model: none|linear|exponential|step
     halfLife: ISO-8601-duration
     strength: 0.0-1.0
-  access_count: integer
-  last_accessed: ISO-8601-datetime
+  accessCount: integer
+  lastAccessed: ISO-8601-datetime
 
 provenance:
   sourceType: user_explicit|user_implicit|agent_inferred|external_import|system_generated
@@ -2189,9 +2053,9 @@ provenance:
 
 embedding:
   model: string
-  model_version: string
+  modelVersion: string
   dimensions: integer
-  source_text: string
+  sourceText: string
 
 extensions:
   provider_name:
@@ -2203,17 +2067,17 @@ extensions:
 
 ## Appendix B: Relationship Types Quick Reference
 
-| Markdown Syntax | JSON-LD relationshipType | Description |
-|-----------------|-------------------------|-------------|
-| `[[X]]` | `RelatesTo` | General relationship |
-| `[[X\|derived-from]]` | `DerivedFrom` | Created from source |
-| `[[X\|supersedes]]` | `Supersedes` | Replaces older |
-| `[[X\|conflicts-with]]` | `ConflictsWith` | Contradicts |
-| `[[X\|part-of]]` | `PartOf` | Component of |
-| `[[X\|implements]]` | `Implements` | Realizes |
-| `[[X\|uses]]` | `Uses` | Utilizes |
-| `[[X\|created-by]]` | `Created` | Authored by |
-| `[[X\|mentioned-in]]` | `MentionedIn` | Referenced in |
+| Markdown Syntax | JSON-LD `type` | Description |
+|-----------------|----------------|-------------|
+| `[[X]]` | `relates-to` | General relationship |
+| `[[X\|derived-from]]` | `derived-from` | Created from source |
+| `[[X\|supersedes]]` | `supersedes` | Replaces older |
+| `[[X\|conflicts-with]]` | `conflicts-with` | Contradicts |
+| `[[X\|part-of]]` | `part-of` | Component of |
+| `[[X\|implements]]` | `implements` | Realizes |
+| `[[X\|uses]]` | `uses` | Utilizes |
+| `[[X\|created-by]]` | `created-by` | Authored by |
+| `[[X\|mentioned-in]]` | `mentioned-in` | Referenced in |
 
 ---
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1754,10 +1754,10 @@ root of this repository and is served at:
 https://mif-spec.dev/schema/context.jsonld
 ```
 
-That file is the normative definition of all term mappings for MIF documents.
-Implementations MUST dereference the context URL rather than inlining a local
-copy. The context is versioned alongside the schema; breaking changes to term
-mappings require a new major version of the specification.
+That file defines the JSON-LD term mappings for MIF documents. Implementations
+MUST dereference the context URL rather than inlining a local copy. The context
+is versioned alongside the schema; breaking changes to term mappings require a
+new major version of the specification.
 
 ---
 

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -29,11 +29,11 @@ MIF uses three base memory types. When migrating, map provider-specific categori
 | `episodic` | Events, sessions, incidents, conversations | `episode`, `event`, `session`, `conversation` |
 | `procedural` | Processes, runbooks, patterns, how-to | `pattern`, `procedure`, `workflow`, `template` |
 
-**Key Principle:** The `memoryType` field uses one of the three base types, while specific categorization is expressed through the `namespace` field:
+**Key Principle:** The `conceptType` field uses one of the three base types, while specific categorization is expressed through the `namespace` field:
 
 ```json
 {
-  "memoryType": "semantic",
+  "conceptType": "semantic",
   "namespace": "_semantic/decisions"
 }
 ```
@@ -69,7 +69,7 @@ Mem0 stores memories as JSON objects:
 | `id` | `@id` | Prefix with `urn:mif:` |
 | `memory` | `content` | Direct mapping |
 | `user_id` | `namespace` | Use base type prefix (e.g., `_semantic/preferences`) |
-| `metadata.category` | `memoryType` | Map to base types (`semantic`, `episodic`, `procedural`) |
+| `metadata.category` | `conceptType` | Map to base types (`semantic`, `episodic`, `procedural`) |
 | `metadata.category` | `namespace` (second part) | Preserve as namespace suffix (e.g., `_semantic/{category}`) |
 | `metadata.created_at` | `created` | Direct mapping |
 | `metadata.*` | `extensions.mem0.*` | Preserve in extensions |
@@ -85,7 +85,7 @@ import uuid
 def mem0_to_mif(mem0_data: dict) -> dict:
     """Convert Mem0 memory to MIF format with base memory types."""
 
-    # Map category to base memoryType and namespace
+    # Map category to base conceptType and namespace
     # MIF uses semantic/episodic/procedural as base types
     # Specific categorization is expressed via namespace
     category_map = {
@@ -106,9 +106,9 @@ def mem0_to_mif(mem0_data: dict) -> dict:
     # Build MIF document
     mif = {
         "@context": "https://mif-spec.dev/schema/context.jsonld",
-        "@type": "Memory",
+        "@type": "Concept",
         "@id": f"urn:mif:{mem0_data['id']}",
-        "memoryType": memory_type,
+        "conceptType": memory_type,
         "content": mem0_data["memory"],
         "created": mem0_data.get("metadata", {}).get(
             "created_at",
@@ -228,9 +228,9 @@ def zep_to_mif(zep_data: dict) -> dict:
 
     mif = {
         "@context": "https://mif-spec.dev/schema/context.jsonld",
-        "@type": "Memory",
+        "@type": "Concept",
         "@id": f"urn:mif:{zep_data['uuid']}",
-        "memoryType": "semantic",  # Default to semantic for factual memories
+        "conceptType": "semantic",  # Default to semantic for factual memories
         "content": zep_data["content"],
         "created": zep_data["created_at"],
         "namespace": "_semantic/knowledge",  # Categorize via namespace
@@ -250,11 +250,8 @@ def zep_to_mif(zep_data: dict) -> dict:
         mif["relationships"] = []
         for edge in zep_data["entity_edges"]:
             mif["relationships"].append({
-                "@type": "Relationship",
-                "relationshipType": map_zep_relation(edge["relation"]),
-                "target": {
-                    "@id": f"urn:mif:entity:{edge['target'].replace(':', '-')}"
-                },
+                "type": map_zep_relation(edge["relation"]),
+                "target": f"urn:mif:entity:{edge['target'].replace(':', '-')}",
                 "metadata": {
                     "source": edge["source"],
                     "original_relation": edge["relation"]
@@ -276,13 +273,13 @@ def zep_to_mif(zep_data: dict) -> dict:
 def map_zep_relation(relation: str) -> str:
     """Map Zep relation types to MIF relationship types."""
     mapping = {
-        "prefers": "RelatesTo",
-        "uses": "Uses",
-        "knows": "RelatesTo",
-        "created": "Created",
-        "part_of": "PartOf",
+        "prefers": "relates-to",
+        "uses": "uses",
+        "knows": "relates-to",
+        "created": "created",
+        "part_of": "part-of",
     }
-    return mapping.get(relation, "RelatesTo")
+    return mapping.get(relation, "relates-to")
 ```
 
 ---
@@ -344,9 +341,9 @@ def letta_to_mif(letta_data: dict) -> list:
             memory_type, namespace = classify_fact(fact)
             mif = {
                 "@context": "https://mif-spec.dev/schema/context.jsonld",
-                "@type": "Memory",
+                "@type": "Concept",
                 "@id": f"urn:mif:letta-{block_name}-{i}",
-                "memoryType": memory_type,
+                "conceptType": memory_type,
                 "content": fact,
                 "created": datetime.now(timezone.utc).isoformat() + "Z",
                 "namespace": namespace,
@@ -436,7 +433,7 @@ Subcog format is closest to MIF (MIF was partially inspired by Subcog):
 |--------------|-----------|-------|
 | `id` | `@id` | Prefix with `urn:mif:` |
 | `content` | `content` | Direct mapping |
-| `namespace` | `memoryType` + `namespace` | Map to base type and MIF namespace |
+| `namespace` | `conceptType` + `namespace` | Map to base type and MIF namespace |
 | `domain` | `extensions.subcog.domain` | Preserved in extensions |
 | `tags` | `tags` | Direct mapping |
 | `created_at` | `created` | Direct mapping |
@@ -450,7 +447,7 @@ from datetime import datetime, timezone
 def subcog_to_mif(subcog_data: dict) -> dict:
     """Convert Subcog memory to MIF format with base memory types."""
 
-    # Map Subcog namespace to base memoryType and MIF namespace
+    # Map Subcog namespace to base conceptType and MIF namespace
     namespace_map = {
         "decisions": ("semantic", "_semantic/decisions"),
         "patterns": ("procedural", "_procedural/patterns"),
@@ -470,9 +467,9 @@ def subcog_to_mif(subcog_data: dict) -> dict:
 
     mif = {
         "@context": "https://mif-spec.dev/schema/context.jsonld",
-        "@type": "Memory",
+        "@type": "Concept",
         "@id": f"urn:mif:{subcog_data['id']}",
-        "memoryType": memory_type,
+        "conceptType": memory_type,
         "content": subcog_data["content"],
         "created": subcog_data.get("created_at", datetime.now(timezone.utc).isoformat() + "Z"),
         "namespace": mif_namespace,
@@ -550,9 +547,9 @@ def text_to_mif(text_file: str) -> list:
 
         mif = {
             "@context": "https://mif-spec.dev/schema/context.jsonld",
-            "@type": "Memory",
+            "@type": "Concept",
             "@id": f"urn:mif:import-{uuid.uuid4()}",
-            "memoryType": "semantic",  # Base memory type
+            "conceptType": "semantic",  # Base concept type
             "namespace": "_semantic/preferences" if ":" in line else "_semantic/knowledge",
             "content": content,
             "created": datetime.now(timezone.utc).isoformat() + "Z",
@@ -625,9 +622,9 @@ def langmem_to_mif(langmem_data: dict) -> list:
 
         mif = {
             "@context": "https://mif-spec.dev/schema/context.jsonld",
-            "@type": "Memory",
+            "@type": "Concept",
             "@id": f"urn:mif:{mem['id']}",
-            "memoryType": memory_type,
+            "conceptType": memory_type,
             "namespace": namespace,
             "content": mem["text"],
             "created": mem.get("metadata", {}).get(
@@ -640,9 +637,8 @@ def langmem_to_mif(langmem_data: dict) -> list:
         if mem["id"] in relationships:
             mif["relationships"] = [
                 {
-                    "@type": "Relationship",
-                    "relationshipType": map_langmem_relation(rel["type"]),
-                    "target": {"@id": f"urn:mif:{rel['target']}"}
+                    "type": map_langmem_relation(rel["type"]),
+                    "target": f"urn:mif:{rel['target']}"
                 }
                 for rel in relationships[mem["id"]]
             ]
@@ -672,12 +668,12 @@ def map_langmem_type(langmem_type: str) -> tuple:
 def map_langmem_relation(relation: str) -> str:
     """Map LangMem relation to MIF relationship type."""
     mapping = {
-        "related": "RelatesTo",
-        "derived": "DerivedFrom",
-        "supersedes": "Supersedes",
-        "conflicts": "ConflictsWith",
+        "related": "relates-to",
+        "derived": "derived-from",
+        "supersedes": "supersedes",
+        "conflicts": "conflicts-with",
     }
-    return mapping.get(relation, "RelatesTo")
+    return mapping.get(relation, "relates-to")
 ```
 
 ---
@@ -699,7 +695,7 @@ done
 
 If validation fails for missing fields, ensure:
 - `@context` is set to `"https://mif-spec.dev/schema/context.jsonld"`
-- `@type` is `"Memory"`
+- `@type` is `"Concept"`
 - `@id` starts with `urn:mif:`
 - `created` is a valid ISO 8601 datetime
 

--- a/docs/SCHEMA-REFERENCE.md
+++ b/docs/SCHEMA-REFERENCE.md
@@ -30,7 +30,7 @@ All schemas use JSON Schema Draft 2020-12.
 | Field | Type | Description |
 |-------|------|-------------|
 | `@context` | string/array/object | JSON-LD context |
-| `@type` | `"Concept"` or `"Memory"` (or array containing `"Concept"`) | Document type; the projection emits `"Concept"` |
+| `@type` | `"Concept"` (or array containing `"Concept"`) | Document type |
 | `@id` | string (pattern: `^urn:mif:`) | Unique identifier |
 | `conceptType` | enum | Knowledge taxonomy classification |
 | `content` | string (minLength: 1) | Memory content |
@@ -123,9 +123,8 @@ Ontologies can define extended types that map to these base types via namespace 
 ```json
 "relationships": [
   {
-    "@type": "Relationship",
-    "relationshipType": "DerivedFrom",
-    "target": { "@id": "urn:mif:memory:source-id" },
+    "type": "derived-from",
+    "target": "urn:mif:memory:source-id",
     "strength": 0.9,
     "metadata": { "reason": "Extracted insight" }
   }
@@ -134,9 +133,8 @@ Ontologies can define extended types that map to these base types via namespace 
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `@type` | Yes | Must be `"Relationship"` |
-| `relationshipType` | Yes | See relationship types below |
-| `target` | Yes | Object with `@id` (pattern: `^urn:mif:`) |
+| `type` | Yes | Kebab-case token (e.g. `derived-from`); optional `ns:` prefix |
+| `target` | Yes | String path or URN identifying the related concept |
 | `strength` | No | 0.0-1.0 relationship strength |
 | `metadata` | No | Additional properties |
 
@@ -144,15 +142,15 @@ Ontologies can define extended types that map to these base types via namespace 
 
 | Type | Description |
 |------|-------------|
-| `RelatesTo` | General relationship |
-| `DerivedFrom` | Created based on source |
-| `Supersedes` | Replaces older memory |
-| `ConflictsWith` | Contradicts another memory |
-| `PartOf` | Component of larger whole |
-| `Implements` | Realizes a concept/pattern |
-| `Uses` | Utilizes a technology/tool |
-| `Created` | Authored by entity |
-| `MentionedIn` | Referenced in memory |
+| `relates-to` | General relationship |
+| `derived-from` | Created based on source |
+| `supersedes` | Replaces older memory |
+| `conflicts-with` | Contradicts another memory |
+| `part-of` | Component of larger whole |
+| `implements` | Realizes a concept/pattern |
+| `uses` | Utilizes a technology/tool |
+| `created` | Authored by entity |
+| `mentioned-in` | Referenced in memory |
 
 #### Temporal Metadata
 
@@ -189,12 +187,12 @@ Ontologies can define extended types that map to these base types via namespace 
 
 **Reinforcement History Entry:**
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `date` | date-time | When reinforcement occurred |
-| `source` | string | What triggered the reinforcement |
-| `delta` | number | Strength change amount |
-| `newStrength` | number | Strength after reinforcement |
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `timestamp` | Yes | date-time | When reinforcement occurred |
+| `event` | Yes | string | What triggered the reinforcement |
+| `strengthDelta` | No | number | Strength change amount |
+| `context` | No | string | Additional context about the reinforcement |
 
 **Recommended Half-Life Values:**
 
@@ -516,7 +514,7 @@ jsonschema.validate(document, schema)
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `@id must match pattern` | Invalid URN format | Use `urn:mif:` prefix |
-| `memoryType must be equal to one of` | Invalid type | Use valid memory type |
+| `conceptType must be equal to one of` | Invalid type | Use valid concept type |
 | `created must match format date-time` | Bad timestamp | Use ISO 8601 format |
 | `namespace must match pattern` | Invalid namespace | Use alphanumeric with `/` separators |
 
@@ -524,7 +522,7 @@ jsonschema.validate(document, schema)
 
 ## Schema URLs
 
-Production schemas will be available at:
+Production schemas are available at:
 
 - `https://mif-spec.dev/schema/mif.schema.json`
 - `https://mif-spec.dev/schema/citation.schema.json`

--- a/docs/SCHEMA-REFERENCE.md
+++ b/docs/SCHEMA-REFERENCE.md
@@ -30,7 +30,7 @@ All schemas use JSON Schema Draft 2020-12.
 | Field | Type | Description |
 |-------|------|-------------|
 | `@context` | string/array/object | JSON-LD context |
-| `@type` | `"Concept"` (or array containing `"Concept"`) | Document type |
+| `@type` | `"Concept"` (or array containing `"Concept"`; the deprecated alias `"Memory"` is also accepted) | Document type |
 | `@id` | string (pattern: `^urn:mif:`) | Unique identifier |
 | `conceptType` | enum | Knowledge taxonomy classification |
 | `content` | string (minLength: 1) | Memory content |
@@ -149,7 +149,7 @@ Ontologies can define extended types that map to these base types via namespace 
 | `part-of` | Component of larger whole |
 | `implements` | Realizes a concept/pattern |
 | `uses` | Utilizes a technology/tool |
-| `created` | Authored by entity |
+| `created-by` | Authored by entity |
 | `mentioned-in` | Referenced in memory |
 
 #### Temporal Metadata

--- a/profiles/ai-memory/SPECIFICATION.md
+++ b/profiles/ai-memory/SPECIFICATION.md
@@ -122,9 +122,9 @@ Tuning guidance:
   than a stable `observation`. Apply a shorter half-life (e.g. P7D) to episodic
   memories and a longer one (e.g. P30D) to semantic facts.
 - **Access reinforces.** Each recall MAY reset or slow decay by updating
-  `last_reinforced` and incrementing `access_count`, analogous to spaced
+  `lastReinforced` and incrementing `accessCount`, analogous to spaced
   repetition strengthening a memory trace. This is why the `recallable` trait
-  carries `access_count` and `last_accessed`.
+  carries `accessCount` and `lastAccessed`.
 - **High-velocity environments forget faster.** Shorten half-lives where context
   churns quickly; lengthen them for stable domains.
 
@@ -132,17 +132,17 @@ Tuning guidance:
 
 ```yaml
 temporal:
-  valid_from: 2026-01-15T00:00:00Z
-  valid_until: null
-  recorded_at: 2026-01-15T10:30:00Z
+  validFrom: 2026-01-15T00:00:00Z
+  validUntil: null
+  recordedAt: 2026-01-15T10:30:00Z
   ttl: P90D
   decay:
     model: exponential
     halfLife: P7D          # forgetting-curve half-life
     strength: 0.85
-    last_reinforced: 2026-01-18T09:00:00Z
-  access_count: 5
-  last_accessed: 2026-01-20T14:22:00Z
+    lastReinforced: 2026-01-18T09:00:00Z
+  accessCount: 5
+  lastAccessed: 2026-01-20T14:22:00Z
 ```
 
 **References**
@@ -187,24 +187,24 @@ purpose: **similarity recall** — finding the memories most relevant to the
 agent's current context.
 
 The `recallable` trait in [`./ontology.yaml`](./ontology.yaml) adds
-`embedding_model` and `embedding_source_text` alongside `access_count` and
-`last_accessed`. Profile guidance:
+`model` and `sourceText` alongside `accessCount` and
+`lastAccessed`. Profile guidance:
 
-- Embed the `source_text` that best represents *what the agent would search for*,
+- Embed the `sourceText` that best represents *what the agent would search for*,
   not necessarily the full stored content. For a session, that is usually the
   `summary`; for an observation, the `statement`.
 - Recall ranking SHOULD combine embedding similarity with decay `strength`: a
   highly similar but heavily-decayed memory is less useful than a fresh one. A
   simple composite is `score = similarity * strength`.
 - Re-embedding on import (per core §11.1) is expected when migrating between
-  models; only the metadata and `source_text` need survive.
+  models; only the metadata and `sourceText` need survive.
 
 ```yaml
 embedding:
   model: text-embedding-3-small
-  model_version: "2024-01"
+  modelVersion: "2024-01"
   dimensions: 1536
-  source_text: "User prefers dark mode"
+  sourceText: "User prefers dark mode"
   normalized: true
 ```
 
@@ -236,7 +236,7 @@ Mem0 stores flat memories with a free-form `metadata.category`.
     "@context": "https://mif-spec.dev/schema/context.jsonld",
     "@id": "urn:mif:mem0_123",                 # id -> @id
     "content": "User prefers dark mode",       # memory -> content
-    "memoryType": "semantic",                  # a preference is a known fact
+    "conceptType": "semantic",                  # a preference is a known fact
     "namespace": "_semantic/preferences",      # base type + category
     "created": "2026-01-15T10:30:00Z",         # created_at -> created
     "extensions": {
@@ -296,13 +296,13 @@ memory per fact so decay and recall apply at the right granularity.
 # MIF mapping (one memory per fact)
 {
     "@id": "urn:mif:letta-human-name",
-    "memoryType": "semantic",
+    "conceptType": "semantic",
     "content": "Name: Alice",
     "namespace": "_semantic/entities"
 },
 {
     "@id": "urn:mif:letta-human-pref",
-    "memoryType": "semantic",
+    "conceptType": "semantic",
     "content": "Prefers dark mode",
     "namespace": "_semantic/preferences"
 }
@@ -328,7 +328,7 @@ namespace with its triad base type.
 {
     "@id": "urn:mif:subcog_abc",
     "content": "Decision: Use React",
-    "memoryType": "semantic",                  # a decision is known knowledge
+    "conceptType": "semantic",                  # a decision is known knowledge
     "namespace": "_semantic/decisions",        # base prefix + category
     "tags": ["frontend"],
     "created": "2026-01-15T10:30:00Z"
@@ -360,8 +360,8 @@ created: 2026-01-15T10:30:00Z
 ontology:
   id: ai-memory
 relationships:
-  - target: urn:mif:entity:auth-service   # [[Auth Service]] -> relates_to
-    relationshipType: RelatesTo
+  - type: relates-to
+    target: urn:mif:entity:auth-service   # [[Auth Service]] -> relates_to
 ---
 The auth timeout was caused by JWT clock skew producing 401s.
 ```
@@ -380,8 +380,8 @@ core-spec conformance:
    `procedural` triad.
 2. It applies an exponential (forgetting-curve) decay model by default to
    un-reinforced memories, with per-type half-lives per §3.2.
-3. It updates `access_count` / `last_accessed` (and MAY update
-   `last_reinforced`) on each recall.
+3. It updates `accessCount` / `lastAccessed` (and MAY update
+   `lastReinforced`) on each recall.
 4. It uses recall-oriented embedding metadata per §5 for similarity retrieval.
 
 Profile conformance is independent of which ontology entity types are used; an

--- a/profiles/ai-memory/SPECIFICATION.md
+++ b/profiles/ai-memory/SPECIFICATION.md
@@ -186,9 +186,10 @@ and is deliberately model-agnostic. This profile uses that mechanism for one
 purpose: **similarity recall** — finding the memories most relevant to the
 agent's current context.
 
-The `recallable` trait in [`./ontology.yaml`](./ontology.yaml) adds
-`model` and `sourceText` alongside `accessCount` and
-`lastAccessed`. Profile guidance:
+The `recallable` trait in [`./ontology.yaml`](./ontology.yaml) carries
+access-frequency and last-access metadata together with an embedding reference;
+in the JSON-LD projection these correspond to the schema's `accessCount`/`lastAccessed`
+and `model`/`sourceText`. Profile guidance:
 
 - Embed the `sourceText` that best represents *what the agent would search for*,
   not necessarily the full stored content. For a session, that is usually the
@@ -361,7 +362,7 @@ ontology:
   id: ai-memory
 relationships:
   - type: relates-to
-    target: urn:mif:entity:auth-service   # [[Auth Service]] -> relates_to
+    target: urn:mif:entity:auth-service   # [[Auth Service]] -> relates-to
 ---
 The auth timeout was caused by JWT clock skew producing 401s.
 ```

--- a/profiles/ai-memory/examples/level-3-citations.md
+++ b/profiles/ai-memory/examples/level-3-citations.md
@@ -34,9 +34,9 @@ temporal:
   accessCount: 12
   lastAccessed: '2026-01-22T15:30:00Z'
 provenance:
-  source_ref: meeting:arch-review-2026-01-20
+  sourceRef: meeting:arch-review-2026-01-20
   agent: claude-3-opus
-  agent_version: '20240229'
+  agentVersion: '20240229'
   confidence: 0.98
   sourceType: user_explicit
   trustLevel: verified


### PR DESCRIPTION
Epic #103: align the reference docs and the AI-memory profile spec with the canonical schema.

## Changes
- `conceptType` (not the deprecated `memoryType`) and `@type: Concept` in JSON-LD examples.
- Relationship objects use `type` (kebab, optional `ns:` prefix) + `target` (string); dropped `@type`/`relationshipType`/object-`target` everywhere, including the §8.5 properties table.
- camelCase `TemporalMetadata`/`EmbeddingReference` keys throughout; canonical provenance names; `reinforcementHistory` fields (`timestamp`, `event`, `strengthDelta`, `context`).
- `SPECIFICATION.md`: `mif_version` 1.0.0; §14.2 inline JSON-LD context replaced with a normative pointer to `schema/context.jsonld` (it was diverging from the canonical context).
- `docs/SCHEMA-REFERENCE.md`, `docs/MIGRATION-GUIDE.md` (converter outputs), `profiles/ai-memory/SPECIFICATION.md`, and `profiles/ai-memory/examples/level-3-citations.md` (camelCase provenance keys).

## Scope note
The Bucket A audit under-flagged the pervasive snake_case / `relationshipType` examples in `SPECIFICATION.md`; this PR covers all same-class occurrences (the sub-issues named only a subset). The `memoryType` references that remain in `docs/SCHEMA-REFERENCE.md` are the intentional deprecated-alias documentation.

## Verification
Gate replay green: `okf_validate.py`, `mif_convert.py roundtrip` (lossless), and `emit-jsonld` + `ajv` against `schema/mif.schema.json` for all projections. Local impartial review converged (2 rounds, 0 must-fix / 0 should-fix).

Closes #120, #121, #122, #123, #124, #125
