### PR TITLE
ci(scorecard): pass CI App key so Scorecard reads branch protection

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,6 +23,9 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: modeled-information-format/.github/.github/workflows/reusable-scorecard.yml@ff8adc6b1267c272beef916af851d9506160354f
+    uses: modeled-information-format/.github/.github/workflows/reusable-scorecard.yml@f83ee8058630235396f7242580570b26cf3617fa
     with:
       publish-results: true
+    secrets:
+      # Org CI App private key → Scorecard reads branch protection (administration:read).
+      app-private-key: ${{ secrets.MIF_CI_CLIENT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Completes the Scorecard branch-protection fix (companion to `.github` #15, now merged).

- Bumps the `reusable-scorecard.yml` pin to `f83ee80` (the merged App-token change).
- Passes `secrets.app-private-key = ${{ secrets.MIF_CI_CLIENT_APP_PRIVATE_KEY }}`.

Scorecard now mints the org CI App installation token (`administration: read`) and scores **Branch-Protection from real settings** — so `#639` re-scores against the actual require-PR + 1 approval + strict + 15 required checks, instead of the incomplete data the default `GITHUB_TOKEN` can see.

**Ceiling note:** Scorecard still prefers codeowners-required review and ≥2 approvers, neither of which fits a solo maintainer, so `#639` will climb well above 5 but may not reach a perfect 10. Enforcement is real regardless of the score.
