### PR TITLE
ci: repoint app-token mint at live five-app credentials

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   automerge:
     if: ${{ github.actor == 'dependabot[bot]' }}
-    uses: modeled-information-format/.github/.github/workflows/reusable-dependabot-automerge.yml@219e6e121531701e787db57c9bdf9e5cfdcbfb7b # reusable-dependabot-automerge.yml @ .github main
+    uses: modeled-information-format/.github/.github/workflows/reusable-dependabot-automerge.yml@f29366f7dbe223fcf14e8994483fec667faa3164 # reusable-dependabot-automerge.yml @ .github main
     with:
       update-types: patch
     secrets:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: modeled-information-format/.github/.github/workflows/reusable-scorecard.yml@f83ee8058630235396f7242580570b26cf3617fa
+    uses: modeled-information-format/.github/.github/workflows/reusable-scorecard.yml@f29366f7dbe223fcf14e8994483fec667faa3164
     with:
       publish-results: true
     secrets:


### PR DESCRIPTION
## What

Bump the pinned `.github` reusable-workflow SHAs to `f29366f` so the App token mints read the current five-app-fleet credentials instead of the removed `MIF_CI_*` one.

- `reusable-dependabot-automerge.yml@f29366f` reads `vars.AUTOMERGE_CLIENT_APP_ID`
- `reusable-scorecard.yml@f29366f` reads `vars.CI_CLIENT_APP_ID`

## Why

The legacy `modeled-information-format-ci` App and its `MIF_CI_*` variable/secret were retired under ADR-011 (five least-privilege Apps: ci/catalog/pages/automerge/release). The old pins still resolved to reusables that read the removed `MIF_CI_CLIENT_APP_ID`, so the token mint would find an empty client-id and the auto-merge/scorecard identity would break.

## Scope

Touches only `.github/workflows/**`. The reusable caller contract (`app-private-key` secret, inputs) is unchanged, so the bump is drop-in. SHA-pinned to a 40-char commit; no app permissions changed beyond what ADR-011/apps.json define.
