### PR TITLE
docs(adr): fix ADR-004 artifact, ADR-007 historical notes, ADR-016 structure (epic #105)

### DIFF
--- a/adr/ADR-004-three-tier-trait-inheritance.md
+++ b/adr/ADR-004-three-tier-trait-inheritance.md
@@ -302,5 +302,3 @@ this conversion cites the file-accurate names. The three-tier *model* — the
 substance of the decision — is fully compliant.
 
 **Action Required:** None.
-</content>
-</invoke>

--- a/adr/ADR-007-github-raw-urls-for-schema-ids.md
+++ b/adr/ADR-007-github-raw-urls-for-schema-ids.md
@@ -229,14 +229,17 @@ values continue to use relative paths within the repository.
 ### Negative
 
 1. **Domain ownership cost**: `mif-spec.dev` must be registered and renewed.
-2. **Two identifier authorities**: Contributors must understand why schema `$id`
-   lives on `mif-spec.dev` while the namespace IRI lives on GitHub raw.
+2. **Two identifier authorities** *(historical, pre-2026-06)*: for a time the
+   schema `$id` lived on `mif-spec.dev` while the namespace IRI stayed on GitHub
+   raw. The 2026-06 amendment migrated the namespace IRI to `mif-spec.dev/ns/`,
+   closing this split (see the Amendment section).
 
 ### Neutral
 
-1. **Split is by design, not drift**: The schema-vs-namespace URI divergence is
-   an intentional architectural choice documented in `ns/README.md`, not an
-   inconsistency to be "fixed."
+1. **Split was by design, not drift** *(historical, pre-2026-06)*: the
+   schema-vs-namespace URI divergence was an intentional choice, not drift; the
+   2026-06 amendment subsequently unified both onto `mif-spec.dev`. See
+   `ns/README.md` and the Amendment section.
 
 ## Decision Outcome
 
@@ -244,8 +247,10 @@ The custom-domain approach achieves the primary drivers: resolvability (HTTP
 dereferenceable), low infrastructure (GitHub Pages), and identifier stability
 (domain outlives hosting path). Mitigations:
 
-- The intentional schema-`$id` vs. namespace-IRI split is documented inline in
-  `ns/README.md` so it reads as a decision rather than a bug.
+- The schema-`$id` vs. namespace-IRI split (the 2026-02 state) was documented
+  inline in `ns/README.md` as a deliberate decision; the 2026-06 amendment then
+  unified both onto `mif-spec.dev/ns/`, removing the split (see the Amendment
+  section).
 - The amendment preserved the zero-infrastructure benefit of the original
   GitHub-raw decision by keeping delivery on GitHub Pages.
 
@@ -261,7 +266,7 @@ dereferenceable), low infrastructure (GitHub Pages), and identifier stability
 
 ## More Information
 
-- **Date:** 2026-01-27 (original); amended 2026-02
+- **Date:** 2026-01-27 (original); amended 2026-02 and 2026-06
 - **Source:** `schema/mif.schema.json` and sibling schema `$id` values; `schema/context.jsonld`; `ns/README.md`.
 - **Related ADRs:** ADR-002, ADR-011
 

--- a/adr/ADR-016-versioned-schema-mirror-publication.md
+++ b/adr/ADR-016-versioned-schema-mirror-publication.md
@@ -311,6 +311,21 @@ served `Content-Type` for schema detection.
    mirrored ones. This is the intended behavior: the mirror pins bytes, the
    `$id` graph stays canonical.
 
+## Decision Outcome
+
+The versioned-mirror approach meets all four primary drivers: pinned version
+paths give immutable, byte-stable URLs; the canonical unversioned `$id` is
+preserved in every mirror (per ADR-007); the mirror is committed source, so
+SLSA provenance covers each snapshot; and the release workflow's `--check` gate
+fails closed when a mirror is missing. The secondary drivers are also satisfied:
+an `index.json` catalog for discovery, doc-site-served version paths, and an
+offline `mif-schemas-<version>.tar.gz`.
+
+Mitigations for the negatives: the growing `public/schema/` directory is accepted
+as the cost of the immutability guarantee (no pruning, by design); the
+release-prep discipline of running `snapshot-schema-version.py` before tagging is
+backed by the fail-closed gate, which blocks a tag whose mirror is absent.
+
 ## Implementation
 
 ### Release-prep sequence


### PR DESCRIPTION
Epic #105: ADR cleanup.

- **ADR-004**: remove the stray `</content>` / `</invoke>` tool-call artifact tags at the end of the file (they rendered as literal text).
- **ADR-007**: the body already documents the 2026-06 amendment (status line + Amendment section) that migrated the namespace IRI to `mif-spec.dev/ns/`, closing the earlier schema-`$id`-vs-namespace-IRI split. This annotates the Consequences (Negative #2, Neutral #1) and Decision Outcome that still described the split as the historical pre-2026-06 state, and adds 2026-06 to the More Information date. No statement now claims the split is current.
- **ADR-016**: add the missing `## Decision Outcome` section (drivers met + mitigations), so all ADRs carry it.

Builds clean. Local impartial review converged round 1 (0 must-fix / 0 should-fix).

Closes #129, #130, #131
