### PR TITLE
ci: add Dependabot auto-merge caller (patch-only)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,24 @@
+---
+name: Dependabot auto-merge
+
+# Thin caller of the org reusable (pinned to .github main). Approves + auto-merges
+# patch Dependabot updates via the org CI App; minor/major stay manual. Repo
+# settings (allow_auto_merge + branch protection) are applied out-of-band by
+# docs/onboarding/org/dependabot-automerge-settings.sh in the .github repo.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  automerge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    uses: modeled-information-format/.github/.github/workflows/reusable-dependabot-automerge.yml@219e6e121531701e787db57c9bdf9e5cfdcbfb7b # reusable-dependabot-automerge.yml @ .github main
+    with:
+      update-types: patch
+    secrets:
+      app-private-key: ${{ secrets.MIF_CI_CLIENT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Adds the thin Dependabot auto-merge caller, pinned to the org reusable on `.github` main (`219e6e1`). Approves + auto-merges **patch** Dependabot updates via the org CI App; minor/major and non-semver bumps stay manual.

Part of the org-wide rollout — epic modeled-information-format/.github#23, sub-issue #180.

After merge: repo settings (`allow_auto_merge` + branch protection) are applied via `dependabot-automerge-settings.sh`, then existing Dependabot PRs are rebased to auto-merge. See the [runbook](https://github.com/modeled-information-format/.github/blob/main/docs/runbooks/dependabot-automerge-runbook.md).