### PR TITLE
ci(auth): split to least-privilege app identities (auth refactor)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -21,4 +21,4 @@ jobs:
     with:
       update-types: patch
     secrets:
-      app-private-key: ${{ secrets.MIF_CI_CLIENT_APP_PRIVATE_KEY }}
+      app-private-key: ${{ secrets.AUTOMERGE_CLIENT_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -2,7 +2,7 @@
 name: Dependabot auto-merge
 
 # Thin caller of the org reusable (pinned to .github main). Approves + auto-merges
-# patch Dependabot updates via the org CI App; minor/major stay manual. Repo
+# patch Dependabot updates via the org automerge App; minor/major stay manual. Repo
 # settings (allow_auto_merge + branch protection) are applied out-of-band by
 # docs/onboarding/org/dependabot-automerge-settings.sh in the .github repo.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
             --predicate-type https://cyclonedx.org/bom
 
       - name: Mint release app token (publish identity)
-        id: release-token
+        id: release_token
         if: github.event_name == 'release'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -216,7 +216,7 @@ jobs:
       - name: Upload attested artifacts to the release
         if: github.event_name == 'release'
         env:
-          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+          GH_TOKEN: ${{ steps.release_token.outputs.token }}
           TAG: ${{ steps.ver.outputs.tag }}
           SRC_ARTIFACT: ${{ steps.src.outputs.artifact }}
           SCHEMAS_ARTIFACT: ${{ steps.schemas.outputs.artifact }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,10 +203,20 @@ jobs:
             --signer-workflow "${SIGNER}" \
             --predicate-type https://cyclonedx.org/bom
 
+      - name: Mint release app token (publish identity)
+        id: release-token
+        if: github.event_name == 'release'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_CLIENT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_CLIENT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Upload attested artifacts to the release
         if: github.event_name == 'release'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
           TAG: ${{ steps.ver.outputs.tag }}
           SRC_ARTIFACT: ${{ steps.src.outputs.artifact }}
           SCHEMAS_ARTIFACT: ${{ steps.schemas.outputs.artifact }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     permissions:
       id-token: write       # OIDC token for keyless Sigstore signing
       attestations: write   # persist the provenance + SBOM attestations
-      contents: write       # upload assets to the release (tag runs only)
+      contents: read        # checkout + gh attestation verify; the release upload now uses the release App token
     steps:
       - name: Resolve checkout ref
         id: ref

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,4 +28,4 @@ jobs:
       publish-results: true
     secrets:
       # Org CI App private key → Scorecard reads branch protection (administration:read).
-      app-private-key: ${{ secrets.MIF_CI_CLIENT_APP_PRIVATE_KEY }}
+      app-private-key: ${{ secrets.CI_CLIENT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Splits MIF's workflow auth onto the least-privilege apps (epic modeled-information-format/.github#37).

- **scorecard** caller passes `CI_CLIENT_APP_PRIVATE_KEY` (the `ci` app).
- **dependabot auto-merge** caller passes `AUTOMERGE_CLIENT_APP_PRIVATE_KEY` (the `automerge` app).
- **release.yml** mints the `release` app (`vars.RELEASE_CLIENT_APP_ID` + `secrets.RELEASE_CLIENT_APP_PRIVATE_KEY`) and uses it for the `gh release upload` step only. The keyless OIDC attestation (`id-token` + `attestations`) is untouched, so the attestation signer SAN stays the workflow and `gh attestation verify` is unaffected.

Draft until the `ci`, `automerge`, and `release` apps + their variables/secrets are provisioned. Verify a release still attests and verifies after provisioning.

Closes #196
Part of modeled-information-format/.github#37