### PR TITLE
chore(release): MIF specification 1.1.0

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "MIF Version Constants",
   "description": "Canonical version numbers for MIF specification and components",
-  "specification": "1.0.0",
+  "specification": "1.1.0",
   "schemas": {
     "mif": "1.0.0",
     "citation": "1.0.0",


### PR DESCRIPTION
Bumps VERSION.json .specification to 1.1.0 for the minor release covering the serve-ontologies + object+sha vendoring work merged since v1.0.0. Tag v1.1.0 will be cut at the merge commit to fire the attested release.