### PR TITLE
ci(deploy): build Pages with GitHub-owned actions (drop withastro/action)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 'lts/*'
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ./dist
 
   deploy:
     needs: build


### PR DESCRIPTION
The Pages deploy has failed on every push to main since the org allowed-actions policy took effect. withastro/action@v6 references pnpm/action-setup in its composite action.yml, and the policy validates every nested action at job setup, so the build job fails before it runs even though MIF builds with npm.

This swaps withastro/action for the standard GitHub-owned Pages build: actions/setup-node, npm ci, npm run build, actions/configure-pages, and actions/upload-pages-artifact, all SHA-pinned and on the allow-list. The deploy job is unchanged.

Verified locally: npm run build completes and emits dist/; actionlint passes on deploy.yml.