### PR TITLE
docs: drop AI-tell buzzwords from spec prose

### DIFF
--- a/ontologies/examples/BACKSTAGE-MAPPING.md
+++ b/ontologies/examples/BACKSTAGE-MAPPING.md
@@ -5,7 +5,7 @@ diataxis_type: how-to
 # Backstage.io Entity Mapping Guide
 
 This document maps MIF industry ontologies to Backstage.io's Software Catalog
-model, enabling organizations to leverage both systems together.
+model, so organizations can use both systems together.
 
 ## Complete Catalog Examples
 
@@ -347,7 +347,7 @@ traits from `shared-traits.ontology.yaml`:
 
 1. **Use MIF for Deep Domain Knowledge**
    - Store detailed domain-specific memories in MIF format
-   - Leverage base types for proper categorization
+   - Use base types for proper categorization
    - Enable agent-based discovery patterns
 
 2. **Use Backstage for Developer/Operator Experience**

--- a/src/content/docs/specification/overview.mdx
+++ b/src/content/docs/specification/overview.mdx
@@ -49,7 +49,7 @@ The `.md` file is the source of truth; the JSON-LD form is a derived projection,
 
 ### Obsidian Compatibility
 
-The Markdown format is valid Obsidian-compatible notes, ensuring files work seamlessly in Obsidian vaults while remaining readable in any text editor or Markdown processor. Concept relationships are expressed as standard bundle-relative markdown links (so a generic OKF consumer sees every edge); Obsidian's bidirectional features remain available for authoring.
+The Markdown format is valid Obsidian-compatible notes, so files work in Obsidian vaults while remaining readable in any text editor or Markdown processor. Concept relationships are expressed as standard bundle-relative markdown links (so a generic OKF consumer sees every edge); Obsidian's bidirectional features remain available for authoring.
 
 **Required Markdown Features:**
 


### PR DESCRIPTION
Final language pass before the v1.0.0 cutover.

Replaces two AI-tell buzzwords in flowing prose with plain wording:

- `src/content/docs/specification/overview.mdx`: "work seamlessly in Obsidian vaults" becomes "work in Obsidian vaults".
- `ontologies/examples/BACKSTAGE-MAPPING.md`: two uses of "leverage" become "use".

Scope was confirmed as language-only. Em-dash punctuation reads as normal technical-writing typography across the spec and ADRs (the product tagline itself is `MIF — Modeled Information Format`), so it is left unchanged. ADR historical text is preserved verbatim by convention and is also untouched. The eight `Utilizes` entries are relationship-type glosses that mirror the schema `description` fields; editing the docs alone would drift them from the schema, so they are left as-is.

Gates: `npm run build` Complete; ontology and namespace validators pass.