### PR TITLE
chore(labels): adopt org reusable label-sync

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,18 @@
+# Sync this repo's labels to the org standard (modeled-information-format/.github
+# labels.yml) plus an optional repo-local overlay (.github/labels.yml).
+name: Sync labels
+on:
+  push:
+    branches: [main]
+    paths: ['.github/labels.yml', '.github/workflows/label-sync.yml']
+  schedule:
+    - cron: '0 6 * * 1'   # weekly drift correction
+  workflow_dispatch: {}
+jobs:
+  labels:
+    permissions:
+      contents: read
+      issues: write
+    uses: modeled-information-format/.github/.github/workflows/reusable-label-sync.yml@0ef7cfddaf9b1f763c896c373f227b3450270abc
+    with:
+      local-labels: .github/labels.yml   # merged over the org set; absent file = org set only

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,5 +1,6 @@
-# Sync this repo's labels to the org standard (modeled-information-format/.github
-# labels.yml) plus an optional repo-local overlay (.github/labels.yml).
+# Sync this repo's labels to the org standard in modeled-information-format/.github
+# (the labels.yml source of truth), plus an optional repo-local overlay
+# (.github/labels.yml).
 name: Sync labels
 on:
   push:
@@ -8,11 +9,12 @@ on:
   schedule:
     - cron: '0 6 * * 1'   # weekly drift correction
   workflow_dispatch: {}
+permissions: {}
 jobs:
   labels:
     permissions:
       contents: read
       issues: write
-    uses: modeled-information-format/.github/.github/workflows/reusable-label-sync.yml@0ef7cfddaf9b1f763c896c373f227b3450270abc
+    uses: modeled-information-format/.github/.github/workflows/reusable-label-sync.yml@08f06af29dfb1877e2dcfaaa90bf773a63261139
     with:
       local-labels: .github/labels.yml   # merged over the org set; absent file = org set only


### PR DESCRIPTION
Wires this repo to the organization's centralized label set by adding a thin caller workflow that invokes the shared `reusable-label-sync.yml` from `modeled-information-format/.github` (SHA-pinned). Labels are kept in sync with the org standard automatically — on a weekly cron, whenever the label files change, and on demand via `workflow_dispatch`. A repo-local `.github/labels.yml` overlay is optional and merges over the org set; this PR adds none, so the repo simply inherits the org labels.
