### PR TITLE
docs: fix ajv validation commands and runtime versions (epic #104)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,13 @@ Help grow the ecosystem by building:
 Use the provided schemas to validate your implementations:
 
 ```bash
-# Validate MIF documents
-npx ajv validate -s schema/mif.schema.json -d your-memory.json
+# Validate the JSON-LD projection of a MIF document
+npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
+  -d your-memory.json --spec=draft2020 -c ajv-formats
 
 # Validate citations
-npx ajv validate -s schema/citation.schema.json -d citation.json
+npx ajv validate -s schema/citation.schema.json -r "schema/definitions/*.schema.json" \
+  -d citation.json --spec=draft2020 -c ajv-formats
 ```
 
 ## Specification Change Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Help grow the ecosystem by building:
 Use the provided schemas to validate your implementations:
 
 ```bash
+# Requires: npm install -g ajv-cli ajv-formats
 # Validate the JSON-LD projection of a MIF document
 npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
   -d your-memory.json --spec=draft2020 -c ajv-formats

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ Use the provided schemas to validate your implementations:
 
 ```bash
 # Requires: npm install -g ajv-cli ajv-formats
-# Validate the JSON-LD projection of a MIF document
+# Validate the JSON-LD projection of a MIF document.
+# The converter emits .jsonld; ajv-cli reads .json, so validate a .json copy.
 npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
   -d your-memory.json --spec=draft2020 -c ajv-formats
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ python scripts/okf_validate.py
 python scripts/mif_convert.py roundtrip examples profiles/ai-memory/examples
 
 # JSON Schema validation of the JSON-LD projection (ajv-cli reads .json)
+# Requires: npm install -g ajv-cli ajv-formats
 npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
   -d your-concept.json --spec=draft2020 -c ajv-formats
 ```

--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ python scripts/okf_validate.py
 # Lossless markdown -> json-ld -> markdown round trip
 python scripts/mif_convert.py roundtrip examples profiles/ai-memory/examples
 
-# JSON Schema validation of the JSON-LD projection
-npx ajv validate -s schema/mif.schema.json -d your-concept.jsonld
+# JSON Schema validation of the JSON-LD projection (ajv-cli reads .json)
+npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
+  -d your-concept.json --spec=draft2020 -c ajv-formats
 ```
 
 See [docs/okf-conformance.md](./docs/okf-conformance.md) for the pinned OKF v0.1

--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ python scripts/okf_validate.py
 # Lossless markdown -> json-ld -> markdown round trip
 python scripts/mif_convert.py roundtrip examples profiles/ai-memory/examples
 
-# JSON Schema validation of the JSON-LD projection (ajv-cli reads .json)
+# JSON Schema validation of the JSON-LD projection.
+# The converter emits .jsonld; ajv-cli reads .json, so validate a .json copy
+# (e.g. cp your-concept.jsonld your-concept.json).
 # Requires: npm install -g ajv-cli ajv-formats
 npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
   -d your-concept.json --spec=draft2020 -c ajv-formats

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -355,11 +355,18 @@ for (const file of fs.readdirSync(defsDir)) {
 }
 
 const validateMif = ajv.compile(JSON.parse(fs.readFileSync('schema/mif.schema.json')));
+const validateCitation = ajv.compile(JSON.parse(fs.readFileSync('schema/citation.schema.json')));
 
 // Validate a derived JSON-LD projection (produced by scripts/mif_convert.py emit-jsonld)
 const document = JSON.parse(fs.readFileSync('memory.json'));
 if (!validateMif(document)) {
-  console.log('Validation errors:', validateMif.errors);
+  console.log('MIF validation errors:', validateMif.errors);
+}
+
+// Validate a citation object
+const citation = JSON.parse(fs.readFileSync('citation.json'));
+if (!validateCitation(citation)) {
+  console.log('Citation validation errors:', validateCitation.errors);
 }
 ```
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -338,24 +338,27 @@ def validate_ontology(ontology: dict) -> bool:
 ### Using ajv (JavaScript/Node.js)
 
 ```javascript
-const Ajv = require('ajv');
+const Ajv2020 = require('ajv/dist/2020');
+const addFormats = require('ajv-formats');
 const fs = require('fs');
+const path = require('path');
 
-const ajv = new Ajv({ allErrors: true });
+const ajv = new Ajv2020({ allErrors: true });
+addFormats(ajv);
 
-// Load schemas
-const mifSchema = JSON.parse(fs.readFileSync('schema/mif.schema.json'));
-const citationSchema = JSON.parse(fs.readFileSync('schema/citation.schema.json'));
+// Register the referenced definition schemas so $refs resolve
+const defsDir = 'schema/definitions';
+for (const file of fs.readdirSync(defsDir)) {
+  if (file.endsWith('.schema.json')) {
+    ajv.addSchema(JSON.parse(fs.readFileSync(path.join(defsDir, file))));
+  }
+}
 
-// Compile validators
-const validateMif = ajv.compile(mifSchema);
-const validateCitation = ajv.compile(citationSchema);
+const validateMif = ajv.compile(JSON.parse(fs.readFileSync('schema/mif.schema.json')));
 
-// Validate a document
+// Validate a derived JSON-LD projection (produced by scripts/mif_convert.py emit-jsonld)
 const document = JSON.parse(fs.readFileSync('memory.json'));
-const valid = validateMif(document);
-
-if (!valid) {
+if (!validateMif(document)) {
   console.log('Validation errors:', validateMif.errors);
 }
 ```
@@ -517,7 +520,7 @@ convert_file(Path("ontology.yaml"))
 
 | MIF Version | Python | Node.js | JSON Schema Draft |
 |-------------|--------|---------|-------------------|
-| 0.1.x | 3.8+ | 16+ | 2020-12 |
+| 1.0.x | 3.10+ | 22+ | 2020-12 |
 
 ---
 

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -357,8 +357,9 @@ for (const file of fs.readdirSync(defsDir)) {
 const validateMif = ajv.compile(JSON.parse(fs.readFileSync('schema/mif.schema.json')));
 const validateCitation = ajv.compile(JSON.parse(fs.readFileSync('schema/citation.schema.json')));
 
-// Validate a derived JSON-LD projection (produced by scripts/mif_convert.py emit-jsonld)
-const document = JSON.parse(fs.readFileSync('memory.json'));
+// Validate a derived JSON-LD projection (produced by scripts/mif_convert.py emit-jsonld).
+// Node reads .jsonld directly (unlike ajv-cli, which needs a .json file).
+const document = JSON.parse(fs.readFileSync('memory.jsonld'));
 if (!validateMif(document)) {
   console.log('MIF validation errors:', validateMif.errors);
 }

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -291,7 +291,7 @@ npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json"
 npx ajv validate -s schema/citation.schema.json -r "schema/definitions/*.schema.json" \
   -d citation.json --spec=draft2020 -c ajv-formats
 
-# Validate an ontology (ajv-cli does not read YAML; use the project validator)
+# Validate all ontology files (ajv-cli does not read YAML; use the project validator)
 python scripts/validate-ontologies.py
 ```
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -283,7 +283,8 @@ Validate MIF documents using JSON Schema:
 # Install ajv-cli + ajv-formats
 npm install -g ajv-cli ajv-formats
 
-# Validate the JSON-LD projection of a memory (ajv-cli reads .json)
+# Validate the JSON-LD projection of a memory.
+# The converter emits .jsonld; ajv-cli reads .json, so validate a .json copy.
 npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
   -d my-memory.json --spec=draft2020 -c ajv-formats
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -280,17 +280,19 @@ For machine processing, use JSON-LD:
 Validate MIF documents using JSON Schema:
 
 ```bash
-# Install ajv-cli
-npm install -g ajv-cli
+# Install ajv-cli + ajv-formats
+npm install -g ajv-cli ajv-formats
 
-# Validate a memory
-npx ajv validate -s schema/mif.schema.json -d my-memory.json
+# Validate the JSON-LD projection of a memory (ajv-cli reads .json)
+npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
+  -d my-memory.json --spec=draft2020 -c ajv-formats
 
 # Validate a citation
-npx ajv validate -s schema/citation.schema.json -d citation.json
+npx ajv validate -s schema/citation.schema.json -r "schema/definitions/*.schema.json" \
+  -d citation.json --spec=draft2020 -c ajv-formats
 
-# Validate an ontology
-npx ajv validate -s schema/ontology/ontology.schema.json -d ontology.yaml
+# Validate an ontology (ajv-cli does not read YAML; use the project validator)
+python scripts/validate-ontologies.py
 ```
 
 ## Converting Ontologies

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -683,9 +683,10 @@ def map_langmem_relation(relation: str) -> str:
 After migrating, validate your MIF documents:
 
 ```bash
-# Validate all migrated memories
+# Validate all migrated memories (requires: npm install -g ajv-cli ajv-formats)
 for f in memories/*.json; do
-  npx ajv validate -s schema/mif.schema.json -d "$f" || echo "FAILED: $f"
+  npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
+    -d "$f" --spec=draft2020 -c ajv-formats || echo "FAILED: $f"
 done
 ```
 

--- a/docs/SCHEMA-REFERENCE.md
+++ b/docs/SCHEMA-REFERENCE.md
@@ -479,16 +479,19 @@ discovery:
 
 ```bash
 # Install
-npm install -g ajv-cli
+npm install -g ajv-cli ajv-formats
 
-# Validate MIF document
-npx ajv validate -s schema/mif.schema.json -d memory.json
+# Validate MIF document (ajv-cli reads .json)
+npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
+  -d memory.json --spec=draft2020 -c ajv-formats
 
 # Validate with verbose output
-npx ajv validate -s schema/mif.schema.json -d memory.json --verbose
+npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
+  -d memory.json --spec=draft2020 -c ajv-formats --verbose
 
 # Validate multiple files
-npx ajv validate -s schema/mif.schema.json -d "memories/*.json"
+npx ajv validate -s schema/mif.schema.json -r "schema/definitions/*.schema.json" \
+  -d "memories/*.json" --spec=draft2020 -c ajv-formats
 ```
 
 ### Using Python

--- a/public/schema/ontology/README.md
+++ b/public/schema/ontology/README.md
@@ -28,7 +28,7 @@ JSON-LD context for semantic web compatibility. Maps ontology concepts to:
 
 ```bash
 # Using ajv-cli (ajv reads JSON, so convert the YAML first)
-yq -o=json '.' ../../ontologies/mif-base.ontology.yaml > /tmp/ontology.json
+yq -o=json '.' ../../../ontologies/mif-base.ontology.yaml > /tmp/ontology.json
 npx ajv validate -s ontology.schema.json -d /tmp/ontology.json --spec=draft2020 -c ajv-formats
 
 # Using Python jsonschema
@@ -38,7 +38,7 @@ from jsonschema import validate
 
 with open('ontology.schema.json') as f:
     schema = json.load(f)
-with open('../../ontologies/mif-base.ontology.yaml') as f:
+with open('../../../ontologies/mif-base.ontology.yaml') as f:
     data = yaml.safe_load(f)
 validate(data, schema)
 print('Valid!')
@@ -48,7 +48,7 @@ print('Valid!')
 ### Converting to JSON-LD
 
 ```bash
-python ../../scripts/yaml2jsonld.py ../../ontologies/mif-base.ontology.yaml
+python ../../../scripts/yaml2jsonld.py ../../../ontologies/mif-base.ontology.yaml
 ```
 
 ## Schema Evolution

--- a/public/schema/ontology/README.md
+++ b/public/schema/ontology/README.md
@@ -27,8 +27,9 @@ JSON-LD context for semantic web compatibility. Maps ontology concepts to:
 ### Validating an ontology file
 
 ```bash
-# Using ajv-cli
-npx ajv validate -s ontology.schema.json -d ../../ontologies/mif-base.ontology.yaml
+# Using ajv-cli (ajv reads JSON, so convert the YAML first)
+yq -o=json '.' ../../ontologies/mif-base.ontology.yaml > /tmp/ontology.json
+npx ajv validate -s ontology.schema.json -d /tmp/ontology.json --spec=draft2020 -c ajv-formats
 
 # Using Python jsonschema
 python -c "

--- a/public/schema/ontology/README.md
+++ b/public/schema/ontology/README.md
@@ -28,6 +28,7 @@ JSON-LD context for semantic web compatibility. Maps ontology concepts to:
 
 ```bash
 # Using ajv-cli (ajv reads JSON, so convert the YAML first)
+# Requires: npm install -g ajv-cli ajv-formats
 yq -o=json '.' ../../../ontologies/mif-base.ontology.yaml > /tmp/ontology.json
 npx ajv validate -s ontology.schema.json -d /tmp/ontology.json --spec=draft2020 -c ajv-formats
 

--- a/schema/ontology/README.md
+++ b/schema/ontology/README.md
@@ -41,9 +41,9 @@ with open('ontology.schema.json') as s, open('../../ontologies/mif-base.ontology
 print('Valid')
 "
 
-# ajv validation (requires JSON conversion)
+# ajv validation (requires JSON conversion; npm install -g ajv-cli ajv-formats)
 yq -o=json '.' ../../ontologies/mif-base.ontology.yaml | \
-  npx ajv validate -s ontology.schema.json -d /dev/stdin
+  npx ajv validate -s ontology.schema.json -d /dev/stdin --spec=draft2020 -c ajv-formats
 ```
 
 ### Converting to JSON-LD


### PR DESCRIPTION
Epic #104: fix the documented validation commands and runtime versions.

## Changes
- `ajv` commands now validate the emitted JSON-LD projection as `.json` (ajv-cli does not read `.jsonld`) with the required flags: `-r "schema/definitions/*.schema.json" --spec=draft2020 -c ajv-formats` (citation.schema.json `$ref`s a definition, so it needs `-r` too).
- Ontology validation: use `python scripts/validate-ontologies.py` (ajv-cli cannot read YAML); the ontology README's ajv path pre-converts with `yq`.
- `npm install -g ajv-cli ajv-formats` documented wherever the `-c ajv-formats` commands appear.
- API-REFERENCE: JS example upgraded to Ajv 8 (`ajv/dist/2020`) + `ajv-formats` + registered definition schemas; version row `1.0.x | Python 3.10+ | Node 22+`.
- Fixed broken relative paths in `public/schema/ontology/README.md` (`../../` -> `../../../`).

## Scope note
The named sub-issues covered README/CONTRIBUTING/GETTING-STARTED/API-REFERENCE/public-ontology, but the local review found the same broken `ajv` invocations in `docs/SCHEMA-REFERENCE.md`, `docs/MIGRATION-GUIDE.md`, and `schema/ontology/README.md`; those are fixed here too so the correction is complete.

## Verification
Every documented command was run: emitted projection + ajv (mif and citation) report `valid`; `validate-ontologies.py` passes; the Ajv 8 JS example executes. Repo-wide, all 11 `ajv validate` commands carry the correct flags. Local impartial review converged (2 rounds, 0 must-fix / 0 should-fix).

Closes #126, #127, #128
