### PR TITLE
docs: remove Obsidian-specific conventions for vendor neutrality (#183)

### DIFF
--- a/.github/readme-infographic-dark.svg
+++ b/.github/readme-infographic-dark.svg
@@ -69,7 +69,7 @@
     <text x="0" y="25" font-family="Georgia, serif" font-size="14" font-weight="bold" fill="#d4bc94" text-anchor="middle">Portable</text>
     <text x="0" y="42" font-family="Georgia, serif" font-size="14" font-weight="bold" fill="#d4bc94" text-anchor="middle">Destinations</text>
 
-    <text x="0" y="70" font-family="Georgia, serif" font-size="12" fill="#c9a87c" text-anchor="middle">Obsidian</text>
+    <text x="0" y="70" font-family="Georgia, serif" font-size="12" fill="#c9a87c" text-anchor="middle">Markdown</text>
     <text x="0" y="88" font-family="Georgia, serif" font-size="12" fill="#c9a87c" text-anchor="middle">Local Files</text>
     <text x="0" y="106" font-family="Georgia, serif" font-size="12" fill="#c9a87c" text-anchor="middle">New Provider</text>
     <text x="0" y="124" font-family="Georgia, serif" font-size="12" fill="#c9a87c" text-anchor="middle">Archives</text>
@@ -90,7 +90,7 @@
       <rect x="-70" y="0" width="140" height="80" fill="#2a231c" stroke="#3d3124" stroke-width="1" rx="6"/>
       <text x="0" y="25" font-family="Georgia, serif" font-size="13" font-weight="bold" fill="#d4bc94" text-anchor="middle">Human Readable</text>
       <text x="0" y="45" font-family="Georgia, serif" font-size="10" fill="#a68b5b" text-anchor="middle">Markdown format.</text>
-      <text x="0" y="60" font-family="Georgia, serif" font-size="10" fill="#a68b5b" text-anchor="middle">Works in Obsidian.</text>
+      <text x="0" y="60" font-family="Georgia, serif" font-size="10" fill="#a68b5b" text-anchor="middle">Works in any editor.</text>
     </g>
 
     <!-- Box 3 -->

--- a/.github/readme-infographic.svg
+++ b/.github/readme-infographic.svg
@@ -69,7 +69,7 @@
     <text x="0" y="25" font-family="Georgia, serif" font-size="14" font-weight="bold" fill="#5c4a32" text-anchor="middle">Portable</text>
     <text x="0" y="42" font-family="Georgia, serif" font-size="14" font-weight="bold" fill="#5c4a32" text-anchor="middle">Destinations</text>
 
-    <text x="0" y="70" font-family="Georgia, serif" font-size="12" fill="#7a6548" text-anchor="middle">Obsidian</text>
+    <text x="0" y="70" font-family="Georgia, serif" font-size="12" fill="#7a6548" text-anchor="middle">Markdown</text>
     <text x="0" y="88" font-family="Georgia, serif" font-size="12" fill="#7a6548" text-anchor="middle">Local Files</text>
     <text x="0" y="106" font-family="Georgia, serif" font-size="12" fill="#7a6548" text-anchor="middle">New Provider</text>
     <text x="0" y="124" font-family="Georgia, serif" font-size="12" fill="#7a6548" text-anchor="middle">Archives</text>
@@ -90,7 +90,7 @@
       <rect x="-70" y="0" width="140" height="80" fill="#fff" stroke="#e8d5b7" stroke-width="1" rx="6"/>
       <text x="0" y="25" font-family="Georgia, serif" font-size="13" font-weight="bold" fill="#5c4a32" text-anchor="middle">Human Readable</text>
       <text x="0" y="45" font-family="Georgia, serif" font-size="10" fill="#8b7355" text-anchor="middle">Markdown format.</text>
-      <text x="0" y="60" font-family="Georgia, serif" font-size="10" fill="#8b7355" text-anchor="middle">Works in Obsidian.</text>
+      <text x="0" y="60" font-family="Georgia, serif" font-size="10" fill="#8b7355" text-anchor="middle">Works in any editor.</text>
     </g>
 
     <!-- Box 3 -->

--- a/.github/social-preview-dark.svg
+++ b/.github/social-preview-dark.svg
@@ -80,7 +80,7 @@
     </g>
     <g transform="translate(230, -120)">
       <ellipse cx="0" cy="0" rx="36" ry="30" fill="#3d3124" opacity="0.8"/>
-      <text x="0" y="5" font-family="Georgia, serif" font-size="12" fill="#c9a87c" text-anchor="middle">Obsidian</text>
+      <text x="0" y="5" font-family="Georgia, serif" font-size="12" fill="#c9a87c" text-anchor="middle">Any editor</text>
     </g>
 
     <!-- Central text -->
@@ -103,7 +103,7 @@
     <text x="-320" y="0" font-family="Georgia, serif" font-size="16" fill="#a68b5b" text-anchor="middle">JSON-LD</text>
     <text x="-160" y="0" font-family="Georgia, serif" font-size="16" fill="#a68b5b" text-anchor="middle">Bi-Temporal</text>
     <text x="0" y="0" font-family="Georgia, serif" font-size="16" fill="#a68b5b" text-anchor="middle">W3C PROV</text>
-    <text x="160" y="0" font-family="Georgia, serif" font-size="16" fill="#a68b5b" text-anchor="middle">Obsidian Native</text>
+    <text x="160" y="0" font-family="Georgia, serif" font-size="16" fill="#a68b5b" text-anchor="middle">Plain Markdown</text>
     <text x="320" y="0" font-family="Georgia, serif" font-size="16" fill="#a68b5b" text-anchor="middle">Open Source</text>
 
     <circle cx="-240" cy="-3" r="3" fill="#8b7355" opacity="0.6"/>

--- a/.github/social-preview.svg
+++ b/.github/social-preview.svg
@@ -86,7 +86,7 @@
     </g>
     <g transform="translate(230, -120)">
       <ellipse cx="0" cy="0" rx="36" ry="30" fill="#e8d5b7" opacity="0.8"/>
-      <text x="0" y="5" font-family="Georgia, serif" font-size="12" fill="#5c4a32" text-anchor="middle">Obsidian</text>
+      <text x="0" y="5" font-family="Georgia, serif" font-size="12" fill="#5c4a32" text-anchor="middle">Any editor</text>
     </g>
 
     <!-- Central text -->
@@ -109,7 +109,7 @@
     <text x="-320" y="0" font-family="Georgia, serif" font-size="16" fill="#8b7355" text-anchor="middle">JSON-LD</text>
     <text x="-160" y="0" font-family="Georgia, serif" font-size="16" fill="#8b7355" text-anchor="middle">Bi-Temporal</text>
     <text x="0" y="0" font-family="Georgia, serif" font-size="16" fill="#8b7355" text-anchor="middle">W3C PROV</text>
-    <text x="160" y="0" font-family="Georgia, serif" font-size="16" fill="#8b7355" text-anchor="middle">Obsidian Native</text>
+    <text x="160" y="0" font-family="Georgia, serif" font-size="16" fill="#8b7355" text-anchor="middle">Plain Markdown</text>
     <text x="320" y="0" font-family="Georgia, serif" font-size="16" fill="#8b7355" text-anchor="middle">Open Source</text>
 
     <!-- Decorative dots between features -->

--- a/.marksman.toml
+++ b/.marksman.toml
@@ -2,8 +2,6 @@
 # https://github.com/artempyanykh/marksman
 
 [core]
-# Wiki-links in example files reference non-existent documents intentionally
-# They demonstrate the MIF relationship and entity reference syntax
-
-# Exclude example directories from wiki-link validation
-# These contain illustrative references, not real documents
+# Relationship markdown links in example files reference illustrative,
+# non-existent documents intentionally — they demonstrate MIF's relationship
+# syntax, not real targets, so unresolved-link findings there are expected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ fills OKF's deliberately empty envelope. AI memory becomes the first domain
   `relationships` array **and** mirrored as OKF-legible body markdown links in a
   `## Relationships` section (`- <type> [Text](/path/target.md)`). Obsidian
   wiki-links are no longer the canonical edge representation.
+- **[Format]**: Removed all Obsidian-specific conventions for vendor neutrality
+  (ADR-017, superseding ADR-003) — wiki-link relationships (`[[...]]`),
+  `@[[Name|Type]]` entity references, block references, and embeds, plus the
+  Obsidian-compatibility positioning. Relationships use markdown links; entity
+  references use frontmatter `EntityReference` objects. The `blocks` field is
+  removed from the schema and converter; existing data still carrying a `blocks`
+  object continues to validate (the concept object permits additional
+  properties).
 - **[Identity]**: `id` MUST be a UUID (OKF concept ID is the path; the UUID is
   MIF's stable, location-independent identity). Legacy slug ids migrate to a
   deterministic UUIDv5 with the slug preserved as an `alias`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,7 +32,6 @@ keywords:
   - semantic-web
   - ontology
   - specification
-  - obsidian
 preferred-citation:
   type: software
   title: "MIF: Modeled Information Format"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ For specification changes:
 Help grow the ecosystem by building:
 - Import/export converters for memory providers
 - Validation tools
-- Editor plugins (Obsidian, VS Code, etc.)
+- Editor plugins and integrations (VS Code, etc.)
 
 ### 4. Validate with JSON Schema
 
@@ -67,7 +67,7 @@ When adding examples:
 - Use language tags on all code blocks
 - Ensure JSON is valid and parseable
 - Ensure YAML frontmatter is valid
-- Test wiki-link syntax in Obsidian if possible
+- Ensure relationship markdown links use the `- <type> [Text](/path.md)` form
 
 ## Style Guide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ When adding examples:
 - Use language tags on all code blocks
 - Ensure JSON is valid and parseable
 - Ensure YAML frontmatter is valid
-- Ensure relationship markdown links use the `- <type> [Text](/path.md)` form
+- Ensure relationship markdown links use the `- <type> [Text](<target>)` form, where `<target>` is a bundle-relative path (`/path.md`) or a `urn:mif:` identifier
 
 ## Style Guide
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A MIF bundle is a directory tree of `.md` concept files — **a valid OKF
 bundle**. Markdown is the canonical representation; JSON-LD is a derived,
 regenerable projection.
 
-- **Markdown** (`.md`) — canonical, human-readable, Obsidian-compatible.
+- **Markdown** (`.md`) — canonical, human-readable, plain CommonMark.
 - **JSON-LD** (`*.jsonld`, derived) — machine-processable, semantically linked,
   regenerated from markdown with `scripts/mif_convert.py`.
 
@@ -162,7 +162,6 @@ definition of every property is [`schema/mif.schema.json`](./schema/mif.schema.j
 | `tags` | Classification tags | [Basic metadata](./docs/SCHEMA-REFERENCE.md#basic-metadata) |
 | `aliases` | Alternative names for the memory | [Basic metadata](./docs/SCHEMA-REFERENCE.md#basic-metadata) |
 | `properties` | First-class scalar key/value pairs with no concept target | [Basic metadata](./docs/SCHEMA-REFERENCE.md#basic-metadata) |
-| `blocks` | Named block references (`^block-id`) with their text, for granular linking | [Basic metadata](./docs/SCHEMA-REFERENCE.md#basic-metadata) |
 | `ontology` | Reference to the ontology this memory conforms to | [Ontology reference](./docs/SCHEMA-REFERENCE.md#ontology-reference) |
 | `entity` | Structured entity data for ontology-typed memories | [Entities](./docs/SCHEMA-REFERENCE.md#entities) |
 | `entities` | Referenced entities (people, orgs, technologies, …) | [Entities](./docs/SCHEMA-REFERENCE.md#entities) |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1854,11 +1854,8 @@ User prefers dark mode
 
 #### JSON-LD to Markdown
 
-1. Generate frontmatter `citations` array from JSON-LD
-2. Convert entity URIs to `EntityReference` objects
-3. If any citation has `note` exceeding 100 characters:
-   - Create `## Citations` body section
-   - Format as markdown list with metadata
+1. Write the `citations` array back to frontmatter verbatim — each entry is already a `Citation` object (`@type: Citation`, `citationType`, `citationRole`, ...) with `author` as plain text or an `EntityReference`; the converter performs no rewriting.
+2. Any `## Citations` body section is authored content carried inside `content` and is preserved unchanged.
 
 #### Example
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -482,7 +482,7 @@ citations:
     title: "Memory Systems in AI Agents"   # REQUIRED: Citation title
     url: https://arxiv.org/abs/2024.12345  # REQUIRED: Valid URL
     citationRole: supports                 # REQUIRED: Relationship to memory
-    author: "Jane Smith"                   # OPTIONAL: EntityReference or text
+    author: "Jane Smith"                   # OPTIONAL: string, EntityReference, or array
     date: 2024-06-15                       # OPTIONAL: Publication date
     accessed: 2026-01-20                   # OPTIONAL: Access date
     relevance: 0.95                        # OPTIONAL: Relevance score (0-1)
@@ -498,7 +498,7 @@ citations:
 | `title` | REQUIRED | String | Citation title |
 | `url` | REQUIRED | URI | Valid URL or URI |
 | `citationRole` | REQUIRED | Enum | Relationship to memory (see 5.4.4) |
-| `author` | OPTIONAL | EntityReference or String | Entity reference or plain text |
+| `author` | OPTIONAL | EntityReference, array of EntityReference, or String | One or more entity references, or plain text |
 | `date` | OPTIONAL | Date | Publication date (ISO 8601) |
 | `accessed` | OPTIONAL | Date | Access date (ISO 8601) |
 | `relevance` | OPTIONAL | Decimal | Relevance score (0.0-1.0) |
@@ -1787,17 +1787,14 @@ new major version of the specification.
 
 ### 15.1 Markdown to JSON-LD
 
-1. Parse YAML frontmatter as structured data (including `relationships[]` and `entities[]`)
-2. Map frontmatter properties to JSON-LD using context
-3. Parse the body `## Relationships` section: each `- <type> [Text](<target>)` line maps to a `relationships` entry (reconciled with the authoritative frontmatter array)
-4. Convert body content to `content` field
+1. Parse the YAML frontmatter, including the authoritative `relationships[]` and `entities[]`, and map each property into the JSON-LD projection: `id` becomes `@id` (`urn:mif:<id>`), `type` becomes `conceptType`, and the remaining fields pass through under the context.
+2. Take the full Markdown body, verbatim, as the `content` field. The OKF-legible `## Relationships` body mirror is part of the body, so it is carried inside `content`.
+3. Add the projection mirror fields the converter always emits: `timestamp` (= `modified`, else `created`) and, when `summary` is present, `description` (= `summary`).
 
 ### 15.2 JSON-LD to Markdown
 
-1. Generate YAML frontmatter from JSON-LD properties (including `relationships[]` and `entities[]`)
-2. Set first `title` or H1 from `dc:title`
-3. Convert `content` to Markdown body
-4. Append a "## Relationships" section, rendering each relationship as `- <type> [Text](<target>)`
+1. Recover the frontmatter from the JSON-LD properties: `@id` (`urn:mif:<uuid>`) becomes `id` (`<uuid>`), `conceptType` becomes `type`, and the remaining properties (including `relationships[]`) pass through.
+2. Write the `content` field back as the Markdown body, verbatim. Any `## Relationships` body mirror is authored content preserved unchanged, which is what keeps the round trip lossless.
 
 ### 15.3 Example Conversion
 
@@ -1808,21 +1805,29 @@ new major version of the specification.
   "@context": "https://mif-spec.dev/schema/context.jsonld",
   "@type": "Concept",
   "@id": "urn:mif:550e8400",
+  "conceptType": "semantic",
   "title": "Dark Mode",
-  "content": "User prefers dark mode",
+  "content": "# Dark Mode\n\nUser prefers dark mode\n\n## Relationships\n\n- relates-to [UI Preferences](/semantic/ui-prefs.md)",
+  "created": "2026-01-15T10:30:00Z",
   "relationships": [
-    {"type": "relates-to", "target": "urn:mif:ui-prefs"}
+    {"type": "relates-to", "target": "/semantic/ui-prefs.md"}
   ]
 }
 ```
 
 #### Output (Markdown)
 
+The `content` field is written back verbatim as the body; `relationships[]` passes through to frontmatter. The round trip is lossless:
+
 ```markdown
 ---
 id: 550e8400
 type: semantic
 title: Dark Mode
+created: 2026-01-15T10:30:00Z
+relationships:
+  - type: relates-to
+    target: /semantic/ui-prefs.md
 ---
 
 # Dark Mode
@@ -1831,7 +1836,7 @@ User prefers dark mode
 
 ## Relationships
 
-- relates-to [ui-prefs](urn:mif:ui-prefs)
+- relates-to [UI Preferences](/semantic/ui-prefs.md)
 ```
 
 ### 15.4 Citations Conversion
@@ -2179,7 +2184,7 @@ citations:
     title: "Citation Title"    # REQUIRED
     url: https://example.com   # REQUIRED
     citationRole: supports     # REQUIRED
-    author: "Author Name"      # OPTIONAL (string or EntityReference)
+    author: "Author Name"      # OPTIONAL (string, EntityReference, or array)
     date: 2024-06-15           # OPTIONAL
     accessed: 2026-01-20       # OPTIONAL
     relevance: 0.95            # OPTIONAL (0-1)

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -195,7 +195,7 @@ bundle/
 │   │   ├── {id}.md
 │   │   └── {id}.jsonld
 │   └── ...
-└── README.md                       # Vault documentation
+└── README.md                       # Bundle documentation
 ```
 
 ---

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -38,7 +38,7 @@ MIF is designed to be:
 - **OKF-compliant**: every bundle is a valid OKF bundle (a tested invariant).
 - **Markdown-canonical**: the `.md` file is the source of truth; JSON-LD is a
   derived projection (Invariant 2).
-- **Human-Readable**: valid Obsidian-compatible notes in any Markdown editor.
+- **Human-Readable**: valid CommonMark notes in any Markdown editor.
 - **Machine-Processable**: JSON-LD with semantic web compatibility.
 - **Extensible**: domain profiles extend the base without breaking compatibility.
 
@@ -94,7 +94,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 - **Entity**: A named thing (person, organization, technology, concept, or file) that can participate in relationships.
 - **Relationship**: A typed, directed connection between two entities or between a memory and an entity.
 - **Namespace**: A hierarchical scope for organizing memories (e.g., `org/user/project/session`).
-- **Vault**: A collection of MIF files, analogous to an Obsidian vault.
+- **Bundle**: A collection of MIF files organized as a unit.
 - **Provider**: An AI memory system that can import or export MIF format.
 
 ---
@@ -105,34 +105,24 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 MIF defines two equivalent representations:
 
-1. **Markdown Format** (`.md`): Human-readable, Obsidian-compatible
+1. **Markdown Format** (`.md`): Human-readable, plain CommonMark
 2. **JSON-LD Format** (`.jsonld`): Machine-processable, semantically linked
 
 Both representations MUST be losslessly convertible to each other. A conforming implementation MAY support either or both formats.
 
-### 2.2 Obsidian Compatibility
+### 2.2 Markdown Conventions
 
-The Markdown format MUST be valid Obsidian notes, ensuring files work in Obsidian vaults without modification while remaining readable in any text editor or Markdown processor.
+The Markdown format is plain, vendor-neutral CommonMark — readable in any text editor or Markdown processor, and tied to no single tool. It uses a small set of conventions:
 
-#### Required Obsidian Features
+- **YAML Frontmatter**: Structured metadata at the top of files, enclosed in `---` delimiters, supporting typed fields (text, number, date, list).
 
-- **YAML Frontmatter**: Structured metadata at the top of files, enclosed in `---` delimiters. Obsidian's Properties panel reads and writes this data, supporting typed fields (text, number, date, checkbox, list).
+- **Relationships**: Typed relationships are authoritative in frontmatter `relationships[]` and mirrored in the body as standard markdown links (see 5.3).
 
-- **Wiki-Links**: Internal links using double-bracket syntax `[[Target Note]]` enable bidirectional linking. Obsidian automatically tracks backlinks, enabling graph visualization and relationship discovery. Links can include display text `[[Target|Display Text]]` and heading anchors `[[Target#Heading]]`.
-
-- **Block References**: Unique identifiers (`^block-id`) attached to paragraphs, list items, or other blocks enable granular linking and transclusion. References like `[[Note#^block-id]]` link to specific content within a file.
-
-- **Aliases**: The `aliases` frontmatter property allows notes to be found and linked using alternative names, improving discoverability.
+- **Aliases**: The `aliases` frontmatter property lets a memory be referred to by alternative names.
 
 - **Tags**: Both inline `#tags` and frontmatter `tags: [a, b]` are supported, with hierarchical tags using forward slashes (`#category/subcategory`).
 
-- **Standard Markdown**: All content uses CommonMark-compatible Markdown, ensuring portability to other tools and platforms.
-
-#### Optional Obsidian Extensions
-
-- **Callouts**: Admonition blocks using `> [!type]` syntax for notes, warnings, tips, etc.
-- **Embeds**: Transclusion using `![[Note]]` to embed content from other files
-- **Dataview Queries**: Compatible with Dataview plugin for vault-as-database queries
+- **Standard Markdown**: All content uses CommonMark-compatible Markdown, ensuring portability across tools and platforms.
 
 ### 2.3 Semantic Web Compatibility
 
@@ -187,12 +177,12 @@ dark-mode-preference.md
 
 ### 3.3 Directory Structure
 
-A MIF vault SHOULD follow this structure:
+A MIF bundle SHOULD follow this structure:
 
 ```text
-vault/
+bundle/
 ├── .mif/                           # MIF configuration
-│   ├── config.yaml                 # Vault configuration
+│   ├── config.yaml                 # Bundle configuration
 │   ├── context.jsonld              # Local JSON-LD context
 │   └── entities/                   # Entity definitions
 │       ├── person/
@@ -395,13 +385,8 @@ Memory content in Markdown format.
 
 ## Relationships (optional section)
 
-- relates-to [[Other Memory]]
-- derived-from [[Source Memory]]
-
-## Entities (optional section)
-
-- mentions @[[Person Name]]
-- uses @[[Technology Name]]
+- relates-to [Other Memory](/semantic/other-memory.md)
+- derived-from [Source Memory](/episodic/source-memory.md)
 ```
 
 ### 5.2 Frontmatter Schema
@@ -469,46 +454,25 @@ extensions:
 ---
 ```
 
-### 5.3 Wiki-Link Syntax
+### 5.3 Relationship Syntax
 
-MIF extends Obsidian wiki-link syntax for typed relationships:
-
-```markdown
-# Basic link (RelatesTo relationship)
-[[Other Memory]]
-
-# Typed relationship
-[[Other Memory|derives-from]]
-[[Other Memory|supersedes]]
-
-# Entity reference (prefixed with @)
-@[[Person Name]]
-@[[Technology Name|uses]]
-
-# Block reference
-[[Memory Name#^block-id]]
-
-# With display text
-[[Other Memory|derives-from|"See also"]]
-```
-
-### 5.4 Block References
-
-Blocks can be referenced for granular linking:
+Typed relationships are authoritative in the frontmatter `relationships[]` array and mirrored in the body as standard markdown links under a `## Relationships` section, one per line:
 
 ```markdown
-This is an important statement. ^important-point
+## Relationships
 
-- Key insight about the system ^insight-1
+- relates-to [Other Memory](/semantic/other-memory.md)
+- derived-from [Source Incident](/episodic/source-incident.md)
+- supersedes [Old Policy](/semantic/old-policy.md)
 ```
 
-Referenced as: `[[Memory Name#^important-point]]`
+Each line is `- <type> [Text](<target>)`, where `<type>` is a kebab-case relationship type and `<target>` is a bundle-relative path to the target concept or a `urn:mif:` identifier (see 8). Entity references are declared in the frontmatter `entities[]` array (see 7.5).
 
-### 5.5 Citations (Level 3)
+### 5.4 Citations (Level 3)
 
 Citations provide structured references to external sources that inform, support, or relate to the memory content. Citations are a Level 3 (Full) optional feature.
 
-#### 5.5.1 Frontmatter Schema
+#### 5.4.1 Frontmatter Schema
 
 ```yaml
 # === OPTIONAL: Citations (Level 3) ===
@@ -517,28 +481,28 @@ citations:
     title: "Memory Systems in AI Agents"   # REQUIRED: Citation title
     url: https://arxiv.org/abs/2024.12345  # REQUIRED: Valid URL
     role: supports                         # REQUIRED: Relationship to memory
-    author: "@[[Jane Smith|Person]]"       # OPTIONAL: Entity ref or text
+    author: "Jane Smith"                   # OPTIONAL: EntityReference or text
     date: 2024-06-15                       # OPTIONAL: Publication date
     accessed: 2026-01-20                   # OPTIONAL: Access date
     relevance: 0.95                        # OPTIONAL: Relevance score (0-1)
     note: "Foundational paper on semantic memory"  # OPTIONAL: Annotation
 ```
 
-#### 5.5.2 Citation Fields
+#### 5.4.2 Citation Fields
 
 | Field | Required | Type | Description |
 | --- | --- | --- | --- |
-| `type` | REQUIRED | Enum | Source category (see 5.5.3) |
+| `type` | REQUIRED | Enum | Source category (see 5.4.3) |
 | `title` | REQUIRED | String | Citation title |
 | `url` | REQUIRED | URI | Valid URL or URI |
-| `role` | REQUIRED | Enum | Relationship to memory (see 5.5.4) |
+| `role` | REQUIRED | Enum | Relationship to memory (see 5.4.4) |
 | `author` | OPTIONAL | String | Entity reference or plain text |
 | `date` | OPTIONAL | Date | Publication date (ISO 8601) |
 | `accessed` | OPTIONAL | Date | Access date (ISO 8601) |
 | `relevance` | OPTIONAL | Decimal | Relevance score (0.0-1.0) |
 | `note` | OPTIONAL | String | Free-form annotation |
 
-#### 5.5.3 Citation Types
+#### 5.4.3 Citation Types
 
 | Type | Description | Example |
 | --- | --- | --- |
@@ -557,7 +521,7 @@ citations:
 
 Custom types MAY use namespace prefixes: `acme:internal-memo`, `research:lab-notes`
 
-#### 5.5.4 Citation Roles
+#### 5.4.4 Citation Roles
 
 | Role | Description | Use Case |
 | --- | --- | --- |
@@ -574,46 +538,56 @@ Custom types MAY use namespace prefixes: `acme:internal-memo`, `research:lab-not
 
 Custom roles MAY use namespace prefixes: `research:replicates`, `legal:cites-precedent`
 
-#### 5.5.5 Body Section Syntax
+#### 5.4.5 Body Section Syntax
 
 An optional `## Citations` section MAY appear in the memory body for detailed annotations. When present, corresponding entries MUST exist in frontmatter.
 
 ```markdown
 ## Citations
 
-- [Memory Systems in AI Agents](https://arxiv.org/abs/2024.12345) by @[[Jane Smith|Person]] (2024)
+- [Memory Systems in AI Agents](https://arxiv.org/abs/2024.12345) by Jane Smith (2024)
   - **Type**: article
   - **Role**: supports
   - **Relevance**: 0.95
   - Foundational paper on semantic memory structures. Introduces bi-temporal
     model that informed MIF's temporal design.
 
-- [Obsidian Help](https://help.obsidian.md/) by @[[Obsidian Team|Organization]]
+- [JSON-LD 1.1](https://www.w3.org/TR/json-ld11/) by W3C
   - **Type**: documentation
   - **Role**: background
   - **Accessed**: 2026-01-18
-  - Reference for wiki-link syntax and block references.
+  - Reference for the JSON-LD projection format.
 ```
 
-#### 5.5.6 Author Entity References
+#### 5.4.6 Author Entity References
 
-Authors MAY use wiki-link syntax to reference MIF entities:
+A citation `author` MAY be plain text or one or more `EntityReference` objects (see 7.5):
 
 ```yaml
-# Single author entity
-author: "@[[Jane Smith|Person]]"
-
-# Multiple authors (comma-separated)
-author: "@[[Jane Smith|Person]], @[[John Doe|Person]]"
-
-# Organization author
-author: "@[[Anthropic|Organization]]"
-
-# Plain text (no entity reference)
+# Plain text
 author: "Jane Smith et al."
+
+# Single author as an entity reference
+author:
+  "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:person:jane-smith
+  entityType: Person
+  name: Jane Smith
+
+# Multiple authors
+author:
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:person:jane-smith }
+    entityType: Person
+    name: Jane Smith
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:organization:anthropic }
+    entityType: Organization
+    name: Anthropic
 ```
 
-#### 5.5.7 Citation Validation
+#### 5.4.7 Citation Validation
 
 Implementations SHOULD validate citations according to these rules:
 
@@ -621,16 +595,16 @@ Implementations SHOULD validate citations according to these rules:
 
 | Field | Constraint |
 | --- | --- |
-| `type` | MUST be a value from Section 5.5.3 or a custom namespaced type (e.g., `acme:memo`) |
+| `type` | MUST be a value from Section 5.4.3 or a custom namespaced type (e.g., `acme:memo`) |
 | `title` | MUST be a non-empty string |
 | `url` | MUST be a valid URI (http, https, or custom schemes) |
-| `role` | MUST be a value from Section 5.5.4 or a custom namespaced role (e.g., `legal:precedent`) |
+| `role` | MUST be a value from Section 5.4.4 or a custom namespaced role (e.g., `legal:precedent`) |
 
 ##### Optional Field Constraints
 
 | Field | Constraint |
 | --- | --- |
-| `author` | SHOULD be entity reference(s) `@[[Name\|Type]]` or plain text; multiple authors comma-separated |
+| `author` | SHOULD be an `EntityReference` (or array of them) or plain text |
 | `date` | MUST be ISO 8601 date format (`YYYY-MM-DD`) |
 | `accessed` | MUST be ISO 8601 date format (`YYYY-MM-DD`) |
 | `relevance` | MUST be decimal between 0.0 and 1.0 inclusive |
@@ -863,7 +837,7 @@ MIF provides an **extensible entity type system**. Implementations SHOULD suppor
 
 ### 7.1 Entity Type Architecture
 
-Entity types are **not hard-coded**. They are defined in vault configuration and can be extended per-project:
+Entity types are **not hard-coded**. They are defined in bundle configuration and can be extended per-project:
 
 ```yaml
 # .mif/config.yaml
@@ -987,14 +961,22 @@ properties:
 
 ### 7.5 Entity References in Memories
 
-#### Markdown
+Entity references are declared in the frontmatter `entities[]` array as `EntityReference` objects.
 
-```markdown
-## Entities
+#### Frontmatter
 
-- mentions @[[Jane Doe]]
-- uses @[[Python|Technology]]
-- about @[[Dark Mode|Concept]]
+```yaml
+entities:
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:person:jane-doe }
+    entityType: Person
+    name: Jane Doe
+    role: mentions
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:technology:python }
+    entityType: Technology
+    name: Python
+    role: uses
 ```
 
 #### JSON-LD
@@ -1017,7 +999,7 @@ MIF provides an **extensible relationship type system**. Implementations SHOULD 
 
 ### 8.1 Relationship Type Architecture
 
-Relationship types are **not hard-coded**. They are defined in vault configuration and can be extended per-project:
+Relationship types are **not hard-coded**. They are defined in bundle configuration and can be extended per-project:
 
 ```yaml
 # .mif/config.yaml
@@ -1144,19 +1126,19 @@ relationship_types:
 
 #### Markdown syntax
 
-Relationships use a simple `type [[target]]` format in a dedicated section:
+Relationships are mirrored in the body as standard markdown links under a `## Relationships` section:
 
 ```markdown
 ## Relationships
 
-- relates-to [[Other Memory]]
-- derived-from [[Source Memory]]
-- supersedes [[Old Memory]]
-- conflicts-with [[Contradicting Memory]]
-- part-of [[Parent Memory]]
+- relates-to [Other Memory](/semantic/other-memory.md)
+- derived-from [Source Memory](/episodic/source-memory.md)
+- supersedes [Old Memory](/semantic/old-memory.md)
+- conflicts-with [Contradicting Memory](/semantic/contradicting-memory.md)
+- part-of [Parent Memory](/semantic/parent-memory.md)
 ```
 
-The relationship type name is converted to kebab-case in Markdown. The target uses wiki-link syntax `[[]]` which resolves to the memory's `@id` or title.
+Each line is `- <type> [Text](<target>)`. The type is a kebab-case token; the target is a bundle-relative path to the target concept or a `urn:mif:` identifier. The frontmatter `relationships[]` array is authoritative; the body links are its OKF-legible mirror.
 
 #### JSON-LD schema
 
@@ -1738,7 +1720,7 @@ provenance:
 
 - `id`, `type`, `content`, `created` fields
 - Valid Markdown or JSON-LD structure
-- Basic wiki-link syntax
+- Standard markdown-link relationship syntax
 
 ### 13.2 Level 2: Standard (RECOMMENDED)
 
@@ -1802,22 +1784,17 @@ new major version of the specification.
 
 ### 15.1 Markdown to JSON-LD
 
-1. Parse YAML frontmatter as structured data
+1. Parse YAML frontmatter as structured data (including `relationships[]` and `entities[]`)
 2. Map frontmatter properties to JSON-LD using context
-3. Parse Markdown content for:
-   - Wiki-links → `relationships` array
-   - Entity references (@[[...]]) → `entities` array
-   - Block references (^id) → fragment identifiers
+3. Parse the body `## Relationships` section: each `- <type> [Text](<target>)` line maps to a `relationships` entry (reconciled with the authoritative frontmatter array)
 4. Convert body content to `content` field
 
 ### 15.2 JSON-LD to Markdown
 
-1. Generate YAML frontmatter from JSON-LD properties
+1. Generate YAML frontmatter from JSON-LD properties (including `relationships[]` and `entities[]`)
 2. Set first `title` or H1 from `dc:title`
 3. Convert `content` to Markdown body
-4. Append "## Relationships" section from `relationships`
-5. Append "## Entities" section from `entities`
-6. Convert `@id` URIs to wiki-links
+4. Append a "## Relationships" section, rendering each relationship as `- <type> [Text](<target>)`
 
 ### 15.3 Example Conversion
 
@@ -1851,7 +1828,7 @@ User prefers dark mode
 
 ## Relationships
 
-- relates-to [[ui-prefs]]
+- relates-to [ui-prefs](urn:mif:ui-prefs)
 ```
 
 ### 15.4 Citations Conversion
@@ -1862,8 +1839,8 @@ User prefers dark mode
 2. For each citation:
    - Map `type` → `citationType` vocabulary term
    - Map `role` → `citationRole` vocabulary term
-   - Resolve `@[[Entity|Type]]` author refs → entity URIs
-   - For multiple authors (comma-separated), convert to array of author objects
+   - Resolve `EntityReference` author objects → entity URIs
+   - For multiple authors (an array), convert to an array of author objects
    - Convert dates to ISO 8601 format
 3. If `## Citations` body section exists:
    - Parse markdown links for title/url
@@ -1874,7 +1851,7 @@ User prefers dark mode
 #### JSON-LD to Markdown
 
 1. Generate frontmatter `citations` array from JSON-LD
-2. Convert entity URIs to wiki-link syntax
+2. Convert entity URIs to `EntityReference` objects
 3. If any citation has `note` exceeding 100 characters:
    - Create `## Citations` body section
    - Format as markdown list with metadata
@@ -1888,7 +1865,11 @@ citations:
     title: "Research Paper"
     url: https://example.com/paper
     role: supports
-    author: "@[[Jane Smith|Person]]"
+    author:
+      "@type": EntityReference
+      entity: { "@id": urn:mif:entity:person:jane-smith }
+      entityType: Person
+      name: Jane Smith
 ```
 
 Converts to:
@@ -1952,6 +1933,19 @@ namespace: _semantic/decisions
 tags:
   - frontend
   - architecture
+entities:
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:technology:react }
+    entityType: Technology
+    name: React
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:technology:vuejs }
+    entityType: Technology
+    name: Vue.js
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:organization:project-x }
+    entityType: Organization
+    name: Project X
 ---
 
 # Use React over Vue for the dashboard
@@ -1975,14 +1969,8 @@ We will use React because:
 
 ## Relationships
 
-- relates-to [[frontend-architecture]]
-- supersedes [[vue-exploration]]
-
-## Entities
-
-- @[[React|Technology]]
-- @[[Vue.js|Technology]]
-- @[[Project X|Organization]]
+- relates-to [Frontend Architecture](/semantic/frontend-architecture.md)
+- supersedes [Vue Exploration](/semantic/vue-exploration.md)
 ```
 
 ### 16.3 Full Memory (Level 3)
@@ -2113,26 +2101,38 @@ extensions:
 
 | Markdown Syntax | JSON-LD `type` | Description |
 | --- | --- | --- |
-| `[[X]]` | `relates-to` | General relationship |
-| `[[X\|derived-from]]` | `derived-from` | Created from source |
-| `[[X\|supersedes]]` | `supersedes` | Replaces older |
-| `[[X\|conflicts-with]]` | `conflicts-with` | Contradicts |
-| `[[X\|part-of]]` | `part-of` | Component of |
-| `[[X\|implements]]` | `implements` | Realizes |
-| `[[X\|uses]]` | `uses` | Utilizes |
-| `[[X\|created-by]]` | `created-by` | Authored by |
-| `[[X\|mentioned-in]]` | `mentioned-in` | Referenced in |
+| `- relates-to [X](<target>)` | `relates-to` | General relationship |
+| `- derived-from [X](<target>)` | `derived-from` | Created from source |
+| `- supersedes [X](<target>)` | `supersedes` | Replaces older |
+| `- conflicts-with [X](<target>)` | `conflicts-with` | Contradicts |
+| `- part-of [X](<target>)` | `part-of` | Component of |
+| `- implements [X](<target>)` | `implements` | Realizes |
+| `- uses [X](<target>)` | `uses` | Utilizes |
+| `- created-by [X](<target>)` | `created-by` | Authored by |
+| `- mentioned-in [X](<target>)` | `mentioned-in` | Referenced in |
 
 ---
 
 ## Appendix C: Entity Reference Syntax
 
-| Markdown | Meaning |
-| --- | --- |
-| `@[[Name]]` | Reference entity by name |
-| `@[[Name\|Person]]` | Reference with explicit type |
-| `@[[Name\|uses]]` | Reference with relationship |
-| `@[[Name\|Technology\|uses]]` | Type and relationship |
+Entity references are declared in the frontmatter `entities[]` array as `EntityReference` objects:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `@type` | REQUIRED | Always `EntityReference` |
+| `entity.@id` | REQUIRED | Entity URN (`urn:mif:entity:<type>:<slug>`) |
+| `entityType` | OPTIONAL | `Person`, `Organization`, `Technology`, `Concept`, `File`, or a custom ontology type |
+| `name` | OPTIONAL | Display name |
+| `role` | OPTIONAL | Role in the memory (e.g. `author`, `mentions`, `uses`) |
+
+```yaml
+entities:
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:person:jane-doe }
+    entityType: Person
+    name: Jane Doe
+    role: mentions
+```
 
 ---
 
@@ -2178,7 +2178,7 @@ citations:
     title: "Citation Title"    # REQUIRED
     url: https://example.com   # REQUIRED
     role: supports             # REQUIRED
-    author: "@[[Name|Person]]" # OPTIONAL
+    author: "Author Name"      # OPTIONAL (string or EntityReference)
     date: 2024-06-15           # OPTIONAL
     accessed: 2026-01-20       # OPTIONAL
     relevance: 0.95            # OPTIONAL (0-1)
@@ -2190,7 +2190,7 @@ citations:
 ```markdown
 ## Citations
 
-- [Title](url) by @[[Author|Person]] (date)
+- [Title](url) by Author Name (date)
   - **Type**: article
   - **Role**: supports
   - **Relevance**: 0.95
@@ -2206,7 +2206,7 @@ citations:
 - [Dublin Core Metadata Terms](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/)
 - [W3C PROV-DM](https://www.w3.org/TR/prov-dm/)
 - [ISO 8601: Date and Time Format](https://www.iso.org/iso-8601-date-and-time-format.html)
-- [Obsidian Help](https://help.obsidian.md/)
+- [CommonMark Specification](https://spec.commonmark.org/)
 - [JSON Canvas Specification](https://jsoncanvas.org/)
 
 ---

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -477,10 +477,11 @@ Citations provide structured references to external sources that inform, support
 ```yaml
 # === OPTIONAL: Citations (Level 3) ===
 citations:
-  - type: article                          # REQUIRED: Source category
+  - "@type": Citation                      # REQUIRED: object type
+    citationType: article                  # REQUIRED: Source category
     title: "Memory Systems in AI Agents"   # REQUIRED: Citation title
     url: https://arxiv.org/abs/2024.12345  # REQUIRED: Valid URL
-    role: supports                         # REQUIRED: Relationship to memory
+    citationRole: supports                 # REQUIRED: Relationship to memory
     author: "Jane Smith"                   # OPTIONAL: EntityReference or text
     date: 2024-06-15                       # OPTIONAL: Publication date
     accessed: 2026-01-20                   # OPTIONAL: Access date
@@ -492,11 +493,12 @@ citations:
 
 | Field | Required | Type | Description |
 | --- | --- | --- | --- |
-| `type` | REQUIRED | Enum | Source category (see 5.4.3) |
+| `@type` | REQUIRED | Const | Always `Citation` |
+| `citationType` | REQUIRED | Enum | Source category (see 5.4.3) |
 | `title` | REQUIRED | String | Citation title |
 | `url` | REQUIRED | URI | Valid URL or URI |
-| `role` | REQUIRED | Enum | Relationship to memory (see 5.4.4) |
-| `author` | OPTIONAL | String | Entity reference or plain text |
+| `citationRole` | REQUIRED | Enum | Relationship to memory (see 5.4.4) |
+| `author` | OPTIONAL | EntityReference or String | Entity reference or plain text |
 | `date` | OPTIONAL | Date | Publication date (ISO 8601) |
 | `accessed` | OPTIONAL | Date | Access date (ISO 8601) |
 | `relevance` | OPTIONAL | Decimal | Relevance score (0.0-1.0) |
@@ -595,10 +597,11 @@ Implementations SHOULD validate citations according to these rules:
 
 | Field | Constraint |
 | --- | --- |
-| `type` | MUST be a value from Section 5.4.3 or a custom namespaced type (e.g., `acme:memo`) |
+| `@type` | MUST be `Citation` |
+| `citationType` | MUST be a value from Section 5.4.3 or a custom namespaced type (e.g., `acme:memo`) |
 | `title` | MUST be a non-empty string |
 | `url` | MUST be a valid URI (http, https, or custom schemes) |
-| `role` | MUST be a value from Section 5.4.4 or a custom namespaced role (e.g., `legal:precedent`) |
+| `citationRole` | MUST be a value from Section 5.4.4 or a custom namespaced role (e.g., `legal:precedent`) |
 
 ##### Optional Field Constraints
 
@@ -1835,18 +1838,14 @@ User prefers dark mode
 
 #### Markdown to JSON-LD
 
-1. Parse frontmatter `citations` array
-2. For each citation:
-   - Map `type` → `citationType` vocabulary term
-   - Map `role` → `citationRole` vocabulary term
-   - Resolve `EntityReference` author objects → entity URIs
-   - For multiple authors (an array), convert to an array of author objects
-   - Convert dates to ISO 8601 format
-3. If `## Citations` body section exists:
-   - Parse markdown links for title/url
-   - Extract metadata from `**Key**: value` patterns
-   - Merge with frontmatter (frontmatter takes precedence)
-4. Build `Citation` objects array
+1. Parse the frontmatter `citations` array. Each entry is already a `Citation`
+   object authored in its final shape (`@type: Citation`, `citationType`,
+   `citationRole`, `title`, `url`, ...).
+2. Pass each citation through to the JSON-LD projection verbatim — the converter
+   performs no field renaming. Author values are preserved as written (plain
+   text or an `EntityReference`).
+3. Any `## Citations` body section is authored content carried inside `content`;
+   the frontmatter `citations` array remains authoritative.
 
 #### JSON-LD to Markdown
 
@@ -1861,10 +1860,11 @@ User prefers dark mode
 ```yaml
 # Frontmatter
 citations:
-  - type: article
+  - "@type": Citation
+    citationType: article
     title: "Research Paper"
     url: https://example.com/paper
-    role: supports
+    citationRole: supports
     author:
       "@type": EntityReference
       entity: { "@id": urn:mif:entity:person:jane-smith }
@@ -2174,10 +2174,11 @@ entities:
 
 ```yaml
 citations:
-  - type: article              # REQUIRED
+  - "@type": Citation          # REQUIRED
+    citationType: article      # REQUIRED
     title: "Citation Title"    # REQUIRED
     url: https://example.com   # REQUIRED
-    role: supports             # REQUIRED
+    citationRole: supports     # REQUIRED
     author: "Author Name"      # OPTIONAL (string or EntityReference)
     date: 2024-06-15           # OPTIONAL
     accessed: 2026-01-20       # OPTIONAL

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1283,7 +1283,7 @@ Where `{root}` is either:
 
 - **Organization name** - private to that organization
 - **Reserved prefix** - special namespace with defined semantics. Two kinds of
-  reserved prefix exist (both begin with `_`): **visibility prefixes** that
+  reserved prefixes exist (both begin with `_`): **visibility prefixes** that
   control sharing scope, and **base-type prefixes** that name the cognitive
   memory type. Both are defined in 10.2.
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -242,9 +242,9 @@ MIF uses three **base memory types**, reflecting how human memory systems organi
 
 | Type | Description | Namespace Hint |
 | --- | --- | --- |
-| `semantic` | Facts, concepts, relationships, and knowledge | `semantic/*` |
-| `episodic` | Events, experiences, sessions, and timelines | `episodic/*` |
-| `procedural` | Step-by-step processes, runbooks, and patterns | `procedural/*` |
+| `semantic` | Facts, concepts, relationships, and knowledge | `_semantic/*` |
+| `episodic` | Events, experiences, sessions, and timelines | `_episodic/*` |
+| `procedural` | Step-by-step processes, runbooks, and patterns | `_procedural/*` |
 
 #### Base Type Descriptions
 
@@ -320,7 +320,7 @@ memory unit can declare directly:
 1. **`type`** (REQUIRED, see 4.2) — the cognitive memory type: `semantic`,
    `episodic`, or `procedural`.
 2. **`namespace`** (RECOMMENDED, see 10) — hierarchical scope that carries the
-   finer-grained label (e.g. `semantic/knowledge`, `episodic/sessions`).
+   finer-grained label (e.g. `_semantic/knowledge`, `_episodic/sessions`).
 
 A memory unit has no field to name an ontology-extended type directly. Instead,
 **ontologies define extended types and their namespace mappings** (OPTIONAL, see
@@ -328,15 +328,15 @@ A memory unit has no field to name an ontology-extended type directly. Instead,
 entry with a `base` type, and implementations express that extended type by
 following the referenced ontology's namespace hierarchy on the `namespace` axis
 above (e.g. an `incident` extended type whose `base` is `episodic`, reached via
-`episodic/incidents`). The extended type is therefore a richer label *on* the
+`_episodic/incidents`). The extended type is therefore a richer label *on* the
 namespace axis, not a separate third axis the unit declares.
 
-> **Note on namespace form.** The namespace examples in this section use the
-> unprefixed form (e.g. `semantic/knowledge`). Other sections (e.g. 4.2.1 and
-> 10.8.4) use the underscore-prefixed `_semantic/…` form. Section 10 is
-> authoritative for namespace structure; follow the form it defines for your
-> deployment. Where an ontology is referenced, follow the namespace hierarchy it
-> declares; the examples below omit ontology binding for clarity.
+> **Note on namespace form.** Base-type roots use the underscore-prefixed form
+> (`_semantic`, `_episodic`, `_procedural`); these are reserved base-type
+> prefixes (see 10.2), distinct from the visibility prefixes (`_public`,
+> `_shared`, `_local`, `_system`) defined alongside them. Where an ontology is
+> referenced, follow the namespace hierarchy it declares; the examples below
+> omit ontology binding for clarity.
 
 A **Fact** is a `semantic` memory — declarative knowledge that holds independently
 of any single moment:
@@ -344,7 +344,7 @@ of any single moment:
 ```yaml
 ---
 type: semantic
-namespace: semantic/knowledge
+namespace: _semantic/knowledge
 ---
 ```
 
@@ -354,14 +354,14 @@ carry `temporal` validity to bound when they hold (see 9):
 ```yaml
 ---
 type: episodic
-namespace: episodic/sessions
+namespace: _episodic/sessions
 temporal:
   validFrom: 2026-01-15T00:00:00Z
   validUntil: 2026-01-15T11:00:00Z
 ---
 ```
 
-Finer distinctions are added through the namespace (e.g. `episodic/incidents`),
+Finer distinctions are added through the namespace (e.g. `_episodic/incidents`),
 whose path MAY map to an ontology-extended type defined by a referenced ontology
 (e.g. an `incident` whose `base` is `episodic`) — not through a new unit-level
 field. Implementations SHOULD express domain categories through `type` +
@@ -1282,11 +1282,18 @@ Namespaces use a flexible scoping model with reserved prefixes for cross-organiz
 Where `{root}` is either:
 
 - **Organization name** - private to that organization
-- **Reserved prefix** - special namespace with defined semantics
+- **Reserved prefix** - special namespace with defined semantics. Two kinds of
+  reserved prefix exist (both begin with `_`): **visibility prefixes** that
+  control sharing scope, and **base-type prefixes** that name the cognitive
+  memory type. Both are defined in 10.2.
 
 ### 10.2 Reserved Namespace Prefixes
 
-Names beginning with underscore (`_`) are reserved for special namespaces:
+Names beginning with underscore (`_`) are reserved for special namespaces. Two
+kinds exist: **visibility prefixes** that control sharing scope, and
+**base-type prefixes** that name the cognitive memory type.
+
+#### Visibility Prefixes
 
 | Prefix | Visibility | Description |
 | --- | --- | --- |
@@ -1294,6 +1301,21 @@ Names beginning with underscore (`_`) are reserved for special namespaces:
 | `_shared` | Negotiated | Cross-organization sharing with explicit agreements |
 | `_local` | Local only | Never synchronized or exported |
 | `_system` | Implementation | Reserved for system/implementation use |
+
+#### Base-Type Prefixes
+
+Namespace paths use an underscore prefix (`_semantic`, `_episodic`,
+`_procedural`) to distinguish base-type namespaces from domain-specific
+namespaces. This convention ensures consistent namespace identification across
+implementations. Each base-type prefix corresponds to a base memory `type`
+(see 4.2) and is the top-level root of the base ontology's namespace hierarchy
+(see 10.8.2).
+
+| Prefix | Base type | Description |
+| --- | --- | --- |
+| `_semantic` | `semantic` | Facts, concepts, relationships - declarative knowledge |
+| `_episodic` | `episodic` | Events, experiences, timelines - time-bound records |
+| `_procedural` | `procedural` | Step-by-step processes - how-to knowledge |
 
 #### Examples
 
@@ -1440,23 +1462,24 @@ Ontologies are defined in YAML files with optional JSON-LD export:
 
 #### 10.8.2 Base Type Hierarchy
 
-The base ontology uses a three-tier hierarchy based on cognitive memory types:
+The base ontology uses a three-tier hierarchy based on cognitive memory types.
+Its three top-level roots are the base-type prefixes defined in 10.2:
 
 ```yaml
 namespaces:
-  semantic:                    # Facts, concepts, relationships
+  _semantic:                   # Facts, concepts, relationships
     type_hint: semantic
     children:
       decisions: {}
       knowledge: {}
       entities: {}
-  episodic:                    # Events, experiences, timelines
+  _episodic:                   # Events, experiences, timelines
     type_hint: episodic
     children:
       incidents: {}
       sessions: {}
       blockers: {}
-  procedural:                  # Step-by-step processes
+  _procedural:                 # Step-by-step processes
     type_hint: procedural
     children:
       runbooks: {}

--- a/adr/ADR-003-obsidian-compatibility.md
+++ b/adr/ADR-003-obsidian-compatibility.md
@@ -8,9 +8,10 @@ tags:
   - markdown
   - compatibility
   - wiki-links
-status: accepted
+status: superseded
+superseded_by: ADR-017-revert-obsidian-compatibility.md
 created: 2026-01-27
-updated: 2026-06-18
+updated: 2026-06-29
 author: MIF Maintainers
 project: MIF
 technologies:
@@ -20,6 +21,7 @@ audience:
   - developers
   - architects
 related:
+  - ADR-017-revert-obsidian-compatibility.md
   - ADR-002-dual-format-design.md
   - ADR-005-underscore-namespace-prefix.md
 ---
@@ -28,7 +30,16 @@ related:
 
 ## Status
 
-Accepted
+Superseded by [ADR-017](ADR-017-revert-obsidian-compatibility.md).
+
+The Obsidian-specific conventions decided here — wiki-link relationships,
+`@[[Name|Type]]` entity references, block references, and embeds — were never
+implemented by the canonical tooling (the OKF conformance gate requires
+markdown-link relationships; entity references are frontmatter `EntityReference`
+objects), so documenting them created a spec-versus-implementation contradiction
+(issue #183). ADR-017 reverts them. YAML frontmatter, plain-text/local-first
+storage, and folder-as-namespace are retained there. The original decision is
+preserved below for the record.
 
 ## Context
 

--- a/adr/ADR-017-revert-obsidian-compatibility.md
+++ b/adr/ADR-017-revert-obsidian-compatibility.md
@@ -1,0 +1,152 @@
+---
+title: "Revert Obsidian Compatibility"
+description: "MIF drops the Obsidian-specific Markdown conventions adopted in ADR-003 — wiki-links, @[[entity]] references, block references, and embeds — because none are supported by the canonical tooling, which already requires standard markdown-link relationships and frontmatter entity references. YAML frontmatter, plain-text/local-first storage, and folder-as-namespace are retained; they are not Obsidian-specific."
+type: adr
+category: architecture
+tags:
+  - markdown
+  - relationships
+  - entities
+  - commonmark
+  - vendor-neutral
+status: accepted
+created: 2026-06-29
+updated: 2026-06-29
+author: MIF Maintainers
+project: MIF
+technologies:
+  - markdown
+audience:
+  - developers
+  - architects
+supersedes:
+  - ADR-003-obsidian-compatibility.md
+related:
+  - ADR-003-obsidian-compatibility.md
+  - ADR-002-dual-format-design.md
+  - ADR-010-modeled-information-format-repositioning.md
+  - ADR-011-markdown-canonical-derived-jsonld.md
+  - ADR-012-okf-conformance-tested-invariant.md
+  - ADR-014-document-reference-not-embed.md
+---
+
+# ADR-017: Revert Obsidian Compatibility
+
+## Status
+
+Accepted — supersedes [ADR-003](ADR-003-obsidian-compatibility.md).
+
+## Context
+
+### Background and Problem Statement
+
+ADR-003 committed MIF's Markdown representation to Obsidian-specific conventions:
+wiki-link relationships (`[[target]]`, `[[Target|type]]`), `@[[Name|Type]]`
+entity references, block references (`^block-id`), and embeds (`![[ ]]`), framed
+as making a MIF store openable as an Obsidian vault.
+
+This conflicts with MIF's positioning as a **vendor-neutral** content model
+(ADR-010), the same principle that keeps source documents out of vendor schemas
+(ADR-014): binding the canonical Markdown to one editor's proprietary notation
+couples every MIF bundle to that vendor. The notation is also not what the
+tooling implements.
+
+That notation was never the format the tooling actually implements:
+
+- **Relationships.** The OKF conformance gate `scripts/okf_validate.py` matches a
+  body relationship line with `REL_LINE_RE` = `^-\s+([a-z0-9-]+)\s+\[[^\]]+\]\(([^)]+)\)\s*$`
+  — a standard markdown link `- <type> [Text](/path.md)`. A wiki-link line
+  (`- relates-to [[Other]]`) does **not** match and would fail the gate. The
+  schema defines `Relationship.target` as a bundle-relative path or `urn:mif:`
+  identifier (`schema/mif.schema.json`), not a wiki-link.
+- **Entities.** `scripts/mif_convert.py` carries `entities` as a frontmatter
+  passthrough; it does not parse `@[[...]]`. The canonical entity model is the
+  `EntityReference` object (`schema/definitions/entity-reference.schema.json`),
+  declared in frontmatter `entities[]` / `author`.
+- **Every shipped example** already used markdown-link `## Relationships` sections
+  and frontmatter entities. ADR-003's own 2026-06-18 audit records the example as
+  using "a markdown-link `## Relationships` section" — contradicting the wiki-link
+  decision the same ADR asserts.
+
+The result was a documentation-versus-implementation contradiction (issue #183):
+an author following the spec literally would write wiki-link relationships that
+the normative validator rejects. ADR-003's notation decision was, in practice,
+never adopted.
+
+### Decision Drivers
+
+1. **Vendor neutrality (ADR-010, ADR-014).** MIF's canonical Markdown must not
+   bind a bundle to any single vendor's tool. Wiki-links, `@[[...]]`, block
+   references, and embeds are Obsidian-proprietary; plain CommonMark with
+   markdown-link relationships works in any editor — Obsidian included — without
+   privileging it.
+2. **Spec must match the validated implementation.** The normative documents must
+   describe the forms the gates accept (markdown-link relationships, frontmatter
+   `EntityReference`), not a syntax the tooling rejects.
+2. **No special-case linter caveats.** Removing wiki-links removes the
+   "intentional unresolved-wiki-link warning" exception ADR-003 had to carve out
+   for Marksman.
+3. **Keep what is genuinely portable, drop what is editor-specific.** YAML
+   frontmatter, plain-text/local-first files, and folder-as-namespace are
+   standard and are retained; wiki-links, `@[[...]]`, block refs, and embeds are
+   Obsidian extensions and are dropped.
+
+## Decision
+
+Revert the Obsidian-specific conventions from ADR-003. Specifically:
+
+1. **Relationships** are authoritative in frontmatter `relationships[]` (target =
+   bundle-relative path or `urn:mif:` id) and mirrored in the body as standard
+   markdown links: `- <type> [Text](/path/target.md)`.
+2. **Entity references** are frontmatter `entities[]` / `author` `EntityReference`
+   objects (or plain text for `author`). The `@[[Name|Type]]` notation is removed.
+3. **Block references (`^block-id`) and embeds (`![[ ]]`) are removed.** This
+   includes deleting the `blocks` field from the schema (`mif.schema.json`,
+   `context.jsonld`) and the converter passthrough (`mif_convert.py`) — block
+   references are reachable only via wiki-link syntax, which is itself removed.
+4. **Obsidian is no longer a named compatibility target.** MIF Markdown is plain
+   CommonMark; it still opens in any Markdown editor (Obsidian included), but the
+   spec makes no Obsidian-specific guarantees.
+
+**Retained (not Obsidian-specific):** YAML frontmatter for metadata; plain-text,
+local-first files; folder-as-namespace layout (per [ADR-005](ADR-005-underscore-namespace-prefix.md)).
+
+## Consequences
+
+### Positive
+
+1. The spec now matches the OKF conformance gate and the schema — following it
+   produces bundles that validate.
+2. No more "expected wiki-link warnings" caveat; example files pass generic
+   Markdown tooling cleanly.
+3. One relationship form (markdown links) and one entity model
+   (`EntityReference`), already exercised by every example and the round-trip
+   converter.
+
+### Negative
+
+1. Authors relying on Obsidian's automatic backlink/graph features from
+   wiki-links lose that affordance. Relationships remain fully expressed as
+   markdown links; graph tooling that reads markdown links still works.
+
+### Neutral
+
+1. The relationship and entity forms need no code changes — the tooling already
+   implements them. The only code/schema change is removing the now-orphaned
+   `blocks` field (block references were reachable only via the removed wiki-link
+   syntax): dropped from `mif.schema.json`, `context.jsonld`, the
+   `mif_convert.py` passthrough, and the `test_temporal_and_properties.py`
+   fixture. The schema `$id` is unchanged (ADR-007); `blocks` was an OPTIONAL
+   field unused by any shipped example.
+
+## Related Decisions
+
+- [ADR-003: Obsidian Compatibility](ADR-003-obsidian-compatibility.md) — superseded by this decision.
+- [ADR-002: Dual Format Design](ADR-002-dual-format-design.md) — the Markdown half this ADR re-profiles.
+- [ADR-011: Markdown Canonical, JSON-LD Derived](ADR-011-markdown-canonical-derived-jsonld.md) — the canonical Markdown whose relationship/entity forms this ADR fixes.
+- [ADR-012: OKF Conformance as a Tested Invariant](ADR-012-okf-conformance-tested-invariant.md) — the conformance gate (`okf_validate.py`) that defines the canonical relationship form.
+
+## More Information
+
+- **Date:** 2026-06-29
+- **Source:** issue #183; `scripts/okf_validate.py` (`REL_LINE_RE`); `scripts/mif_convert.py` (entities passthrough); `schema/mif.schema.json` (`Relationship`, `EntityReference`).

--- a/adr/ADR-017-revert-obsidian-compatibility.md
+++ b/adr/ADR-017-revert-obsidian-compatibility.md
@@ -28,6 +28,7 @@ related:
   - ADR-011-markdown-canonical-derived-jsonld.md
   - ADR-012-okf-conformance-tested-invariant.md
   - ADR-014-document-reference-not-embed.md
+  - ADR-016-versioned-schema-mirror-publication.md
 ---
 
 # ADR-017: Revert Obsidian Compatibility
@@ -48,10 +49,13 @@ as making a MIF store openable as an Obsidian vault.
 This conflicts with MIF's positioning as a **vendor-neutral** content model
 (ADR-010), the same principle that keeps source documents out of vendor schemas
 (ADR-014): binding the canonical Markdown to one editor's proprietary notation
-couples every MIF bundle to that vendor. The notation is also not what the
-tooling implements.
+couples every MIF bundle to that vendor.
 
-That notation was never the format the tooling actually implements:
+Critically, **the Obsidian work was never implemented in the tooling.** No MIF
+tool ever parsed or emitted wiki-links, `@[[Name|Type]]` entity references, or
+block references — the converter, the OKF conformance gate, and the schema only
+ever supported the markdown-link and `EntityReference` forms. The Obsidian
+notation existed solely in the spec prose; it was documented but never built: 
 
 - **Relationships.** The OKF conformance gate `scripts/okf_validate.py` matches a
   body relationship line with `REL_LINE_RE` = `^-\s+([a-z0-9-]+)\s+\[[^\]]+\]\(([^)]+)\)\s*$`
@@ -83,13 +87,63 @@ never adopted.
 2. **Spec must match the validated implementation.** The normative documents must
    describe the forms the gates accept (markdown-link relationships, frontmatter
    `EntityReference`), not a syntax the tooling rejects.
-2. **No special-case linter caveats.** Removing wiki-links removes the
+3. **No special-case linter caveats.** Removing wiki-links removes the
    "intentional unresolved-wiki-link warning" exception ADR-003 had to carve out
    for Marksman.
-3. **Keep what is genuinely portable, drop what is editor-specific.** YAML
+4. **Keep what is genuinely portable, drop what is editor-specific.** YAML
    frontmatter, plain-text/local-first files, and folder-as-namespace are
    standard and are retained; wiki-links, `@[[...]]`, block refs, and embeds are
    Obsidian extensions and are dropped.
+
+## Considered Options
+
+### Option 1: Implement the Obsidian notation in the tooling
+
+**Description**: Keep ADR-003's wiki-link / `@[[...]]` / block-reference syntax and build parser + emitter support for it into `mif_convert.py` and `okf_validate.py`, making the documented format the implemented one.
+
+**Advantages**:
+- Preserves Obsidian's automatic backlink/graph affordances for authors.
+- Honors ADR-003 as written.
+
+**Disadvantages**:
+- Couples MIF's canonical format to one vendor's proprietary syntax — contradicts the vendor-neutral positioning (ADR-010, ADR-014).
+- Two parallel relationship representations to parse, round-trip, and keep consistent.
+- Retains the Marksman "expected unresolved-wiki-link" caveat.
+
+**Risk Assessment**:
+- **Technical Risk**: Medium. New parsing/emitting plus round-trip and OKF-legibility guarantees for a second syntax.
+- **Ecosystem Risk**: High. Entrenches the vendor coupling the project is otherwise moving away from.
+
+### Option 2: Leave the spec as-is (documented but unimplemented)
+
+**Description**: Make no change; keep the Obsidian notation in the prose even though no tool implements it.
+
+**Advantages**:
+- Zero immediate work.
+
+**Disadvantages**:
+- The documentation-versus-implementation contradiction (#183) persists: following the spec literally yields bundles the validator rejects.
+- Misrepresents MIF's actual, vendor-neutral format.
+
+**Risk Assessment**:
+- **Technical Risk**: Low (no change), but the latent defect keeps misleading implementers.
+- **Ecosystem Risk**: Medium. Erodes trust in the spec as a faithful description of the format.
+
+### Option 3: Remove the Obsidian notation; standardize on the implemented forms (chosen)
+
+**Description**: Drop wiki-links, `@[[...]]`, block references, and embeds from the spec; make the already-implemented markdown-link relationships and frontmatter `EntityReference`s the only documented forms; remove the orphaned `blocks` field.
+
+**Advantages**:
+- Spec matches the validated implementation; following it produces conformant bundles.
+- One relationship form and one entity model, both already exercised by every example and the round-trip converter.
+- Restores vendor neutrality; removes the Marksman caveat.
+
+**Disadvantages**:
+- Authors lose Obsidian's wiki-link backlink/graph affordance (markdown-link graph tooling still works).
+
+**Risk Assessment**:
+- **Technical Risk**: Low. No code path that anything used is removed — only documentation and an unused OPTIONAL schema field change.
+- **Ecosystem Risk**: Low. Non-breaking (existing data still validates); aligns the spec with reality.
 
 ## Decision
 
@@ -139,14 +193,79 @@ local-first files; folder-as-namespace layout (per [ADR-005](ADR-005-underscore-
    fixture. The schema `$id` is unchanged (ADR-007); `blocks` was an OPTIONAL
    field unused by any shipped example.
 
+## Schema Mirror at the Next Release (ADR-016)
+
+Removing `blocks` changes the canonical schema, but `v1.0.0` is already released,
+so per [ADR-016](ADR-016-versioned-schema-mirror-publication.md) its immutable
+mirror is **not** edited. The change reaches the published mirrors only when the
+next version is cut. Because removing an OPTIONAL field is non-breaking (the
+concept object permits additional properties, so existing `blocks`-bearing data
+still validates), this ships as a **MINOR** bump, `v1.1.0`.
+
+The mirror scheme has exactly three path kinds: exact immutable snapshots
+(`X.Y.Z`, unprefixed), the global `latest` alias, and `vMAJOR` aliases only
+(`v0`, `v1`; `v2` reserved) — there are no minor-level aliases. Running
+`scripts/snapshot-schema-version.py 1.1.0` then yields:
+
+| Path | After v1.1.0 | Mutability |
+| --- | --- | --- |
+| `/schema/1.1.0/<file>` | **new** snapshot ← tag `v1.1.0` (no `blocks`) | immutable |
+| `/schema/latest/<file>` | **moves** → 1.1.0 | tracks newest |
+| `/schema/v1/<file>` | **moves** 1.0.0 → 1.1.0 (newest 1.x) | major alias |
+| `/schema/1.0.0/<file>` | unchanged | immutable |
+| `/schema/v0/<file>` | unchanged → still 0.1.0 (newest 0.x) | major alias |
+| `/schema/0.1.0/<file>` | unchanged | immutable |
+| `/schema/<file>` (root, `$id`) | already 1.1.0 bytes (no `blocks`) | moves with releases |
+
+So `v1` and `latest` advance to 1.1.0; `1.0.0`, `0.1.0`, and `v0` are untouched.
+The canonical `$id` stays unversioned throughout (ADR-007). This PR changes only
+the source schemas and the unversioned canonical root; the versioned mirrors are
+regenerated by the snapshot script at release.
+
+## Decision Outcome
+
+Chose Option 3. It resolves the documentation-versus-implementation
+contradiction at its root: the spec now describes only the forms the tooling
+already validates, MIF's canonical Markdown is vendor-neutral CommonMark, and no
+functional capability is lost because the Obsidian notation was never
+implemented. The single schema change — removing the unused OPTIONAL `blocks`
+field — is non-breaking and reaches the published mirrors at the next release
+(`v1.1.0`) per the table above.
+
 ## Related Decisions
 
 - [ADR-003: Obsidian Compatibility](ADR-003-obsidian-compatibility.md) — superseded by this decision.
 - [ADR-002: Dual Format Design](ADR-002-dual-format-design.md) — the Markdown half this ADR re-profiles.
+- [ADR-010: Modeled Information Format Repositioning](ADR-010-modeled-information-format-repositioning.md) — the vendor-neutrality positioning that motivates dropping editor-specific notation.
+- [ADR-014: Document Reference, Not Embed](ADR-014-document-reference-not-embed.md) — the same keep-vendor-notation-out principle applied to source documents.
 - [ADR-011: Markdown Canonical, JSON-LD Derived](ADR-011-markdown-canonical-derived-jsonld.md) — the canonical Markdown whose relationship/entity forms this ADR fixes.
 - [ADR-012: OKF Conformance as a Tested Invariant](ADR-012-okf-conformance-tested-invariant.md) — the conformance gate (`okf_validate.py`) that defines the canonical relationship form.
+- [ADR-016: Per-Version Schema Mirror Publication](ADR-016-versioned-schema-mirror-publication.md) — governs how the `blocks` removal reaches the versioned mirrors at the next release (see the table above).
 
 ## More Information
 
 - **Date:** 2026-06-29
 - **Source:** issue #183; `scripts/okf_validate.py` (`REL_LINE_RE`); `scripts/mif_convert.py` (entities passthrough); `schema/mif.schema.json` (`Relationship`, `EntityReference`).
+
+## Audit
+
+### 2026-06-29
+
+**Status:** Compliant
+
+**Findings:**
+
+| Finding | Files | Assessment |
+|---------|-------|------------|
+| Relationships documented only as body markdown links mirroring frontmatter `relationships[]` | `SPECIFICATION.md` §5.3/§8.4; `src/content/docs/specification/markdown-format.mdx` | compliant |
+| Entity references documented only as frontmatter `entities[]` / `EntityReference` | `SPECIFICATION.md` §7.5; `src/content/docs/specification/entity-types.mdx` | compliant |
+| `blocks` field removed from schema, context, converter passthrough, and test fixture | `schema/mif.schema.json`, `schema/context.jsonld`, `public/schema/mif.schema.json`, `public/schema/context.jsonld`, `scripts/mif_convert.py`, `scripts/test_temporal_and_properties.py` | compliant |
+| No wiki-link / `@[[...]]` / `^block-id` / embed syntax remains in spec, docs, or examples (excluding migration history and immutable mirrors) | repo-wide sweep | compliant |
+| OKF conformance, lossless round-trip, JSON-LD schema validation, ontology/namespace validation, and Astro build all pass | CI gates | compliant |
+
+**Summary:** The Obsidian-specific notation is removed across the spec, published
+`.mdx`, schema source + unversioned canonical, converter, tests, examples,
+positioning docs, and branding. Immutable versioned schema mirrors (ADR-016) and
+genuine migration history are intentionally retained.
+
+**Action Required:** None.

--- a/adr/README.md
+++ b/adr/README.md
@@ -16,7 +16,7 @@ ADRs follow the **Structured MADR** format — an extension of [MADR](https://ad
 |-----|-------|--------|-------------|
 | [ADR-001](ADR-001-cognitive-triad-taxonomy.md) | Cognitive Triad Taxonomy | Accepted | Adopts the cognitive triad (semantic, episodic, procedural) as the foundational concept taxonomy — MIF's answer to OKF's absent concept-type system |
 | [ADR-002](ADR-002-dual-format-design.md) | Dual-Format Design (Markdown + JSON-LD) | Accepted | Supports both Markdown and JSON-LD as first-class formats (refined by ADR-011: Markdown is canonical) |
-| [ADR-003](ADR-003-obsidian-compatibility.md) | Obsidian Compatibility | Accepted | Ensures Markdown memories are fully compatible with Obsidian vaults and conventions |
+| [ADR-003](ADR-003-obsidian-compatibility.md) | Obsidian Compatibility | Superseded (by ADR-017) | Originally adopted Obsidian-specific conventions (wiki-links, `@[[]]`, block references); reverted by ADR-017 for vendor neutrality |
 | [ADR-004](ADR-004-three-tier-trait-inheritance.md) | Three-Tier Trait Inheritance | Accepted | Defines a three-level trait inheritance model: mif-base, shared-traits, domain ontologies |
 | [ADR-005](ADR-005-underscore-namespace-prefix.md) | Underscore Namespace Prefix Convention | Accepted | Uses underscore prefix for base-type namespace directories to distinguish from domain content |
 | [ADR-006](ADR-006-entitydata-vs-entityreference.md) | EntityData vs EntityReference | Accepted | Distinguishes inline structured entity data from lightweight entity references |
@@ -30,6 +30,7 @@ ADRs follow the **Structured MADR** format — an extension of [MADR](https://ad
 | [ADR-014](ADR-014-document-reference-not-embed.md) | Document References, Not Embedded Vendor Schema | Accepted | Source documents travel by vendor-neutral `DocumentReference` (pointer + integrity metadata), not by embedding a vendor model like DoclingDocument (reframes issue #77) |
 | [ADR-015](ADR-015-attested-release-orchestration.md) | Attested Release Orchestration | Accepted | Every release is SLSA-attested (provenance + CycloneDX SBOM, fail-closed verify), with the full SAST/DAST/SCA/posture gate suite wired by SHA pin to the org's central reusable workflows |
 | [ADR-016](ADR-016-versioned-schema-mirror-publication.md) | Per-Version Schema Mirror Publication | Accepted | Each release publishes an immutable versioned schema mirror (`/schema/X.Y.Z/`, `latest/`, `vMAJOR/`) served by the doc site, keeping canonical `$id` values unversioned per ADR-007 |
+| [ADR-017](ADR-017-revert-obsidian-compatibility.md) | Revert Obsidian Compatibility | Accepted | Supersedes ADR-003: drops Obsidian-specific notation (wiki-links, `@[[]]`, block references, embeds) for vendor-neutral CommonMark with markdown-link relationships and frontmatter `EntityReference`s |
 
 ## Creating New ADRs
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -120,6 +120,20 @@ title: "Use PostgreSQL for Data Storage"
 tags:
   - database
   - architecture
+relationships:
+  - type: relates-to
+    target: /semantic/database-requirements.md
+  - type: supersedes
+    target: /semantic/sqlite-investigation.md
+entities:
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:technology:postgresql }
+    entityType: Technology
+    name: PostgreSQL
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:technology:mysql }
+    entityType: Technology
+    name: MySQL
 ---
 
 # Use PostgreSQL for Data Storage
@@ -137,13 +151,8 @@ PostgreSQL for:
 
 ## Relationships
 
-- relates-to [[database-requirements]]
-- supersedes [[sqlite-investigation]]
-
-## Entities
-
-- @[[PostgreSQL|Technology]]
-- @[[MySQL|Technology]]
+- relates-to [Database Requirements](/semantic/database-requirements.md)
+- supersedes [SQLite Investigation](/semantic/sqlite-investigation.md)
 ```
 
 ### Level 3: Full

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -193,12 +193,12 @@ citations:
 
 ## Directory Structure
 
-Organize your MIF vault using the three base types:
+Organize your MIF bundle using the three base types:
 
 ```
 my-project/
 ├── .mif/
-│   ├── config.yaml           # Vault configuration
+│   ├── config.yaml           # Bundle configuration
 │   └── entities/             # Entity definitions
 ├── memories/
 │   ├── semantic/             # Facts, concepts, knowledge

--- a/docs/SCHEMA-REFERENCE.md
+++ b/docs/SCHEMA-REFERENCE.md
@@ -76,7 +76,6 @@ Ontologies can define extended types that map to these base types via namespace 
 | `namespace` | string (pattern) | Hierarchical scope |
 | `tags` | array of strings | Classification tags |
 | `aliases` | array of strings | Alternative names |
-| `blocks` | object (string → string) | Named block references (`^block-id`) mapped to their text content, for granular linking |
 | `properties` | object (string → string/number/boolean/null) | First-class scalar key/value pairs (e.g. from a knowledge-graph literal-object triple) with no concept target, so they cannot be a relationship. Values MUST be scalar; nested objects/arrays are out of scope at Level 1 |
 
 #### Ontology Reference

--- a/ns/README.md
+++ b/ns/README.md
@@ -60,7 +60,6 @@ The MIF vocabulary defines terms for portable AI memory representation.
 | `namespace` | `mif:namespace` | -- | Hierarchical scope for categorization |
 | `tags` | `mif:tags` | `@set` | Classification tags |
 | `aliases` | `mif:aliases` | `@set` | Alternative names or identifiers |
-| `blocks` | `mif:blocks` | `@index` | Named content blocks |
 | `created` | `dc:created` | `xsd:dateTime` | Creation timestamp |
 | `modified` | `dc:modified` | `xsd:dateTime` | Last modification timestamp |
 | `name` | `schema:name` | -- | Display name (from Schema.org) |

--- a/ontologies/examples/memories/agriculture/grazing-plan-example.md
+++ b/ontologies/examples/memories/agriculture/grazing-plan-example.md
@@ -13,6 +13,12 @@ tags:
 relationships:
 - type: documents
   target: /herd-beef-main.md
+- type: located-on
+  target: /field-pasture-north.md
+- type: located-on
+  target: /field-pasture-south.md
+- type: contributes-to
+  target: /carbon-credit-2026.md
 temporal:
   '@type': TemporalMetadata
   validFrom: '2026-04-01T00:00:00Z'
@@ -101,6 +107,6 @@ Check weekly:
 ## Relationships
 
 - documents [Herd Beef Main](/herd-beef-main.md)
-- located-on [[field-pasture-north]]
-- located-on [[field-pasture-south]]
-- contributes-to [[carbon-credit-2026]]
+- located-on [Field Pasture North](/field-pasture-north.md)
+- located-on [Field Pasture South](/field-pasture-south.md)
+- contributes-to [Carbon Credit 2026](/carbon-credit-2026.md)

--- a/ontologies/examples/memories/biology-lab/grant-example.md
+++ b/ontologies/examples/memories/biology-lab/grant-example.md
@@ -153,5 +153,5 @@ Test lead compounds in PDX mouse models of PDAC.
 - leads [Project Aim1 Metabolomics](/project-aim1-metabolomics.md)
 - leads [Project Aim2 Targets](/project-aim2-targets.md)
 - leads [Project Aim3 Preclinical](/project-aim3-preclinical.md)
-- funded-by [Nih Nci](/nih-nci.md)
+- funded-by [NIH NCI](/nih-nci.md)
 - produces [Dataset Metabolomics 2025](/dataset-metabolomics-2025.md)

--- a/ontologies/examples/memories/biology-lab/grant-example.md
+++ b/ontologies/examples/memories/biology-lab/grant-example.md
@@ -20,6 +20,8 @@ relationships:
   target: /project-aim3-preclinical.md
 - type: produces
   target: /dataset-metabolomics-2025.md
+- type: funded-by
+  target: /nih-nci.md
 temporal:
   '@type': TemporalMetadata
   validFrom: '2025-07-01T00:00:00Z'
@@ -151,5 +153,5 @@ Test lead compounds in PDX mouse models of PDAC.
 - leads [Project Aim1 Metabolomics](/project-aim1-metabolomics.md)
 - leads [Project Aim2 Targets](/project-aim2-targets.md)
 - leads [Project Aim3 Preclinical](/project-aim3-preclinical.md)
-- funded-by [[nih-nci]]
+- funded-by [Nih Nci](/nih-nci.md)
 - produces [Dataset Metabolomics 2025](/dataset-metabolomics-2025.md)

--- a/ontologies/examples/memories/biology-lab/protocol-example.md
+++ b/ontologies/examples/memories/biology-lab/protocol-example.md
@@ -10,6 +10,13 @@ tags:
 - western-blot
 - protein
 - molecular-biology
+relationships:
+- type: uses-equipment
+  target: /equipment-chemidoc.md
+- type: uses-equipment
+  target: /equipment-transblot.md
+- type: used-by
+  target: /experiment-metabolic-screen-001.md
 temporal:
   '@type': TemporalMetadata
   validFrom: '2026-01-01T00:00:00Z'
@@ -196,6 +203,6 @@ expression. Version 2.1 updated January 2026.
 
 ## Relationships
 
-- uses-equipment [[equipment-chemidoc]]
-- uses-equipment [[equipment-transblot]]
-- used-by [[experiment-metabolic-screen-001]]
+- uses-equipment [Equipment Chemidoc](/equipment-chemidoc.md)
+- uses-equipment [Equipment Transblot](/equipment-transblot.md)
+- used-by [Experiment Metabolic Screen 001](/experiment-metabolic-screen-001.md)

--- a/ontologies/examples/memories/publishing/editorial-workflow-example.md
+++ b/ontologies/examples/memories/publishing/editorial-workflow-example.md
@@ -10,6 +10,11 @@ tags:
 - workflow
 - mathematics
 - production
+relationships:
+- type: applies-to
+  target: /program-into-math.md
+- type: owned-by
+  target: /editorial-team-math.md
 temporal:
   '@type': TemporalMetadata
   validFrom: '2026-01-01T00:00:00Z'
@@ -171,5 +176,5 @@ Month:  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20
 
 ## Relationships
 
-- applies-to [[program-into-math]]
-- owned-by [[editorial-team-math]]
+- applies-to [Program Into Math](/program-into-math.md)
+- owned-by [Editorial Team Math](/editorial-team-math.md)

--- a/ontologies/examples/memories/publishing/state-adoption-example.md
+++ b/ontologies/examples/memories/publishing/state-adoption-example.md
@@ -137,5 +137,5 @@ Based on previous cycles, focus preparation on:
 ## Relationships
 
 - submitted-to [Into Math K8 Program](/into-math-k8-program.md)
-- relates-to [Teks Math Standards](/teks-math-standards.md)
-- relates-to [Adoption Ca Math 2025](/adoption-ca-math-2025.md)
+- relates-to [TEKS Math Standards](/teks-math-standards.md)
+- relates-to [Adoption CA Math 2025](/adoption-ca-math-2025.md)

--- a/ontologies/examples/memories/publishing/state-adoption-example.md
+++ b/ontologies/examples/memories/publishing/state-adoption-example.md
@@ -10,6 +10,13 @@ tags:
 - texas
 - mathematics
 - k-8
+relationships:
+- type: submitted-to
+  target: /into-math-k8-program.md
+- type: relates-to
+  target: /teks-math-standards.md
+- type: relates-to
+  target: /adoption-ca-math-2025.md
 temporal:
   '@type': TemporalMetadata
   validFrom: '2026-01-01T00:00:00Z'
@@ -129,6 +136,6 @@ Based on previous cycles, focus preparation on:
 
 ## Relationships
 
-- submitted-to [[into-math-k8-program]]
-- relates-to [[teks-math-standards]]
-- relates-to [[adoption-ca-math-2025]]
+- submitted-to [Into Math K8 Program](/into-math-k8-program.md)
+- relates-to [Teks Math Standards](/teks-math-standards.md)
+- relates-to [Adoption Ca Math 2025](/adoption-ca-math-2025.md)

--- a/profiles/ai-memory/examples/level-2-standard.md
+++ b/profiles/ai-memory/examples/level-2-standard.md
@@ -20,6 +20,27 @@ relationships:
   target: /frontend-architecture-standards.md
 - type: part-of
   target: /project-x-technical-decisions.md
+entities:
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:technology:react
+  entityType: Technology
+  name: React
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:technology:typescript
+  entityType: Technology
+  name: TypeScript
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:technology:vue-js
+  entityType: Technology
+  name: Vue.js
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:concept:project-x-dashboard
+  entityType: Concept
+  name: Project X Dashboard
 ---
 
 # Use React for Dashboard Frontend
@@ -51,10 +72,3 @@ We will use **React** with TypeScript for the dashboard frontend.
 - supersedes [Vue Exploration 2025](/vue-exploration-2025.md)
 - relates-to [Frontend Architecture Standards](/frontend-architecture-standards.md)
 - part-of [Project X Technical Decisions](/project-x-technical-decisions.md)
-
-## Entities
-
-- @[[React|Technology]]
-- @[[TypeScript|Technology]]
-- @[[Vue.js|Technology]]
-- @[[Project X Dashboard|Concept]]

--- a/profiles/ai-memory/examples/level-3-citations.md
+++ b/profiles/ai-memory/examples/level-3-citations.md
@@ -137,11 +137,11 @@ entities:
 
 ## Context
 
-Our AI systems currently use proprietary memory formats that are incompatible across different providers (Mem0, Zep, Letta, Subcog). This creates vendor lock-in and prevents memory portability when switching or combining AI memory systems. ^context
+Our AI systems currently use proprietary memory formats that are incompatible across different providers (Mem0, Zep, Letta, Subcog). This creates vendor lock-in and prevents memory portability when switching or combining AI memory systems.
 
 ## Decision
 
-We will adopt the **Modeled Information Format (MIF)** as our standard for AI memory representation and interchange. ^decision
+We will adopt the **Modeled Information Format (MIF)** as our standard for AI memory representation and interchange.
 
 ### Key Factors
 

--- a/profiles/ai-memory/examples/level-3-citations.md
+++ b/profiles/ai-memory/examples/level-3-citations.md
@@ -54,7 +54,7 @@ citations:
   title: Modeled Information Format (MIF) Specification
   url: https://github.com/zircote/subcog/blob/main/SPECIFICATION.md
   citationRole: source
-  author: '@[[Robert Allen|Person]]'
+  author: Robert Allen
   date: '2026-01-23'
   accessed: '2026-01-20'
   relevance: 1.0
@@ -64,17 +64,17 @@ citations:
   title: The Case for Portable AI Memory
   url: https://example.com/ai-memory-portability
   citationRole: supports
-  author: '@[[Jane Smith|Person]], @[[John Doe|Person]]'
+  author: Jane Smith, John Doe
   date: '2025-11-15'
   accessed: '2026-01-18'
   relevance: 0.92
   note: Research article supporting vendor-neutral memory formats
 - '@type': Citation
   citationType: documentation
-  title: Obsidian Help Documentation
-  url: https://help.obsidian.md/
+  title: CommonMark Specification
+  url: https://spec.commonmark.org/
   citationRole: background
-  author: '@[[Obsidian Team|Organization]]'
+  author: CommonMark
   accessed: '2026-01-19'
   relevance: 0.85
 - '@type': Citation
@@ -82,7 +82,7 @@ citations:
   title: Bi-temporal Data Models in Knowledge Systems
   url: https://arxiv.org/abs/2024.54321
   citationRole: methodology
-  author: '@[[Research Group|Organization]]'
+  author: Research Group
   date: '2024-08-20'
   relevance: 0.78
   note: Theoretical foundation for MIF's temporal model
@@ -91,7 +91,7 @@ citations:
   title: Subcog Memory System
   url: https://github.com/zircote/subcog
   citationRole: extends
-  author: '@[[Robert Allen|Person]]'
+  author: Robert Allen
   accessed: '2026-01-20'
   relevance: 0.88
 documents:
@@ -110,6 +110,27 @@ extensions:
   subcog:
     domain: architecture
     hash: sha256:7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a
+entities:
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:technology:mif
+  entityType: Technology
+  name: MIF
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:technology:subcog
+  entityType: Technology
+  name: Subcog
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:technology:json-ld
+  entityType: Technology
+  name: JSON-LD
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:organization:engineering-architecture-team
+  entityType: Organization
+  name: Engineering Architecture Team
 ---
 
 # Adopt MIF for AI Memory Portability
@@ -125,7 +146,7 @@ We will adopt the **Modeled Information Format (MIF)** as our standard for AI me
 ### Key Factors
 
 1. **Dual Representation**: MIF provides both human-readable Markdown and machine-processable JSON-LD formats
-2. **Obsidian Compatibility**: Direct integration with our existing knowledge management workflows
+2. **Plain-Markdown Compatibility**: Works in any Markdown editor, integrating with our existing knowledge management workflows
 3. **Semantic Web Support**: JSON-LD enables RDF tooling and semantic queries
 4. **Local-First**: No cloud dependencies, full data ownership
 5. **Extensibility**: Custom properties without breaking compatibility
@@ -136,7 +157,7 @@ We will adopt the **Modeled Information Format (MIF)** as our standard for AI me
 
 - Memories portable between AI providers
 - Human-readable format for manual review and editing
-- Compatible with existing Obsidian vaults
+- Works in any Markdown editor
 - Future-proof with semantic web standards
 
 ### Negative
@@ -159,31 +180,23 @@ We will adopt the **Modeled Information Format (MIF)** as our standard for AI me
 - part-of [Platform Architecture Decisions](/platform-architecture-decisions.md)
 - implements [Memory Portability Requirement](/memory-portability-requirement.md)
 
-## Entities
-
-- @[[MIF|Technology]]
-- @[[Subcog|Technology]]
-- @[[Obsidian|Technology]]
-- @[[JSON-LD|Technology]]
-- @[[Engineering Architecture Team|Organization]]
-
 ## Citations
 
-- [Modeled Information Format (MIF) Specification](https://github.com/zircote/subcog/blob/main/SPECIFICATION.md) by @[[Robert Allen|Person]] (2026)
+- [Modeled Information Format (MIF) Specification](https://github.com/zircote/subcog/blob/main/SPECIFICATION.md) by Robert Allen (2026)
   - **Type**: specification
   - **Role**: source
   - **Relevance**: 1.0
   - Primary specification document defining the format we are adopting. This is the authoritative
     source for MIF structure, conformance levels, and implementation requirements.
 
-- [The Case for Portable AI Memory](https://example.com/ai-memory-portability) by @[[Jane Smith|Person]], @[[John Doe|Person]] (2025)
+- [The Case for Portable AI Memory](https://example.com/ai-memory-portability) by Jane Smith, John Doe (2025)
   - **Type**: article
   - **Role**: supports
   - **Relevance**: 0.92
   - Research article arguing for vendor-neutral memory formats in AI systems. Provides empirical
     evidence for productivity gains and reduced lock-in risks.
 
-- [Bi-temporal Data Models in Knowledge Systems](https://arxiv.org/abs/2024.54321) by @[[Research Group|Organization]] (2024)
+- [Bi-temporal Data Models in Knowledge Systems](https://arxiv.org/abs/2024.54321) by Research Group (2024)
   - **Type**: paper
   - **Role**: methodology
   - **Relevance**: 0.78

--- a/profiles/ai-memory/examples/level-3-full.md
+++ b/profiles/ai-memory/examples/level-3-full.md
@@ -62,6 +62,27 @@ extensions:
   subcog:
     domain: user
     hash: sha256:4c04b32ddc2053b5a8f9e2d1c0b7a6e5d4c3b2a1
+entities:
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:person:jane-doe
+  entityType: Person
+  name: Jane Doe
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:technology:vs-code
+  entityType: Technology
+  name: VS Code
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:concept:dark-mode
+  entityType: Concept
+  name: Dark Mode
+- "@type": EntityReference
+  entity:
+    "@id": urn:mif:entity:concept:accessibility
+  entityType: Concept
+  name: Accessibility
 ---
 
 # Dark Mode UI Preference
@@ -99,10 +120,3 @@ This preference has been confirmed multiple times:
 - relates-to [Ide Configuration Preferences](/ide-configuration-preferences.md)
 - relates-to [Terminal Setup](/terminal-setup.md)
 - part-of [User Jane Doe Profile](/user-jane-doe-profile.md)
-
-## Entities
-
-- @[[Jane Doe|Person]]
-- @[[VS Code|Technology]]
-- @[[Dark Mode|Concept]]
-- @[[Accessibility|Concept]]

--- a/profiles/ai-memory/examples/level-3-full.md
+++ b/profiles/ai-memory/examples/level-3-full.md
@@ -87,11 +87,11 @@ entities:
 
 # Dark Mode UI Preference
 
-User strongly prefers dark mode for all applications. ^main-preference
+User strongly prefers dark mode for all applications.
 
 ## Details
 
-This preference applies to: ^details
+This preference applies to:
 
 - **IDE/Editor**: VS Code, JetBrains IDEs
 - **Terminal**: iTerm2, built-in terminal

--- a/public/ns/vocabulary.jsonld
+++ b/public/ns/vocabulary.jsonld
@@ -295,12 +295,6 @@
       "rdfs:comment": "Alternative names or identifiers."
     },
     {
-      "@id": "mif:blocks",
-      "@type": "rdf:Property",
-      "rdfs:label": "blocks",
-      "rdfs:comment": "Named content blocks."
-    },
-    {
       "@id": "mif:byteLength",
       "@type": "rdf:Property",
       "rdfs:label": "byteLength",

--- a/public/schema/citation.schema.json
+++ b/public/schema/citation.schema.json
@@ -143,8 +143,8 @@
       "@type": "Citation",
       "citationType": "documentation",
       "citationRole": "background",
-      "title": "Obsidian Help",
-      "url": "https://help.obsidian.md/",
+      "title": "JSON-LD 1.1",
+      "url": "https://www.w3.org/TR/json-ld11/",
       "accessed": "2026-01-18",
       "relevance": 0.85
     }

--- a/public/schema/context.jsonld
+++ b/public/schema/context.jsonld
@@ -48,10 +48,6 @@
       "@id": "mif:aliases",
       "@container": "@set"
     },
-    "blocks": {
-      "@id": "mif:blocks",
-      "@container": "@index"
-    },
 
     "created": {
       "@id": "dc:created",

--- a/public/schema/latest/citation.schema.json
+++ b/public/schema/latest/citation.schema.json
@@ -143,8 +143,8 @@
       "@type": "Citation",
       "citationType": "documentation",
       "citationRole": "background",
-      "title": "Obsidian Help",
-      "url": "https://help.obsidian.md/",
+      "title": "JSON-LD 1.1",
+      "url": "https://www.w3.org/TR/json-ld11/",
       "accessed": "2026-01-18",
       "relevance": 0.85
     }

--- a/public/schema/latest/context.jsonld
+++ b/public/schema/latest/context.jsonld
@@ -48,10 +48,6 @@
       "@id": "mif:aliases",
       "@container": "@set"
     },
-    "blocks": {
-      "@id": "mif:blocks",
-      "@container": "@index"
-    },
 
     "created": {
       "@id": "dc:created",

--- a/public/schema/latest/mif.schema.json
+++ b/public/schema/latest/mif.schema.json
@@ -137,11 +137,6 @@
       "format": "date-time",
       "description": "When compression was applied (Level 3)"
     },
-    "blocks": {
-      "type": "object",
-      "additionalProperties": { "type": "string" },
-      "description": "Named block references (^block-id) with their text content for granular linking"
-    },
     "extensions": {
       "type": "object",
       "additionalProperties": true,

--- a/public/schema/mif.schema.json
+++ b/public/schema/mif.schema.json
@@ -137,11 +137,6 @@
       "format": "date-time",
       "description": "When compression was applied (Level 3)"
     },
-    "blocks": {
-      "type": "object",
-      "additionalProperties": { "type": "string" },
-      "description": "Named block references (^block-id) with their text content for granular linking"
-    },
     "extensions": {
       "type": "object",
       "additionalProperties": true,

--- a/schema/citation.schema.json
+++ b/schema/citation.schema.json
@@ -143,8 +143,8 @@
       "@type": "Citation",
       "citationType": "documentation",
       "citationRole": "background",
-      "title": "Obsidian Help",
-      "url": "https://help.obsidian.md/",
+      "title": "JSON-LD 1.1",
+      "url": "https://www.w3.org/TR/json-ld11/",
       "accessed": "2026-01-18",
       "relevance": 0.85
     }

--- a/schema/context.jsonld
+++ b/schema/context.jsonld
@@ -48,10 +48,6 @@
       "@id": "mif:aliases",
       "@container": "@set"
     },
-    "blocks": {
-      "@id": "mif:blocks",
-      "@container": "@index"
-    },
 
     "created": {
       "@id": "dc:created",

--- a/schema/mif.schema.json
+++ b/schema/mif.schema.json
@@ -137,11 +137,6 @@
       "format": "date-time",
       "description": "When compression was applied (Level 3)"
     },
-    "blocks": {
-      "type": "object",
-      "additionalProperties": { "type": "string" },
-      "description": "Named block references (^block-id) with their text content for granular linking"
-    },
     "extensions": {
       "type": "object",
       "additionalProperties": true,

--- a/scripts/mif_convert.py
+++ b/scripts/mif_convert.py
@@ -65,7 +65,6 @@ FRONTMATTER_ORDER = [
     "entities",
     "ontology",
     "entity",
-    "blocks",
     "extensions",
 ]
 
@@ -149,7 +148,6 @@ def md_to_jsonld(frontmatter: dict, body: str) -> dict:
         "entities",
         "ontology",
         "entity",
-        "blocks",
         "extensions",
     ]
     for key in passthrough:
@@ -193,7 +191,6 @@ def jsonld_to_md(jsonld: dict) -> tuple[dict, str]:
         "entities",
         "ontology",
         "entity",
-        "blocks",
         "extensions",
     ]
     for key in passthrough:

--- a/scripts/test_temporal_and_properties.py
+++ b/scripts/test_temporal_and_properties.py
@@ -270,7 +270,6 @@ FULL_FRONTMATTER = {
     "entities": [{"name": "Alice"}],
     "ontology": {"id": "mif-base", "version": "1.0.0"},
     "entity": {"name": "Alice Chen", "entity_type": "person"},
-    "blocks": {"b1": "block text"},
     "extensions": {"vendor": {"k": "v"}},
 }
 

--- a/src/content/docs/specification/appendices.mdx
+++ b/src/content/docs/specification/appendices.mdx
@@ -142,7 +142,7 @@ citations:
     title: "Citation Title"    # REQUIRED
     url: https://example.com   # REQUIRED
     citationRole: supports     # REQUIRED
-    author: "Author Name"      # OPTIONAL (string or EntityReference)
+    author: "Author Name"      # OPTIONAL (string, EntityReference, or array of EntityReference)
     date: 2024-06-15           # OPTIONAL
     accessed: 2026-01-20       # OPTIONAL
     relevance: 0.95            # OPTIONAL (0-1)

--- a/src/content/docs/specification/appendices.mdx
+++ b/src/content/docs/specification/appendices.mdx
@@ -137,10 +137,11 @@ entities:
 
 ```yaml
 citations:
-  - type: article              # REQUIRED
+  - "@type": Citation          # REQUIRED
+    citationType: article      # REQUIRED
     title: "Citation Title"    # REQUIRED
     url: https://example.com   # REQUIRED
-    role: supports             # REQUIRED
+    citationRole: supports     # REQUIRED
     author: "Author Name"      # OPTIONAL (string or EntityReference)
     date: 2024-06-15           # OPTIONAL
     accessed: 2026-01-20       # OPTIONAL

--- a/src/content/docs/specification/appendices.mdx
+++ b/src/content/docs/specification/appendices.mdx
@@ -78,12 +78,24 @@ Relationships appear in a `## Relationships` body section as `- <type> [Text](/p
 
 ## Appendix C: Entity Reference Syntax
 
-| Markdown | Meaning |
-|----------|---------|
-| `@[[Name]]` | Reference entity by name |
-| `@[[Name\|Person]]` | Reference with explicit type |
-| `@[[Name\|uses]]` | Reference with relationship |
-| `@[[Name\|Technology\|uses]]` | Type and relationship |
+Entity references are declared in the frontmatter `entities[]` array as `EntityReference` objects:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `@type` | REQUIRED | Always `EntityReference` |
+| `entity.@id` | REQUIRED | Entity URN (`urn:mif:entity:<type>:<slug>`) |
+| `entityType` | OPTIONAL | `Person`, `Organization`, `Technology`, `Concept`, `File`, or a custom ontology type |
+| `name` | OPTIONAL | Display name |
+| `role` | OPTIONAL | Role in the memory (e.g. `author`, `mentions`, `uses`) |
+
+```yaml
+entities:
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:person:jane-doe }
+    entityType: Person
+    name: Jane Doe
+    role: mentions
+```
 
 ---
 
@@ -129,7 +141,7 @@ citations:
     title: "Citation Title"    # REQUIRED
     url: https://example.com   # REQUIRED
     role: supports             # REQUIRED
-    author: "@[[Name|Person]]" # OPTIONAL
+    author: "Author Name"      # OPTIONAL (string or EntityReference)
     date: 2024-06-15           # OPTIONAL
     accessed: 2026-01-20       # OPTIONAL
     relevance: 0.95            # OPTIONAL (0-1)
@@ -141,7 +153,7 @@ citations:
 ```markdown
 ## Citations
 
-- [Title](url) by @[[Author|Person]] (date)
+- [Title](url) by Author Name (date)
   - **Type**: article
   - **Role**: supports
   - **Relevance**: 0.95
@@ -157,4 +169,4 @@ citations:
 - [Dublin Core Metadata Terms](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/)
 - [W3C PROV-DM](https://www.w3.org/TR/prov-dm/)
 - [ISO 8601: Date and Time Format](https://www.iso.org/iso-8601-date-and-time-format.html)
-- [Obsidian Help](https://help.obsidian.md/)
+- [CommonMark Specification](https://spec.commonmark.org/)

--- a/src/content/docs/specification/conversion.mdx
+++ b/src/content/docs/specification/conversion.mdx
@@ -55,7 +55,7 @@ User prefers dark mode
 
 ### Citations Conversion
 
-`citations` is authored in frontmatter in its final shape and passes through to the JSON-LD projection verbatim (it is part of the converter's passthrough set, so the frontmatter and projection forms are identical). Each entry is a `Citation` object: `@type`, `citationType`, `citationRole`, `title`, and `url` are required; `author`, `date`, `accessed`, `relevance`, and `note` are optional. The `author` value is a wiki-link string and is preserved as written. Any `## Citations` body mirror is authored content carried inside `content`.
+`citations` is authored in frontmatter in its final shape and passes through to the JSON-LD projection verbatim (it is part of the converter's passthrough set, so the frontmatter and projection forms are identical). Each entry is a `Citation` object: `@type`, `citationType`, `citationRole`, `title`, and `url` are required; `author`, `date`, `accessed`, `relevance`, and `note` are optional. The `author` value is plain text or an `EntityReference` and is preserved as written. Any `## Citations` body mirror is authored content carried inside `content`.
 
 **Example (frontmatter, identical in the JSON-LD projection):**
 
@@ -66,7 +66,7 @@ citations:
     citationRole: supports
     title: "Research Paper"
     url: https://example.com/paper
-    author: "@[[Jane Smith|Person]]"
+    author: "Jane Smith"
     date: "2025-11-15"
     accessed: "2026-01-18"
     relevance: 0.92

--- a/src/content/docs/specification/conversion.mdx
+++ b/src/content/docs/specification/conversion.mdx
@@ -14,7 +14,7 @@ Markdown is canonical; the JSON-LD projection is regenerated from it. The round 
 ### JSON-LD to Markdown
 
 1. Recover the frontmatter from the JSON-LD properties: `@id` (`urn:mif:<uuid>`) becomes `id` (`<uuid>`), `conceptType` becomes `type`, and the remaining properties (including `relationships[]`) pass through.
-2. Write the `content` field back as the Markdown body, verbatim. Any `## Relationships`/`## Entities` body mirror is authored content preserved unchanged, which is what keeps the round trip lossless.
+2. Write the `content` field back as the Markdown body, verbatim. Any `## Relationships` body mirror is authored content preserved unchanged, which is what keeps the round trip lossless.
 
 ### Example Conversion
 

--- a/src/content/docs/specification/conversion.mdx
+++ b/src/content/docs/specification/conversion.mdx
@@ -55,7 +55,7 @@ User prefers dark mode
 
 ### Citations Conversion
 
-`citations` is authored in frontmatter in its final shape and passes through to the JSON-LD projection verbatim (it is part of the converter's passthrough set, so the frontmatter and projection forms are identical). Each entry is a `Citation` object: `@type`, `citationType`, `citationRole`, `title`, and `url` are required; `author`, `date`, `accessed`, `relevance`, and `note` are optional. The `author` value is plain text or an `EntityReference` and is preserved as written. Any `## Citations` body mirror is authored content carried inside `content`.
+`citations` is authored in frontmatter in its final shape and passes through to the JSON-LD projection verbatim (it is part of the converter's passthrough set, so the frontmatter and projection forms are identical). Each entry is a `Citation` object: `@type`, `citationType`, `citationRole`, `title`, and `url` are required; `author`, `date`, `accessed`, `relevance`, and `note` are optional. The `author` value is plain text, an `EntityReference`, or an array of `EntityReference` (for multiple authors), and is preserved as written. Any `## Citations` body mirror is authored content carried inside `content`.
 
 **Example (frontmatter, identical in the JSON-LD projection):**
 

--- a/src/content/docs/specification/data-model.mdx
+++ b/src/content/docs/specification/data-model.mdx
@@ -35,9 +35,9 @@ Every concept declares one of three **base knowledge types**, a general taxonomy
 
 | Type | Description | Namespace Hint |
 |------|-------------|----------------|
-| `semantic` | Declarative knowledge: facts, concepts, decisions, schemas | `semantic/*` |
-| `episodic` | Time-bound records: events, incidents, changelog/deprecation | `episodic/*` |
-| `procedural` | How-to knowledge: runbooks, processes, patterns, migrations | `procedural/*` |
+| `semantic` | Declarative knowledge: facts, concepts, decisions, schemas | `_semantic/*` |
+| `episodic` | Time-bound records: events, incidents, changelog/deprecation | `_episodic/*` |
+| `procedural` | How-to knowledge: runbooks, processes, patterns, migrations | `_procedural/*` |
 
 **Base Type Descriptions:**
 

--- a/src/content/docs/specification/entity-types.mdx
+++ b/src/content/docs/specification/entity-types.mdx
@@ -7,7 +7,7 @@ MIF provides an **extensible entity type system**. Implementations SHOULD suppor
 
 ### Entity Type Architecture
 
-Entity types are **not hard-coded**. They are defined in vault configuration and can be extended per-project:
+Entity types are **not hard-coded**. They are defined in bundle configuration and can be extended per-project:
 
 ```yaml
 # .mif/config.yaml
@@ -159,14 +159,22 @@ properties:
 
 ### Entity References in Memories
 
-**Markdown:**
+Entity references are declared in the frontmatter `entities[]` array as `EntityReference` objects.
 
-```markdown
-## Entities
+**Frontmatter:**
 
-- mentions @[[Jane Doe]]
-- uses @[[Python|Technology]]
-- about @[[Dark Mode|Concept]]
+```yaml
+entities:
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:person:jane-doe }
+    entityType: Person
+    name: Jane Doe
+    role: mentions
+  - "@type": EntityReference
+    entity: { "@id": urn:mif:entity:technology:python }
+    entityType: Technology
+    name: Python
+    role: uses
 ```
 
 **JSON-LD:**

--- a/src/content/docs/specification/file-format.mdx
+++ b/src/content/docs/specification/file-format.mdx
@@ -34,12 +34,12 @@ The derived projection sits alongside as `dark-mode-preference.jsonld`.
 
 ### Directory Structure
 
-A MIF vault SHOULD follow this structure:
+A MIF bundle SHOULD follow this structure:
 
 ```
-vault/
+bundle/
 ├── .mif/                           # MIF configuration
-│   ├── config.yaml                 # Vault configuration
+│   ├── config.yaml                 # Bundle configuration
 │   ├── context.jsonld              # Local JSON-LD context
 │   └── entities/                   # Entity definitions
 │       ├── person/

--- a/src/content/docs/specification/file-format.mdx
+++ b/src/content/docs/specification/file-format.mdx
@@ -52,5 +52,5 @@ bundle/
 │   │   ├── {slug}.md              # Canonical concept
 │   │   └── {slug}.jsonld          # Derived projection
 │   └── ...
-└── README.md                       # Vault documentation
+└── README.md                       # Bundle documentation
 ```

--- a/src/content/docs/specification/markdown-format.mdx
+++ b/src/content/docs/specification/markdown-format.mdx
@@ -132,10 +132,11 @@ Citations provide structured references to external sources that inform, support
 ```yaml
 # === OPTIONAL: Citations (Level 3) ===
 citations:
-  - type: article                          # REQUIRED: Source category
+  - "@type": Citation                      # REQUIRED: object type
+    citationType: article                  # REQUIRED: Source category
     title: "Memory Systems in AI Agents"   # REQUIRED: Citation title
     url: https://arxiv.org/abs/2024.12345  # REQUIRED: Valid URL
-    role: supports                         # REQUIRED: Relationship to memory
+    citationRole: supports                 # REQUIRED: Relationship to memory
     author: "Jane Smith"                   # OPTIONAL: EntityReference or text
     date: 2024-06-15                       # OPTIONAL: Publication date
     accessed: 2026-01-20                   # OPTIONAL: Access date
@@ -147,11 +148,12 @@ citations:
 
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
-| `type` | REQUIRED | Enum | Source category (see Citation Types) |
+| `@type` | REQUIRED | Const | Always `Citation` |
+| `citationType` | REQUIRED | Enum | Source category (see Citation Types) |
 | `title` | REQUIRED | String | Citation title |
 | `url` | REQUIRED | URI | Valid URL or URI |
-| `role` | REQUIRED | Enum | Relationship to memory (see Citation Roles) |
-| `author` | OPTIONAL | String | Entity reference or plain text |
+| `citationRole` | REQUIRED | Enum | Relationship to memory (see Citation Roles) |
+| `author` | OPTIONAL | EntityReference or String | Entity reference or plain text |
 | `date` | OPTIONAL | Date | Publication date (ISO 8601) |
 | `accessed` | OPTIONAL | Date | Access date (ISO 8601) |
 | `relevance` | OPTIONAL | Decimal | Relevance score (0.0-1.0) |
@@ -238,10 +240,11 @@ Implementations SHOULD validate citations according to these rules:
 
 | Field | Constraint |
 |-------|------------|
-| `type` | MUST be a value from Citation Types or a custom namespaced type (e.g., `acme:memo`) |
+| `@type` | MUST be `Citation` |
+| `citationType` | MUST be a value from Citation Types or a custom namespaced type (e.g., `acme:memo`) |
 | `title` | MUST be a non-empty string |
 | `url` | MUST be a valid URI (http, https, or custom schemes) |
-| `role` | MUST be a value from Citation Roles or a custom namespaced role (e.g., `legal:precedent`) |
+| `citationRole` | MUST be a value from Citation Roles or a custom namespaced role (e.g., `legal:precedent`) |
 
 **Optional Field Constraints:**
 

--- a/src/content/docs/specification/markdown-format.mdx
+++ b/src/content/docs/specification/markdown-format.mdx
@@ -137,7 +137,7 @@ citations:
     title: "Memory Systems in AI Agents"   # REQUIRED: Citation title
     url: https://arxiv.org/abs/2024.12345  # REQUIRED: Valid URL
     citationRole: supports                 # REQUIRED: Relationship to memory
-    author: "Jane Smith"                   # OPTIONAL: EntityReference or text
+    author: "Jane Smith"                   # OPTIONAL: string, EntityReference, or array
     date: 2024-06-15                       # OPTIONAL: Publication date
     accessed: 2026-01-20                   # OPTIONAL: Access date
     relevance: 0.95                        # OPTIONAL: Relevance score (0-1)
@@ -153,7 +153,7 @@ citations:
 | `title` | REQUIRED | String | Citation title |
 | `url` | REQUIRED | URI | Valid URL or URI |
 | `citationRole` | REQUIRED | Enum | Relationship to memory (see Citation Roles) |
-| `author` | OPTIONAL | EntityReference or String | Entity reference or plain text |
+| `author` | OPTIONAL | EntityReference, array of EntityReference, or String | One or more entity references, or plain text |
 | `date` | OPTIONAL | Date | Publication date (ISO 8601) |
 | `accessed` | OPTIONAL | Date | Access date (ISO 8601) |
 | `relevance` | OPTIONAL | Decimal | Relevance score (0.0-1.0) |

--- a/src/content/docs/specification/markdown-format.mdx
+++ b/src/content/docs/specification/markdown-format.mdx
@@ -28,12 +28,9 @@ Concept content in Markdown format.
 
 - relates-to [Other Concept](/semantic/other-concept.md)
 - derived-from [Source Incident](/episodic/source-incident.md)
-
-## Entities (optional section)
-
-- mentions @[[Person Name]]
-- uses @[[Technology Name]]
 ```
+
+Entity references are declared in the frontmatter `entities[]` array (see [Entity Types](/specification/entity-types/)).
 
 ### Frontmatter Schema
 
@@ -124,17 +121,7 @@ relationships:
     target: /semantic/old-policy.md
 ```
 
-Every frontmatter `relationships` entry MUST have a corresponding body markdown link in the `## Relationships` section, and every such body link maps back to a frontmatter entry. Entity references use `@[[Name|Type]]` syntax (see Entity Types).
-
-### Block References
-
-Blocks can be referenced for granular linking within a file:
-
-```markdown
-This is an important statement. ^important-point
-
-- Key insight about the system ^insight-1
-```
+Every frontmatter `relationships` entry MUST have a corresponding body markdown link in the `## Relationships` section, and every such body link maps back to a frontmatter entry. Entity references are declared in the frontmatter `entities[]` array (see [Entity Types](/specification/entity-types/)).
 
 ### Citations (Level 3)
 
@@ -149,7 +136,7 @@ citations:
     title: "Memory Systems in AI Agents"   # REQUIRED: Citation title
     url: https://arxiv.org/abs/2024.12345  # REQUIRED: Valid URL
     role: supports                         # REQUIRED: Relationship to memory
-    author: "@[[Jane Smith|Person]]"       # OPTIONAL: Entity ref or text
+    author: "Jane Smith"                   # OPTIONAL: EntityReference or text
     date: 2024-06-15                       # OPTIONAL: Publication date
     accessed: 2026-01-20                   # OPTIONAL: Access date
     relevance: 0.95                        # OPTIONAL: Relevance score (0-1)
@@ -213,36 +200,34 @@ An optional `## Citations` section MAY appear in the memory body for detailed an
 ```markdown
 ## Citations
 
-- [Memory Systems in AI Agents](https://arxiv.org/abs/2024.12345) by @[[Jane Smith|Person]] (2024)
+- [Memory Systems in AI Agents](https://arxiv.org/abs/2024.12345) by Jane Smith (2024)
   - **Type**: article
   - **Role**: supports
   - **Relevance**: 0.95
   - Foundational paper on semantic memory structures. Introduces bi-temporal
     model that informed MIF's temporal design.
 
-- [Obsidian Help](https://help.obsidian.md/) by @[[Obsidian Team|Organization]]
+- [JSON-LD 1.1](https://www.w3.org/TR/json-ld11/) by W3C
   - **Type**: documentation
   - **Role**: background
   - **Accessed**: 2026-01-18
-  - Reference for wiki-link syntax and block references.
+  - Reference for the JSON-LD projection format.
 ```
 
 #### Author Entity References
 
-Authors MAY use wiki-link syntax to reference MIF entities:
+A citation `author` MAY be plain text or one or more `EntityReference` objects (see [Entity Types](/specification/entity-types/)):
 
 ```yaml
-# Single author entity
-author: "@[[Jane Smith|Person]]"
-
-# Multiple authors (comma-separated)
-author: "@[[Jane Smith|Person]], @[[John Doe|Person]]"
-
-# Organization author
-author: "@[[Anthropic|Organization]]"
-
-# Plain text (no entity reference)
+# Plain text
 author: "Jane Smith et al."
+
+# Single author as an entity reference
+author:
+  "@type": EntityReference
+  entity: { "@id": urn:mif:entity:person:jane-smith }
+  entityType: Person
+  name: Jane Smith
 ```
 
 #### Citation Validation
@@ -262,7 +247,7 @@ Implementations SHOULD validate citations according to these rules:
 
 | Field | Constraint |
 |-------|------------|
-| `author` | SHOULD be entity reference(s) `@[[Name\|Type]]` or plain text; multiple authors comma-separated |
+| `author` | SHOULD be an `EntityReference` (or array of them) or plain text |
 | `date` | MUST be ISO 8601 date format (`YYYY-MM-DD`) |
 | `accessed` | MUST be ISO 8601 date format (`YYYY-MM-DD`) |
 | `relevance` | MUST be decimal between 0.0 and 1.0 inclusive |

--- a/src/content/docs/specification/namespace-model.mdx
+++ b/src/content/docs/specification/namespace-model.mdx
@@ -13,7 +13,7 @@ Namespaces use a flexible scoping model with reserved prefixes for cross-organiz
 
 Where `{root}` is either:
 - **Organization name** - private to that organization
-- **Reserved prefix** - special namespace with defined semantics. Two kinds of reserved prefix exist (both begin with `_`): **visibility prefixes** that control sharing scope, and **base-type prefixes** that name the cognitive memory type.
+- **Reserved prefix** - special namespace with defined semantics. Two kinds of reserved prefixes exist (both begin with `_`): **visibility prefixes** that control sharing scope, and **base-type prefixes** that name the cognitive memory type.
 
 ### Reserved Namespace Prefixes
 

--- a/src/content/docs/specification/namespace-model.mdx
+++ b/src/content/docs/specification/namespace-model.mdx
@@ -13,11 +13,13 @@ Namespaces use a flexible scoping model with reserved prefixes for cross-organiz
 
 Where `{root}` is either:
 - **Organization name** - private to that organization
-- **Reserved prefix** - special namespace with defined semantics
+- **Reserved prefix** - special namespace with defined semantics. Two kinds of reserved prefix exist (both begin with `_`): **visibility prefixes** that control sharing scope, and **base-type prefixes** that name the cognitive memory type.
 
 ### Reserved Namespace Prefixes
 
-Names beginning with underscore (`_`) are reserved for special namespaces:
+Names beginning with underscore (`_`) are reserved for special namespaces. Two kinds exist: **visibility prefixes** that control sharing scope, and **base-type prefixes** that name the cognitive memory type.
+
+#### Visibility Prefixes
 
 | Prefix | Visibility | Description |
 |--------|------------|-------------|
@@ -25,6 +27,16 @@ Names beginning with underscore (`_`) are reserved for special namespaces:
 | `_shared` | Negotiated | Cross-organization sharing with explicit agreements |
 | `_local` | Local only | Never synchronized or exported |
 | `_system` | Implementation | Reserved for system/implementation use |
+
+#### Base-Type Prefixes
+
+Namespace paths use an underscore prefix (`_semantic`, `_episodic`, `_procedural`) to distinguish base-type namespaces from domain-specific namespaces. This convention ensures consistent namespace identification across implementations. Each base-type prefix corresponds to a base memory `type` and is the top-level root of the base ontology's namespace hierarchy.
+
+| Prefix | Base type | Description |
+|--------|-----------|-------------|
+| `_semantic` | `semantic` | Facts, concepts, relationships - declarative knowledge |
+| `_episodic` | `episodic` | Events, experiences, timelines - time-bound records |
+| `_procedural` | `procedural` | Step-by-step processes - how-to knowledge |
 
 **Examples:**
 
@@ -174,19 +186,19 @@ The base ontology uses a three-tier hierarchy based on the base knowledge types:
 
 ```yaml
 namespaces:
-  semantic:                    # Facts, concepts, relationships
+  _semantic:                   # Facts, concepts, relationships
     type_hint: semantic
     children:
       decisions: {}
       knowledge: {}
       entities: {}
-  episodic:                    # Events, experiences, timelines
+  _episodic:                   # Events, experiences, timelines
     type_hint: episodic
     children:
       incidents: {}
       sessions: {}
       blockers: {}
-  procedural:                  # Step-by-step processes
+  _procedural:                 # Step-by-step processes
     type_hint: procedural
     children:
       runbooks: {}

--- a/src/content/docs/specification/overview.mdx
+++ b/src/content/docs/specification/overview.mdx
@@ -14,7 +14,7 @@ OKF compliance is achieved as a **superset, not by subordination**: every MIF bu
 MIF is designed to be:
 - **OKF-compliant**: every bundle is a valid OKF bundle (a tested invariant)
 - **Markdown-canonical**: the `.md` file is the source of truth; JSON-LD is a derived projection
-- **Human-Readable**: valid Obsidian-compatible notes that work in any Markdown editor
+- **Human-Readable**: valid CommonMark notes that work in any Markdown editor
 - **Machine-Processable**: JSON-LD with semantic web compatibility
 - **Extensible**: domain profiles extend the base without breaking compatibility
 
@@ -31,7 +31,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 - **Entity**: A named thing (person, organization, technology, concept, or file) that can participate in relationships.
 - **Relationship**: A typed, directed connection between two concepts, or between a concept and an entity.
 - **Namespace**: A hierarchical scope for organizing concepts (e.g., `org/user/project/session`).
-- **Vault**: A collection of MIF files, analogous to an Obsidian vault.
 - **Provider**: An implementation that can import or export MIF format.
 
 ---
@@ -42,34 +41,26 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 MIF defines two representations, with markdown as the canonical source:
 
-1. **Markdown Format** (`.md`): Canonical, human-readable, Obsidian-compatible
+1. **Markdown Format** (`.md`): Canonical, human-readable, plain CommonMark
 2. **JSON-LD Format** (`.jsonld`): Derived, machine-processable, semantically linked
 
 The `.md` file is the source of truth; the JSON-LD form is a derived projection, regenerable from markdown with `scripts/mif_convert.py`. The round trip MUST be lossless. A conforming implementation MAY support either or both formats; if the two disagree, markdown wins.
 
-### Obsidian Compatibility
+### Markdown Conventions
 
-The Markdown format is valid Obsidian-compatible notes, so files work in Obsidian vaults while remaining readable in any text editor or Markdown processor. Concept relationships are expressed as standard bundle-relative markdown links (so a generic OKF consumer sees every edge); Obsidian's bidirectional features remain available for authoring.
+The Markdown format is plain, vendor-neutral CommonMark — readable in any text editor or Markdown processor, and tied to no single tool. Concept relationships are expressed as standard bundle-relative markdown links, so any generic OKF consumer sees every edge.
 
-**Required Markdown Features:**
+**Markdown conventions:**
 
-- **YAML Frontmatter**: Structured metadata at the top of files, enclosed in `---` delimiters. Obsidian's Properties panel reads and writes this data, supporting typed fields (text, number, date, checkbox, list).
+- **YAML Frontmatter**: Structured metadata at the top of files, enclosed in `---` delimiters, supporting typed fields (text, number, date, list).
 
 - **Standard Markdown Links**: Concept-graph edges use bundle-relative markdown links, `[text](/path/to/target.md)`, in a `## Relationships` section — the OKF-legible representation of relationships.
 
-- **Block References**: Unique identifiers (`^block-id`) attached to paragraphs, list items, or other blocks enable granular linking and transclusion within a file.
-
-- **Aliases**: The `aliases` frontmatter property allows notes to be found and linked using alternative names, improving discoverability.
+- **Aliases**: The `aliases` frontmatter property lets a concept be referred to by alternative names.
 
 - **Tags**: Both inline `#tags` and frontmatter `tags: [a, b]` are supported, with hierarchical tags using forward slashes (`#category/subcategory`).
 
-- **Standard Markdown**: All content uses CommonMark-compatible Markdown, ensuring portability to other tools and platforms.
-
-**Optional Obsidian Extensions:**
-
-- **Callouts**: Admonition blocks using `> [!type]` syntax for notes, warnings, tips, etc.
-- **Embeds**: Transclusion using `![[Note]]` to embed content from other files
-- **Dataview Queries**: Compatible with Dataview plugin for vault-as-database queries
+- **Standard Markdown**: All content uses CommonMark-compatible Markdown, ensuring portability across tools and platforms.
 
 ### Semantic Web Compatibility
 

--- a/src/content/docs/specification/relationship-types.mdx
+++ b/src/content/docs/specification/relationship-types.mdx
@@ -7,7 +7,7 @@ MIF provides an **extensible relationship type system**. Implementations SHOULD 
 
 ### Relationship Type Architecture
 
-Relationship types are **not hard-coded**. They are defined in vault configuration and can be extended per-project:
+Relationship types are **not hard-coded**. They are defined in bundle configuration and can be extended per-project:
 
 ```yaml
 # .mif/config.yaml


### PR DESCRIPTION
## Summary

Removes Obsidian-specific conventions from MIF for **vendor neutrality** (resolves #183). The spec documented notation the canonical tooling never implemented — wiki-link relationships (`[[...]]`), `@[[Name|Type]]` entity references, block references (`^block-id`), and embeds — and positioned MIF as "Obsidian-compatible". The OKF conformance gate (`okf_validate.py`) only accepts markdown-link relationships, entities are frontmatter `EntityReference` objects, and every shipped example already used those forms. Binding the canonical Markdown to one editor's proprietary syntax also conflicts with MIF's vendor-neutral positioning (ADR-010, ADR-014).

**ADR-017** (supersedes ADR-003) records the decision.

> Stacked on #182 (`docs/98-namespace-reserved-prefixes`) — base this PR on it; the diff here is #183 only.

## Decision: what changed vs. what stayed

**Removed (Obsidian-specific):** wiki-link relationships, `@[[...]]` entity refs, block references, embeds, the §Obsidian Compatibility / §Wiki-Link Syntax sections, and "Obsidian-compatible / vault" framing.

**Canonical forms (already what the tooling validates):** relationships = frontmatter `relationships[]` (bundle-relative path or `urn:mif:` target) mirrored as body markdown links `- <type> [Text](/path.md)`; entity references = frontmatter `entities[]` / `EntityReference`; `author` = string or `EntityReference`.

**Retained (not Obsidian-specific):** YAML frontmatter, plain CommonMark, `aliases`, tags, folder-as-namespace.

## Changes

- **Spec:** `SPECIFICATION.md` + 7 published `.mdx` (overview, markdown-format, entity-types, appendices, conversion, file-format, relationship-types). "vault" → "bundle".
- **Schema:** removed the `blocks` field from `schema/mif.schema.json` + `context.jsonld` + the **unversioned canonical** `public/schema/` root, the `mif_convert.py` passthrough, and the `test_temporal_and_properties.py` fixture. The neutralized the `Obsidian Help` citation example in `citation.schema.json`.
- **CI-validated examples:** `ontologies/examples/memories/**` + `profiles/ai-memory/examples/*` — wiki-links → synced markdown-link relationships; `@[[...]]` → frontmatter `entities[]`.
- **Positioning + branding:** `README`, `CONTRIBUTING`, `.marksman.toml`, `docs/GETTING-STARTED`, `docs/SCHEMA-REFERENCE`, `adr/README` (ADR-003 → Superseded, ADR-017 added), and the four `.github/*.svg` assets.
- **CHANGELOG:** Unreleased entry.

## Backward compatibility

Removing `blocks` is **non-breaking**: the concept object has no `additionalProperties: false` (defaults to `true`) and `blocks` was OPTIONAL — existing data still carrying a `blocks` object continues to validate.

## Schema mirror note (ADR-016)

`v1.0.0` is released, so this PR leaves the **immutable versioned mirrors** untouched: it changes only the source schemas and the **unversioned canonical** `public/schema/` root (the `$id` target, which moves with releases). The versioned mirrors are regenerated by `snapshot-schema-version.py` when the next version is cut.

The mirror scheme has exactly three path kinds (per `VERSIONING.md` / `index.json`): exact immutable snapshots (`X.Y.Z`, unprefixed), the global `latest` alias (newest overall), and `vMAJOR` aliases only (`v0`, `v1`; `v2` reserved) — **there are no minor-level aliases** (no `v1.1`).

When this removal ships as **v1.1.0** (non-breaking optional-field removal → MINOR bump), `snapshot-schema-version.py 1.1.0` produces:

| Path | After v1.1.0 | Mutability |
| --- | --- | --- |
| `/schema/1.1.0/` | **new** snapshot ← tag `v1.1.0` (no `blocks`) | immutable |
| `/schema/latest/` | **moves** → 1.1.0 | tracks newest |
| `/schema/v1/` | **moves** 1.0.0 → 1.1.0 (newest 1.x) | major alias |
| `/schema/1.0.0/` | unchanged | immutable |
| `/schema/v0/` | unchanged → still 0.1.0 (newest 0.x) | major alias |
| `/schema/0.1.0/` | unchanged | immutable |
| `/schema/<file>` (root, `$id`) | already 1.1.0 bytes (no `blocks`) | moves with releases |

So `v1` and `latest` advance to 1.1.0; `1.0.0`, `0.1.0`, and `v0` are untouched. The `$id` stays the unversioned canonical throughout (ADR-007).


## Verification

- `npm run build` → Complete!, exit 0
- `okf_validate.py`, `mif_convert.py roundtrip`, `validate-ontologies.py`, `validate-namespaces.py`, `test_subtype_of.py`, `test_temporal_and_properties.py` — all pass
- `emit-jsonld` + `ajv validate` against the blocks-removed schema — all 13 projections valid
- Sweep clean: the only remaining `[[`/Obsidian/wiki hits are intentional — migration history (`SPECIFICATION.md` §17, `MIGRATION.md`, `migrate_0_1_to_1_0.py`), the legacy migration test fixture, the immutable versioned schema mirrors, the Basic-Memory migration illustrations in `profiles/ai-memory/SPECIFICATION.md`, and ADR-003/017 + the adr index rows that describe them.

Closes #183
