### PR TITLE
ci(shellcheck): bump reusable pin for full-scan fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: modeled-information-format/.github/.github/workflows/reusable-shellcheck.yml@02f479d564026f83ee42952a0afad0e123e38bfa
+    uses: modeled-information-format/.github/.github/workflows/reusable-shellcheck.yml@27b548962b44362fe039491504dd9049b15aefc2
     with:
       strict-on-push: false


### PR DESCRIPTION
## Summary

Bump the `reusable-shellcheck.yml` pin to pick up the corrected `triggering-event` handling.

The reusable now resolves `workflow_dispatch` and `schedule` to a full strict scan (the earlier mapping to `manual` failed on the action's base/head guard). The `gate-shellcheck / sast-hooks` job now passes on manual Release and scheduled runs; native push / pull_request runs are unchanged.

Part of modeled-information-format/.github#29
