### PR TITLE
ci(release): disable the SBOM action's own release attach

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,11 @@ jobs:
           format: cyclonedx-json
           output-file: mif-${{ steps.ver.outputs.version }}.sbom.cdx.json
           artifact-name: mif-${{ steps.ver.outputs.version }}.sbom.cdx.json
+          # The verified-upload step below publishes the SBOM with the
+          # release App token; the action's own release attach would need
+          # contents:write on GITHUB_TOKEN (kept read-only) and 403s on a
+          # release-published event.
+          upload-release-assets: false
 
       - name: Attest build provenance (SLSA) for both artifacts
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1


### PR DESCRIPTION
Disables the SBOM action's built-in release attach in release.yml. The job's GITHUB_TOKEN is deliberately read-only (uploads go through the release App token in the verified-upload step, which already includes the SBOM file), so the action's own attach attempt fails a release-published run with resource-not-accessible.

This is why the v1.2.0 attest run failed tonight: it was the first release to reach the SBOM step at all. The v1.1.0 run had failed earlier, at the schema-mirror gate, so the permission regression from the App-token rework sat unexercised until a release passed that gate.

After this merges, the plan is to delete and re-publish the v1.2.0 release object (the tag and its content stay put; no assets were ever uploaded), which re-fires the attest run against the fixed workflow.

Verification: actionlint clean; changelog-check and the mirror gate already passed on the failed run, so the only changed behavior is skipping the doomed attach.
