### PR TITLE
ci(shellcheck): bump reusable pin for triggering-event fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: modeled-information-format/.github/.github/workflows/reusable-shellcheck.yml@d16f2d7aa9dfb6ca21f99f80a2b0ef853beb3ba6
+    uses: modeled-information-format/.github/.github/workflows/reusable-shellcheck.yml@02f479d564026f83ee42952a0afad0e123e38bfa
     with:
       strict-on-push: false


### PR DESCRIPTION
## Summary

Bump the `reusable-shellcheck.yml` pin to the merged SHA so this repo picks up the `triggering-event` fix.

The reusable now passes a supported `triggering-event` to `differential-shellcheck` (mapping `workflow_dispatch` and `schedule` to `manual`), so the `gate-shellcheck / sast-hooks` job stops failing on manual Release runs and scheduled runs. push / pull_request runs are unchanged.

Part of modeled-information-format/.github#29
