### PR TITLE
docs(spec): document timestamp/description OKF mirror fields (#152)

### DIFF
--- a/src/content/docs/specification/json-ld-format.mdx
+++ b/src/content/docs/specification/json-ld-format.mdx
@@ -19,6 +19,7 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
 
   "created": "2026-01-15T10:30:00Z",
   "modified": "2026-01-20T14:22:00Z",
+  "timestamp": "2026-01-20T14:22:00Z",
 
   "namespace": "_semantic/preferences",
   "tags": ["preference", "ui", "accessibility"],
@@ -31,6 +32,8 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
   "extensions": {...}
 }
 ```
+
+The projection always includes two OKF-legible mirror fields the converter derives: `timestamp` (the value of `modified`, or `created` when there is no `modified`) and, when the source has a `summary`, `description` (mapped from `summary`). These are derived mirrors of the canonical frontmatter; markdown remains authoritative.
 
 ### Full Example
 
@@ -52,6 +55,7 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
 
   "created": "2026-01-15T10:30:00Z",
   "modified": "2026-01-20T14:22:00Z",
+  "timestamp": "2026-01-20T14:22:00Z",
 
   "ontology": {
     "@type": "OntologyReference",

--- a/src/content/docs/specification/json-ld-format.mdx
+++ b/src/content/docs/specification/json-ld-format.mdx
@@ -33,7 +33,7 @@ Markdown is canonical. The JSON-LD form below is a **derived projection**: regen
 }
 ```
 
-The projection always includes two OKF-legible mirror fields the converter derives: `timestamp` (the value of `modified`, or `created` when there is no `modified`) and, when the source has a `summary`, `description` (mapped from `summary`). These are derived mirrors of the canonical frontmatter; markdown remains authoritative.
+The projection always includes the OKF-legible mirror field `timestamp` (the value of `modified`, or `created` when there is no `modified`). When the source has a `summary`, it also includes `description` (mapped from `summary`). These are derived mirrors of the canonical frontmatter; markdown remains authoritative.
 
 ### Full Example
 


### PR DESCRIPTION
Issue #152: complete the conversion/projection reconciliation with the minimal reference converter.

conversion.mdx was already reconciled in #146 (verbatim body, lossless flow, Citations passthrough). This finishes the json-ld-format.mdx side:
- Document the two OKF-legible mirror fields the converter always emits but the projection page omitted: `timestamp` (= `modified`, else `created`) and `description` (= `summary`, when present). Both are schema root properties described as OKF mirrors.
- Add `timestamp` to the Structure and Full Example JSON, plus a prose note that both are derived mirrors (markdown stays canonical).

Decision (the issue asked): the converter always emitting `timestamp`/`description` is intended OKF-mirror behavior (the schema documents them as such), so it is documented, not changed.

Verified: the Full Example validates against `schema/mif.schema.json`; the prose matches `scripts/mif_convert.py` exactly; site builds. Single-pass impartial review: 0/0.

Closes #152
