### PR TITLE
docs(changelog): reference the sha256 index field, not sha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Serve the canonical ontology corpus at `mif-spec.dev/ontologies/`** (#186) —
   the org's domain ontologies are published and resolvable at the custom domain.
-- **Serve the object+SHA vendoring index and the layered v0.2.0 corpus** (#193,
-  ADR-0002) — the registry `index.json` is reconciled to object+`sha` entries so
-  downstream consumers fail-closed vendor pinned ontology packs.
+- **Serve the object vendoring index and the layered v0.2.0 corpus** (#193,
+  ADR-0002) — the registry `index.json` is reconciled to object entries each
+  carrying a `sha256` field, so downstream consumers fail-closed vendor pinned
+  ontology packs.
 
 ### Changed
 


### PR DESCRIPTION
Addresses the Copilot review on #195. The served `public/ontologies/index.json` uses a `sha256` field on each object entry (not `sha`); the 1.1.0 changelog bullet said `object+`sha` entries`. Reword to name the actual `sha256` field so the documented contract matches what is served.