### PR TITLE
docs: reconcile base-type namespace prefixes with §10.2 (#98)

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1283,7 +1283,7 @@ Where `{root}` is either:
 
 - **Organization name** - private to that organization
 - **Reserved prefix** - special namespace with defined semantics. Two kinds of
-  reserved prefix exist (both begin with `_`): **visibility prefixes** that
+  reserved prefixes exist (both begin with `_`): **visibility prefixes** that
   control sharing scope, and **base-type prefixes** that name the cognitive
   memory type. Both are defined in 10.2.
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -242,9 +242,9 @@ MIF uses three **base memory types**, reflecting how human memory systems organi
 
 | Type | Description | Namespace Hint |
 | --- | --- | --- |
-| `semantic` | Facts, concepts, relationships, and knowledge | `semantic/*` |
-| `episodic` | Events, experiences, sessions, and timelines | `episodic/*` |
-| `procedural` | Step-by-step processes, runbooks, and patterns | `procedural/*` |
+| `semantic` | Facts, concepts, relationships, and knowledge | `_semantic/*` |
+| `episodic` | Events, experiences, sessions, and timelines | `_episodic/*` |
+| `procedural` | Step-by-step processes, runbooks, and patterns | `_procedural/*` |
 
 #### Base Type Descriptions
 
@@ -320,7 +320,7 @@ memory unit can declare directly:
 1. **`type`** (REQUIRED, see 4.2) — the cognitive memory type: `semantic`,
    `episodic`, or `procedural`.
 2. **`namespace`** (RECOMMENDED, see 10) — hierarchical scope that carries the
-   finer-grained label (e.g. `semantic/knowledge`, `episodic/sessions`).
+   finer-grained label (e.g. `_semantic/knowledge`, `_episodic/sessions`).
 
 A memory unit has no field to name an ontology-extended type directly. Instead,
 **ontologies define extended types and their namespace mappings** (OPTIONAL, see
@@ -328,15 +328,15 @@ A memory unit has no field to name an ontology-extended type directly. Instead,
 entry with a `base` type, and implementations express that extended type by
 following the referenced ontology's namespace hierarchy on the `namespace` axis
 above (e.g. an `incident` extended type whose `base` is `episodic`, reached via
-`episodic/incidents`). The extended type is therefore a richer label *on* the
+`_episodic/incidents`). The extended type is therefore a richer label *on* the
 namespace axis, not a separate third axis the unit declares.
 
-> **Note on namespace form.** The namespace examples in this section use the
-> unprefixed form (e.g. `semantic/knowledge`). Other sections (e.g. 4.2.1 and
-> 10.8.4) use the underscore-prefixed `_semantic/…` form. Section 10 is
-> authoritative for namespace structure; follow the form it defines for your
-> deployment. Where an ontology is referenced, follow the namespace hierarchy it
-> declares; the examples below omit ontology binding for clarity.
+> **Note on namespace form.** Base-type roots use the underscore-prefixed form
+> (`_semantic`, `_episodic`, `_procedural`); these are reserved base-type
+> prefixes (see 10.2), distinct from the visibility prefixes (`_public`,
+> `_shared`, `_local`, `_system`) defined alongside them. Where an ontology is
+> referenced, follow the namespace hierarchy it declares; the examples below
+> omit ontology binding for clarity.
 
 A **Fact** is a `semantic` memory — declarative knowledge that holds independently
 of any single moment:
@@ -344,7 +344,7 @@ of any single moment:
 ```yaml
 ---
 type: semantic
-namespace: semantic/knowledge
+namespace: _semantic/knowledge
 ---
 ```
 
@@ -354,14 +354,14 @@ carry `temporal` validity to bound when they hold (see 9):
 ```yaml
 ---
 type: episodic
-namespace: episodic/sessions
+namespace: _episodic/sessions
 temporal:
   validFrom: 2026-01-15T00:00:00Z
   validUntil: 2026-01-15T11:00:00Z
 ---
 ```
 
-Finer distinctions are added through the namespace (e.g. `episodic/incidents`),
+Finer distinctions are added through the namespace (e.g. `_episodic/incidents`),
 whose path MAY map to an ontology-extended type defined by a referenced ontology
 (e.g. an `incident` whose `base` is `episodic`) — not through a new unit-level
 field. Implementations SHOULD express domain categories through `type` +
@@ -1282,11 +1282,18 @@ Namespaces use a flexible scoping model with reserved prefixes for cross-organiz
 Where `{root}` is either:
 
 - **Organization name** - private to that organization
-- **Reserved prefix** - special namespace with defined semantics
+- **Reserved prefix** - special namespace with defined semantics. Two kinds of
+  reserved prefix exist (both begin with `_`): **visibility prefixes** that
+  control sharing scope, and **base-type prefixes** that name the cognitive
+  memory type. Both are defined in 10.2.
 
 ### 10.2 Reserved Namespace Prefixes
 
-Names beginning with underscore (`_`) are reserved for special namespaces:
+Names beginning with underscore (`_`) are reserved for special namespaces. Two
+kinds exist: **visibility prefixes** that control sharing scope, and
+**base-type prefixes** that name the cognitive memory type.
+
+#### Visibility Prefixes
 
 | Prefix | Visibility | Description |
 | --- | --- | --- |
@@ -1294,6 +1301,21 @@ Names beginning with underscore (`_`) are reserved for special namespaces:
 | `_shared` | Negotiated | Cross-organization sharing with explicit agreements |
 | `_local` | Local only | Never synchronized or exported |
 | `_system` | Implementation | Reserved for system/implementation use |
+
+#### Base-Type Prefixes
+
+Namespace paths use an underscore prefix (`_semantic`, `_episodic`,
+`_procedural`) to distinguish base-type namespaces from domain-specific
+namespaces. This convention ensures consistent namespace identification across
+implementations. Each base-type prefix corresponds to a base memory `type`
+(see 4.2) and is the top-level root of the base ontology's namespace hierarchy
+(see 10.8.2).
+
+| Prefix | Base type | Description |
+| --- | --- | --- |
+| `_semantic` | `semantic` | Facts, concepts, relationships - declarative knowledge |
+| `_episodic` | `episodic` | Events, experiences, timelines - time-bound records |
+| `_procedural` | `procedural` | Step-by-step processes - how-to knowledge |
 
 #### Examples
 
@@ -1440,23 +1462,24 @@ Ontologies are defined in YAML files with optional JSON-LD export:
 
 #### 10.8.2 Base Type Hierarchy
 
-The base ontology uses a three-tier hierarchy based on cognitive memory types:
+The base ontology uses a three-tier hierarchy based on cognitive memory types.
+Its three top-level roots are the base-type prefixes defined in 10.2:
 
 ```yaml
 namespaces:
-  semantic:                    # Facts, concepts, relationships
+  _semantic:                   # Facts, concepts, relationships
     type_hint: semantic
     children:
       decisions: {}
       knowledge: {}
       entities: {}
-  episodic:                    # Events, experiences, timelines
+  _episodic:                   # Events, experiences, timelines
     type_hint: episodic
     children:
       incidents: {}
       sessions: {}
       blockers: {}
-  procedural:                  # Step-by-step processes
+  _procedural:                 # Step-by-step processes
     type_hint: procedural
     children:
       runbooks: {}

--- a/src/content/docs/specification/data-model.mdx
+++ b/src/content/docs/specification/data-model.mdx
@@ -35,9 +35,9 @@ Every concept declares one of three **base knowledge types**, a general taxonomy
 
 | Type | Description | Namespace Hint |
 |------|-------------|----------------|
-| `semantic` | Declarative knowledge: facts, concepts, decisions, schemas | `semantic/*` |
-| `episodic` | Time-bound records: events, incidents, changelog/deprecation | `episodic/*` |
-| `procedural` | How-to knowledge: runbooks, processes, patterns, migrations | `procedural/*` |
+| `semantic` | Declarative knowledge: facts, concepts, decisions, schemas | `_semantic/*` |
+| `episodic` | Time-bound records: events, incidents, changelog/deprecation | `_episodic/*` |
+| `procedural` | How-to knowledge: runbooks, processes, patterns, migrations | `_procedural/*` |
 
 **Base Type Descriptions:**
 

--- a/src/content/docs/specification/namespace-model.mdx
+++ b/src/content/docs/specification/namespace-model.mdx
@@ -13,7 +13,7 @@ Namespaces use a flexible scoping model with reserved prefixes for cross-organiz
 
 Where `{root}` is either:
 - **Organization name** - private to that organization
-- **Reserved prefix** - special namespace with defined semantics. Two kinds of reserved prefix exist (both begin with `_`): **visibility prefixes** that control sharing scope, and **base-type prefixes** that name the cognitive memory type.
+- **Reserved prefix** - special namespace with defined semantics. Two kinds of reserved prefixes exist (both begin with `_`): **visibility prefixes** that control sharing scope, and **base-type prefixes** that name the cognitive memory type.
 
 ### Reserved Namespace Prefixes
 

--- a/src/content/docs/specification/namespace-model.mdx
+++ b/src/content/docs/specification/namespace-model.mdx
@@ -13,11 +13,13 @@ Namespaces use a flexible scoping model with reserved prefixes for cross-organiz
 
 Where `{root}` is either:
 - **Organization name** - private to that organization
-- **Reserved prefix** - special namespace with defined semantics
+- **Reserved prefix** - special namespace with defined semantics. Two kinds of reserved prefix exist (both begin with `_`): **visibility prefixes** that control sharing scope, and **base-type prefixes** that name the cognitive memory type.
 
 ### Reserved Namespace Prefixes
 
-Names beginning with underscore (`_`) are reserved for special namespaces:
+Names beginning with underscore (`_`) are reserved for special namespaces. Two kinds exist: **visibility prefixes** that control sharing scope, and **base-type prefixes** that name the cognitive memory type.
+
+#### Visibility Prefixes
 
 | Prefix | Visibility | Description |
 |--------|------------|-------------|
@@ -25,6 +27,16 @@ Names beginning with underscore (`_`) are reserved for special namespaces:
 | `_shared` | Negotiated | Cross-organization sharing with explicit agreements |
 | `_local` | Local only | Never synchronized or exported |
 | `_system` | Implementation | Reserved for system/implementation use |
+
+#### Base-Type Prefixes
+
+Namespace paths use an underscore prefix (`_semantic`, `_episodic`, `_procedural`) to distinguish base-type namespaces from domain-specific namespaces. This convention ensures consistent namespace identification across implementations. Each base-type prefix corresponds to a base memory `type` and is the top-level root of the base ontology's namespace hierarchy.
+
+| Prefix | Base type | Description |
+|--------|-----------|-------------|
+| `_semantic` | `semantic` | Facts, concepts, relationships - declarative knowledge |
+| `_episodic` | `episodic` | Events, experiences, timelines - time-bound records |
+| `_procedural` | `procedural` | Step-by-step processes - how-to knowledge |
 
 **Examples:**
 
@@ -174,19 +186,19 @@ The base ontology uses a three-tier hierarchy based on the base knowledge types:
 
 ```yaml
 namespaces:
-  semantic:                    # Facts, concepts, relationships
+  _semantic:                   # Facts, concepts, relationships
     type_hint: semantic
     children:
       decisions: {}
       knowledge: {}
       entities: {}
-  episodic:                    # Events, experiences, timelines
+  _episodic:                   # Events, experiences, timelines
     type_hint: episodic
     children:
       incidents: {}
       sessions: {}
       blockers: {}
-  procedural:                  # Step-by-step processes
+  _procedural:                 # Step-by-step processes
     type_hint: procedural
     children:
       runbooks: {}


### PR DESCRIPTION
## Summary

Resolves the namespace-model contradiction in #98. §10.2 listed only the visibility reserved prefixes (`_public`/`_shared`/`_local`/`_system`), while base-type roots appeared inconsistently as both unprefixed (`semantic/…`) and underscored (`_semantic/…`).

**Decision: the underscored form is canonical** — it is what the CI-validated implementation already requires:
- `ontologies/mif-base.ontology.yaml` declares roots as `_semantic:`/`_episodic:`/`_procedural:` (`Path format: _{top-level}/{sub-namespace}`)
- `scripts/validate-namespaces.py` derives the valid namespace set directly from those ontology keys
- every example `.md` declares `namespace: _semantic/…`, and `ontologies/README.md` documents the underscore convention by design

Flipping to unprefixed would have broken every validated example. So this PR aligns the unprefixed prose in `SPECIFICATION.md` (and its two `.mdx` mirrors) to the underscored canonical, and documents base-type prefixes as a **second kind of reserved prefix**, distinct from the visibility prefixes.

## Changes

- **`SPECIFICATION.md`**
  - §10.1: name the two kinds of reserved prefix (visibility, base-type)
  - §10.2: split into **Visibility Prefixes** and a new **Base-Type Prefixes** table; cross-link §10.2 ↔ §10.8.2
  - §4.2 hints, §4.4 examples, §10.8.2 hierarchy keys → underscored
  - §4.4: replace the "Note on namespace form" hedge with a definitive pointer to §10.2 (base-type vs visibility prefixes)
- **`data-model.mdx`**, **`namespace-model.mdx`**: mirror the above

## Verification

- `scripts/validate-namespaces.py` ✓ · `scripts/validate-ontologies.py` ✓ (confirms the decision keeps CI consistent)
- `npm run build` → "Complete!", exit 0
- No residual unprefixed base-type roots remain in the edited files
- Impartial out-of-session review: 0 must-fix, 0 should-fix, 1 nit (applied)

## Out of scope (follow-up filed)

Relationship-target link paths like `/semantic/other-concept.md` in `markdown-format.mdx` / `conversion.mdx` / `relationship-types.mdx` are relationship **link** examples, not `namespace:` declarations — and `SPECIFICATION.md` uses `[[wiki-link]]` targets for the same examples. That is a separate link-syntax convention mismatch, tracked in #183.

Closes #98
