### PR TITLE
chore(release): prepare v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-04
+
+### Fixed
+
+- **Release workflow: SBOM release attach removed** (#210) — the SBOM
+  generation action attempted to attach the raw SBOM file to the release
+  under the job's read-only `GITHUB_TOKEN` and failed every
+  release-published run; the verified App-token upload step already
+  publishes the SBOM alongside the attested artifacts. No attestation or
+  verification step changed.
+- The v1.2.0 GitHub release object was deleted during failure recovery
+  and cannot be recreated (immutable releases); the `v1.2.0` tag and its
+  content remain. v1.2.1 is the attested release for the 1.2 line.
+
 ## [1.2.0] - 2026-07-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **JSON-LD context: `accessed` typed `xsd:date`** — the context declared
+  `xsd:dateTime` while both `citation.schema.json` and `mif.schema.json`
+  constrain `accessed` to `format: date` (YYYY-MM-DD, not a valid
+  `xsd:dateTime` lexical form); the context now agrees with the schemas,
+  matching the sibling `date` term.
 - **Release workflow: SBOM release attach removed** (#210) — the SBOM
   generation action attempted to attach the raw SBOM file to the release
   under the job's read-only `GITHUB_TOKEN` and failed every

--- a/VERSION.json
+++ b/VERSION.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "MIF Version Constants",
   "description": "Canonical version numbers for MIF specification and components",
-  "specification": "1.2.0",
+  "specification": "1.2.1",
   "schemas": {
     "mif": "1.0.0",
     "citation": "1.0.0",

--- a/public/ns/vocabulary.jsonld
+++ b/public/ns/vocabulary.jsonld
@@ -267,7 +267,7 @@
       "rdfs:label": "accessed",
       "rdfs:comment": "When the citation was last accessed.",
       "rdfs:range": {
-        "@id": "xsd:dateTime"
+        "@id": "xsd:date"
       }
     },
     {

--- a/public/schema/1.2.1/citation.schema.json
+++ b/public/schema/1.2.1/citation.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/citation.schema.json",
+  "title": "MIF Citation",
+  "description": "JSON Schema for validating MIF citation objects",
+  "type": "object",
+  "required": ["@type", "citationType", "citationRole", "title", "url"],
+  "properties": {
+    "@type": {
+      "const": "Citation",
+      "description": "Must be 'Citation'"
+    },
+    "citationType": {
+      "type": "string",
+      "description": "Source category - either a standard type or custom namespaced type",
+      "oneOf": [
+        {
+          "enum": [
+            "article",
+            "book",
+            "paper",
+            "website",
+            "documentation",
+            "repository",
+            "video",
+            "podcast",
+            "specification",
+            "dataset",
+            "tool",
+            "other"
+          ],
+          "description": "Standard citation types"
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+          "description": "Custom namespaced type (e.g., 'acme:memo')"
+        }
+      ]
+    },
+    "citationRole": {
+      "type": "string",
+      "description": "Relationship to memory - either a standard role or custom namespaced role",
+      "oneOf": [
+        {
+          "enum": [
+            "supports",
+            "refutes",
+            "background",
+            "methodology",
+            "contradicts",
+            "extends",
+            "derived",
+            "source",
+            "example",
+            "review"
+          ],
+          "description": "Standard citation roles"
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+          "description": "Custom namespaced role (e.g., 'legal:precedent')"
+        }
+      ]
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Citation title (required, non-empty)"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Citation URL (required, valid URI)"
+    },
+    "author": {
+      "description": "Author(s) - can be entity reference object, array of entity references, or plain text string",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/EntityReference",
+          "description": "Single author entity reference"
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EntityReference" },
+          "minItems": 1,
+          "description": "Multiple author entity references"
+        },
+        {
+          "type": "string",
+          "description": "Plain text author name(s)"
+        }
+      ]
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "description": "Publication date in ISO 8601 format (YYYY-MM-DD)"
+    },
+    "accessed": {
+      "type": "string",
+      "format": "date",
+      "description": "Access date in ISO 8601 format (YYYY-MM-DD)"
+    },
+    "relevance": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Relevance score between 0.0 and 1.0"
+    },
+    "note": {
+      "type": "string",
+      "maxLength": 1000,
+      "description": "Free-form annotation (recommended under 1000 characters)"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "EntityReference": {
+      "$ref": "./definitions/entity-reference.schema.json"
+    }
+  },
+  "examples": [
+    {
+      "@type": "Citation",
+      "citationType": "article",
+      "citationRole": "supports",
+      "title": "Memory Systems in AI Agents",
+      "url": "https://arxiv.org/abs/2024.12345",
+      "author": {
+        "@type": "EntityReference",
+        "entity": { "@id": "urn:mif:entity:person:jane-smith" },
+        "entityType": "Person",
+        "name": "Jane Smith"
+      },
+      "date": "2024-06-15",
+      "accessed": "2026-01-20",
+      "relevance": 0.95,
+      "note": "Foundational paper on semantic memory"
+    },
+    {
+      "@type": "Citation",
+      "citationType": "documentation",
+      "citationRole": "background",
+      "title": "JSON-LD 1.1",
+      "url": "https://www.w3.org/TR/json-ld11/",
+      "accessed": "2026-01-18",
+      "relevance": 0.85
+    }
+  ]
+}

--- a/public/schema/1.2.1/context.jsonld
+++ b/public/schema/1.2.1/context.jsonld
@@ -103,7 +103,7 @@
     },
     "accessed": {
       "@id": "mif:accessed",
-      "@type": "xsd:dateTime"
+      "@type": "xsd:date"
     },
     "relevance": {
       "@id": "mif:relevance",

--- a/public/schema/1.2.1/context.jsonld
+++ b/public/schema/1.2.1/context.jsonld
@@ -1,0 +1,306 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "mif": "https://mif-spec.dev/ns/",
+    "dc": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "schema": "https://schema.org/",
+
+    "Memory": "mif:Memory",
+    "Entity": "mif:Entity",
+    "Relationship": "mif:Relationship",
+    "TemporalMetadata": "mif:TemporalMetadata",
+    "EmbeddingReference": "mif:EmbeddingReference",
+    "EntityReference": "mif:EntityReference",
+    "OntologyReference": "mif:OntologyReference",
+    "EntityData": "mif:EntityData",
+    "Vector": "mif:Vector",
+
+    "Person": "mif:Person",
+    "Organization": "mif:Organization",
+    "Technology": "mif:Technology",
+    "Concept": "mif:Concept",
+    "File": "mif:File",
+
+    "id": "@id",
+    "type": "@type",
+
+    "content": {
+      "@id": "mif:content",
+      "@type": "xsd:string"
+    },
+    "conceptType": {
+      "@id": "mif:conceptType",
+      "@type": "@vocab"
+    },
+    "memoryType": {
+      "@id": "mif:memoryType",
+      "@type": "@vocab"
+    },
+    "title": "dc:title",
+    "namespace": "mif:namespace",
+    "tags": {
+      "@id": "mif:tags",
+      "@container": "@set"
+    },
+    "aliases": {
+      "@id": "mif:aliases",
+      "@container": "@set"
+    },
+
+    "created": {
+      "@id": "dc:created",
+      "@type": "xsd:dateTime"
+    },
+    "modified": {
+      "@id": "dc:modified",
+      "@type": "xsd:dateTime"
+    },
+
+    "entities": {
+      "@id": "mif:entities",
+      "@container": "@set"
+    },
+    "entity": {
+      "@id": "mif:entity",
+      "@type": "@id"
+    },
+    "entityType": "mif:entityType",
+    "entity_type": "mif:entity_type",
+    "entity_id": "mif:entity_id",
+    "name": "schema:name",
+    "role": "mif:role",
+
+    "ontology": "mif:ontology",
+    "version": "mif:version",
+    "uri": {
+      "@id": "mif:uri",
+      "@type": "@id"
+    },
+
+    "citations": {
+      "@id": "mif:citations",
+      "@container": "@set"
+    },
+    "Citation": "mif:Citation",
+    "citationType": {
+      "@id": "mif:citationType",
+      "@type": "@vocab"
+    },
+    "citationRole": {
+      "@id": "mif:citationRole",
+      "@type": "@vocab"
+    },
+    "url": {
+      "@id": "schema:url",
+      "@type": "@id"
+    },
+    "author": "schema:author",
+    "date": {
+      "@id": "schema:datePublished",
+      "@type": "xsd:date"
+    },
+    "accessed": {
+      "@id": "mif:accessed",
+      "@type": "xsd:dateTime"
+    },
+    "relevance": {
+      "@id": "mif:relevance",
+      "@type": "xsd:decimal"
+    },
+    "note": "mif:note",
+
+    "documents": {
+      "@id": "mif:documents",
+      "@container": "@set",
+      "@context": {
+        "hash": {
+          "@id": "mif:hash",
+          "@context": {
+            "algorithm": "mif:algorithm",
+            "value": "mif:value"
+          }
+        }
+      }
+    },
+    "DocumentReference": "mif:DocumentReference",
+    "documentType": {
+      "@id": "mif:documentType",
+      "@type": "@vocab"
+    },
+    "contentType": "mif:contentType",
+    "byteLength": {
+      "@id": "mif:byteLength",
+      "@type": "xsd:integer"
+    },
+    "retrievedAt": {
+      "@id": "mif:retrievedAt",
+      "@type": "xsd:dateTime"
+    },
+
+    "relationships": {
+      "@id": "mif:relationships",
+      "@container": "@set",
+      "@context": {
+        "@vocab": "https://mif-spec.dev/ns/",
+        "type": {
+          "@id": "mif:relationshipType",
+          "@type": "@vocab"
+        },
+        "target": {
+          "@id": "mif:target",
+          "@type": "@id"
+        },
+        "metadata": {
+          "@id": "mif:metadata",
+          "@type": "@json"
+        }
+      }
+    },
+    "relationshipType": {
+      "@id": "mif:relationshipType",
+      "@type": "@vocab"
+    },
+    "target": {
+      "@id": "mif:target",
+      "@type": "@id"
+    },
+    "strength": {
+      "@id": "mif:strength",
+      "@type": "xsd:decimal"
+    },
+
+    "RelatesTo": "mif:RelatesTo",
+    "DerivedFrom": "mif:DerivedFrom",
+    "Supersedes": "mif:Supersedes",
+    "ConflictsWith": "mif:ConflictsWith",
+    "PartOf": "mif:PartOf",
+    "Implements": "mif:Implements",
+    "Uses": "mif:Uses",
+    "Created": "mif:Created",
+    "MentionedIn": "mif:MentionedIn",
+
+    "temporal": "mif:temporal",
+    "validFrom": {
+      "@id": "mif:validFrom",
+      "@type": "xsd:dateTime"
+    },
+    "validUntil": {
+      "@id": "mif:validUntil",
+      "@type": "xsd:dateTime"
+    },
+    "recordedAt": {
+      "@id": "mif:recordedAt",
+      "@type": "xsd:dateTime"
+    },
+    "ttl": {
+      "@id": "mif:ttl",
+      "@type": "xsd:duration"
+    },
+    "decay": "mif:decay",
+    "model": "mif:model",
+    "halfLife": {
+      "@id": "mif:halfLife",
+      "@type": "xsd:duration"
+    },
+    "currentStrength": {
+      "@id": "mif:currentStrength",
+      "@type": "xsd:decimal"
+    },
+    "lastReinforced": {
+      "@id": "mif:lastReinforced",
+      "@type": "xsd:dateTime"
+    },
+    "accessCount": {
+      "@id": "mif:accessCount",
+      "@type": "xsd:integer"
+    },
+    "lastAccessed": {
+      "@id": "mif:lastAccessed",
+      "@type": "xsd:dateTime"
+    },
+    "reinforcementHistory": {
+      "@id": "mif:reinforcementHistory",
+      "@container": "@list"
+    },
+
+    "provenance": "mif:provenance",
+    "sourceType": {
+      "@id": "mif:sourceType",
+      "@type": "@vocab"
+    },
+    "sourceRef": {
+      "@id": "mif:sourceRef",
+      "@type": "@id"
+    },
+    "agent": "mif:agent",
+    "agentVersion": "mif:agentVersion",
+    "confidence": {
+      "@id": "mif:confidence",
+      "@type": "xsd:decimal"
+    },
+    "trustLevel": {
+      "@id": "mif:trustLevel",
+      "@type": "@vocab"
+    },
+
+    "wasGeneratedBy": {
+      "@id": "prov:wasGeneratedBy",
+      "@type": "@id"
+    },
+    "wasAttributedTo": {
+      "@id": "prov:wasAttributedTo",
+      "@type": "@id"
+    },
+    "wasDerivedFrom": {
+      "@id": "prov:wasDerivedFrom",
+      "@type": "@id"
+    },
+    "wasAssociatedWith": {
+      "@id": "prov:wasAssociatedWith",
+      "@type": "@id"
+    },
+
+    "user_explicit": "mif:UserExplicit",
+    "user_implicit": "mif:UserImplicit",
+    "agent_inferred": "mif:AgentInferred",
+    "external_import": "mif:ExternalImport",
+    "system_generated": "mif:SystemGenerated",
+
+    "verified": "mif:Verified",
+    "user_stated": "mif:UserStated",
+    "high_confidence": "mif:HighConfidence",
+    "moderate_confidence": "mif:ModerateConfidence",
+    "low_confidence": "mif:LowConfidence",
+    "uncertain": "mif:Uncertain",
+
+    "embedding": "mif:embedding",
+    "modelVersion": "mif:modelVersion",
+    "dimensions": {
+      "@id": "mif:dimensions",
+      "@type": "xsd:integer"
+    },
+    "sourceText": "mif:sourceText",
+    "normalized": {
+      "@id": "mif:normalized",
+      "@type": "xsd:boolean"
+    },
+    "vectorUri": {
+      "@id": "mif:vectorUri",
+      "@type": "@id"
+    },
+    "vector": "mif:vector",
+    "encoding": "mif:encoding",
+    "data": "mif:data",
+
+    "extensions": {
+      "@id": "mif:extensions",
+      "@container": "@index"
+    },
+
+    "semantic": "mif:SemanticType",
+    "episodic": "mif:EpisodicType",
+    "procedural": "mif:ProceduralType"
+  }
+}

--- a/public/schema/1.2.1/definitions/entity-reference.schema.json
+++ b/public/schema/1.2.1/definitions/entity-reference.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/definitions/entity-reference.schema.json",
+  "title": "MIF Entity Reference",
+  "description": "Reference to an entity (person, organization, technology, etc.) within a MIF memory",
+  "type": "object",
+  "required": ["@type", "entity"],
+  "properties": {
+    "@type": {
+      "const": "EntityReference"
+    },
+    "entity": {
+      "type": "object",
+      "description": "Entity identifier object",
+      "required": ["@id"],
+      "properties": {
+        "@id": {
+          "type": "string",
+          "pattern": "^urn:mif:entity:",
+          "description": "Entity URN identifier (e.g., urn:mif:entity:person:jane-smith)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "entityType": {
+      "type": "string",
+      "description": "Entity type classification",
+      "oneOf": [
+        {
+          "enum": ["Person", "Organization", "Technology", "Concept", "File"]
+        },
+        {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Custom entity type from ontology (e.g., grazing-plan, soil-profile)"
+        }
+      ]
+    },
+    "name": {
+      "type": "string",
+      "description": "Display name for the entity"
+    },
+    "role": {
+      "type": "string",
+      "description": "Role of the entity in the memory context (e.g., author, subject, topic)"
+    }
+  },
+  "additionalProperties": false
+}

--- a/public/schema/1.2.1/mif.schema.json
+++ b/public/schema/1.2.1/mif.schema.json
@@ -1,0 +1,619 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/mif.schema.json",
+  "title": "MIF — Modeled Information Format (v1.0)",
+  "description": "JSON Schema for validating the derived JSON-LD projection of a MIF v1.0 concept",
+  "type": "object",
+  "required": ["@context", "@type", "@id", "conceptType", "content", "created"],
+  "properties": {
+    "@context": {
+      "description": "JSON-LD context",
+      "oneOf": [
+        { "type": "string", "format": "uri" },
+        { "type": "array", "items": { "type": ["string", "object"] } },
+        { "type": "object" }
+      ]
+    },
+    "@type": {
+      "description": "Type of the concept document",
+      "oneOf": [
+        { "const": "Concept" },
+        { "const": "Memory" },
+        { "type": "array", "contains": { "const": "Concept" } }
+      ]
+    },
+    "@id": {
+      "type": "string",
+      "pattern": "^urn:mif:",
+      "description": "Unique identifier in URN format"
+    },
+    "conceptType": {
+      "type": "string",
+      "enum": ["semantic", "episodic", "procedural"],
+      "description": "Knowledge taxonomy: semantic (declarative knowledge), episodic (time-bound records), procedural (how-to knowledge)"
+    },
+    "memoryType": {
+      "type": "string",
+      "enum": ["semantic", "episodic", "procedural"],
+      "description": "Deprecated v0.1 alias for conceptType; retained for backward compatibility"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "OKF-recommended mirror of modified (or created)"
+    },
+    "description": {
+      "type": "string",
+      "description": "OKF-recommended description, mapped from MIF summary"
+    },
+    "content": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The memory content in Markdown format"
+    },
+    "title": {
+      "type": "string",
+      "description": "Human-readable title"
+    },
+    "created": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Creation timestamp (ISO 8601)"
+    },
+    "modified": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last modification timestamp (ISO 8601)"
+    },
+    "ontology": {
+      "$ref": "#/$defs/OntologyReference",
+      "description": "Reference to the ontology this memory conforms to"
+    },
+    "entity": {
+      "$ref": "#/$defs/EntityData",
+      "description": "Structured entity data for ontology-typed memories"
+    },
+    "namespace": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)*$",
+      "description": "Hierarchical namespace path"
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Classification tags"
+    },
+    "aliases": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Alternative names for the memory"
+    },
+    "entities": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/EntityReference" },
+      "description": "Referenced entities"
+    },
+    "relationships": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Relationship" },
+      "description": "Typed relationships to other memories"
+    },
+    "temporal": {
+      "$ref": "#/$defs/TemporalMetadata",
+      "description": "Temporal validity and decay data"
+    },
+    "provenance": {
+      "$ref": "#/$defs/Provenance",
+      "description": "Source and trust data"
+    },
+    "embedding": {
+      "$ref": "#/$defs/EmbeddingReference",
+      "description": "Embedding model reference"
+    },
+    "citations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Citation" },
+      "description": "Citation references (Level 3)"
+    },
+    "documents": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/DocumentReference" },
+      "description": "Source documents that travel alongside this memory by reference (not embedded). Vendor-neutral pointers to the underlying artifacts a memory was derived from."
+    },
+    "summary": {
+      "type": "string",
+      "maxLength": 500,
+      "description": "Compressed content summary (Level 3, max 500 chars)"
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean", "null"]
+      },
+      "description": "First-class scalar properties: literal key/value pairs (e.g. from a knowledge-graph literal-object triple) that have no concept target and therefore cannot be a relationship. Values MUST be scalar (string, number, boolean, or null); nested objects/arrays are out of scope at Level 1."
+    },
+    "compressedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When compression was applied (Level 3)"
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Provider-specific extensions"
+    }
+  },
+  "$defs": {
+    "DocumentReference": {
+      "type": "object",
+      "description": "Vendor-neutral reference to a source document that travels alongside a memory by reference rather than by embedding a vendor-specific document schema. Locate the document by either `url` or `id`.",
+      "required": ["@type"],
+      "anyOf": [
+        { "required": ["url"] },
+        { "required": ["id"] }
+      ],
+      "properties": {
+        "@type": {
+          "const": "DocumentReference"
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier for the document (e.g. a URN or opaque key) when no resolvable URL is available"
+        },
+        "documentType": {
+          "type": "string",
+          "description": "Document category",
+          "oneOf": [
+            {
+              "enum": [
+                "pdf",
+                "html",
+                "markdown",
+                "text",
+                "transcript",
+                "dataset",
+                "spreadsheet",
+                "presentation",
+                "image",
+                "audio",
+                "video",
+                "email",
+                "other"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+              "description": "Custom namespaced type"
+            }
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "minLength": 1,
+          "description": "Resolvable location of the document"
+        },
+        "hash": {
+          "type": "object",
+          "description": "Content hash for integrity verification",
+          "required": ["algorithm", "value"],
+          "properties": {
+            "algorithm": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Hash algorithm (e.g. sha256, sha512, blake3)"
+            },
+            "value": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Hash digest value"
+            }
+          },
+          "additionalProperties": false
+        },
+        "contentType": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Media type of the document (e.g. application/pdf, text/html)"
+        },
+        "byteLength": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Size of the document in bytes"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Version token for the document (e.g. a commit SHA, ETag, or revision label)"
+        },
+        "retrievedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the document was retrieved (ISO 8601)"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable document title"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Citation": {
+      "type": "object",
+      "required": ["@type", "citationType", "citationRole", "title", "url"],
+      "properties": {
+        "@type": {
+          "const": "Citation"
+        },
+        "citationType": {
+          "type": "string",
+          "description": "Source category",
+          "oneOf": [
+            {
+              "enum": [
+                "article",
+                "book",
+                "paper",
+                "website",
+                "documentation",
+                "repository",
+                "video",
+                "podcast",
+                "specification",
+                "dataset",
+                "tool",
+                "other"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+              "description": "Custom namespaced type"
+            }
+          ]
+        },
+        "citationRole": {
+          "type": "string",
+          "description": "Relationship to memory",
+          "oneOf": [
+            {
+              "enum": [
+                "supports",
+                "refutes",
+                "background",
+                "methodology",
+                "contradicts",
+                "extends",
+                "derived",
+                "source",
+                "example",
+                "review"
+              ]
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-zA-Z][a-zA-Z0-9]*:[a-zA-Z][a-zA-Z0-9-]*$",
+              "description": "Custom namespaced role"
+            }
+          ]
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Citation title"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Citation URL"
+        },
+        "author": {
+          "description": "Author(s) as entity reference(s) or plain text",
+          "oneOf": [
+            { "$ref": "#/$defs/EntityReference" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/$defs/EntityReference" }
+            },
+            { "type": "string" }
+          ]
+        },
+        "date": {
+          "type": "string",
+          "format": "date",
+          "description": "Publication date (ISO 8601)"
+        },
+        "accessed": {
+          "type": "string",
+          "format": "date",
+          "description": "Access date (ISO 8601)"
+        },
+        "relevance": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Relevance score (0.0-1.0)"
+        },
+        "note": {
+          "type": "string",
+          "maxLength": 1000,
+          "description": "Free-form annotation"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EntityReference": {
+      "$ref": "./definitions/entity-reference.schema.json"
+    },
+    "Relationship": {
+      "type": "object",
+      "description": "v1.0 typed relationship: authoritative in frontmatter, mirrored as an OKF-legible body markdown link (SPECIFICATION.md 4.4)",
+      "required": ["type", "target"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Relationship type as a kebab-case token (e.g. derived-from, supersedes, relates-to) or a custom namespaced type",
+          "pattern": "^[a-z0-9][a-z0-9-]*(:[a-z0-9][a-z0-9-]*)?$"
+        },
+        "target": {
+          "type": "string",
+          "description": "Bundle-relative path to the target concept (e.g. /semantic/policy.md) or a urn:mif: identifier"
+        },
+        "strength": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Relationship strength"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "TemporalMetadata": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "const": "TemporalMetadata"
+        },
+        "validFrom": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "validUntil": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "recordedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ttl": {
+          "type": "string",
+          "pattern": "^P",
+          "description": "ISO 8601 duration"
+        },
+        "decay": {
+          "type": "object",
+          "properties": {
+            "model": {
+              "type": "string",
+              "enum": ["none", "linear", "exponential", "step"]
+            },
+            "halfLife": {
+              "type": "string",
+              "pattern": "^P"
+            },
+            "currentStrength": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "strength": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Alias for currentStrength"
+            },
+            "lastReinforced": {
+              "type": "string",
+              "format": "date-time",
+              "description": "When the memory was last reinforced"
+            }
+          },
+          "additionalProperties": false
+        },
+        "accessCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "lastAccessed": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reinforcementHistory": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["timestamp", "event"],
+            "properties": {
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "event": {
+                "type": "string"
+              },
+              "strengthDelta": {
+                "type": "number"
+              },
+              "context": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "description": "History of reinforcement events that strengthened or weakened the memory"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Provenance": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        },
+        "sourceType": {
+          "type": "string",
+          "enum": [
+            "user_explicit",
+            "user_implicit",
+            "agent_inferred",
+            "external_import",
+            "system_generated"
+          ]
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "trustLevel": {
+          "type": "string",
+          "enum": [
+            "verified",
+            "user_stated",
+            "high_confidence",
+            "moderate_confidence",
+            "low_confidence",
+            "uncertain"
+          ]
+        },
+        "sourceRef": {
+          "type": "string",
+          "description": "OPTIONAL reference to the originating source (e.g. conversation:conv-456)"
+        },
+        "agent": {
+          "type": "string",
+          "description": "OPTIONAL identifier of the agent that created the unit (e.g. claude-3-opus)"
+        },
+        "agentVersion": {
+          "type": "string",
+          "description": "OPTIONAL version of the creating agent"
+        },
+        "wasGeneratedBy": {
+          "$ref": "#/$defs/ProvNode",
+          "description": "OPTIONAL prov:wasGeneratedBy — the activity that produced this unit"
+        },
+        "wasAttributedTo": {
+          "$ref": "#/$defs/ProvNode",
+          "description": "OPTIONAL prov:wasAttributedTo — the agent the unit is attributed to"
+        },
+        "wasDerivedFrom": {
+          "description": "OPTIONAL prov:wasDerivedFrom — the entity or entities this unit was derived from",
+          "oneOf": [
+            { "$ref": "#/$defs/ProvNode" },
+            { "type": "array", "items": { "$ref": "#/$defs/ProvNode" } }
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "ProvNode": {
+      "description": "A W3C-PROV node: either a plain IRI/identifier string or an open node object (e.g. {\"@id\": \"...\", \"@type\": \"prov:Activity\"}). Kept permissive because PROV graphs are open-ended.",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "anyOf": [
+            { "required": ["@id"] },
+            { "required": ["id"] }
+          ],
+          "additionalProperties": true
+        }
+      ]
+    },
+    "EmbeddingReference": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "const": "EmbeddingReference"
+        },
+        "model": {
+          "type": "string"
+        },
+        "modelVersion": {
+          "type": "string"
+        },
+        "dimensions": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "sourceText": {
+          "type": "string"
+        },
+        "vectorUri": {
+          "type": "string",
+          "format": "uri"
+        },
+        "normalized": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "OntologyReference": {
+      "type": "object",
+      "description": "Reference to the ontology this memory conforms to",
+      "required": ["id"],
+      "properties": {
+        "@type": {
+          "const": "OntologyReference"
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Ontology identifier (must match ontology.id in ontology definition)"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+.*$",
+          "description": "Semantic version of the ontology"
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI to the ontology definition"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EntityData": {
+      "type": "object",
+      "description": "Structured entity data for ontology-typed memories. Fields are defined by the entity_type schema in the referenced ontology.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the entity"
+        },
+        "entity_type": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Entity type from ontology (e.g., grazing-plan, soil-profile)"
+        },
+        "entity_id": {
+          "type": "string",
+          "description": "Unique identifier for this entity instance"
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/public/schema/1.2.1/ontology/ontology.context.jsonld
+++ b/public/schema/1.2.1/ontology/ontology.context.jsonld
@@ -1,0 +1,144 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "https://mif-spec.dev/ns/ontology#",
+    "mif": "https://mif-spec.dev/ns/",
+    "schema": "https://schema.org/",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "ontology": {
+      "@id": "mif:Ontology",
+      "@type": "@id"
+    },
+    "id": {
+      "@id": "@id"
+    },
+    "version": {
+      "@id": "schema:version",
+      "@type": "xsd:string"
+    },
+    "description": {
+      "@id": "schema:description",
+      "@type": "xsd:string"
+    },
+    "schema_url": {
+      "@id": "rdfs:isDefinedBy",
+      "@type": "@id"
+    },
+
+    "namespaces": {
+      "@id": "mif:hasNamespace",
+      "@container": "@id"
+    },
+    "type_hint": {
+      "@id": "mif:typeHint",
+      "@type": "xsd:string"
+    },
+    "replaces": {
+      "@id": "mif:replaces",
+      "@type": "@id"
+    },
+    "children": {
+      "@id": "mif:hasChildNamespace",
+      "@container": "@id"
+    },
+
+    "entity_types": {
+      "@id": "mif:definesEntityType",
+      "@container": "@list"
+    },
+    "name": {
+      "@id": "schema:name",
+      "@type": "xsd:string"
+    },
+    "base": {
+      "@id": "mif:baseType",
+      "@type": "@vocab"
+    },
+    "semantic": "mif:SemanticMemory",
+    "episodic": "mif:EpisodicMemory",
+    "procedural": "mif:ProceduralMemory",
+
+    "traits": {
+      "@id": "mif:definesTrait",
+      "@container": "@id"
+    },
+    "subtype_of": {
+      "@id": "mif:subtypeOf",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "aliases": {
+      "@id": "skos:altLabel",
+      "@container": "@set"
+    },
+    "exemplars": {
+      "@id": "skos:example",
+      "@container": "@set"
+    },
+    "negative_examples": {
+      "@id": "https://mif-spec.dev/ns/ontology#negativeExample",
+      "@container": "@set"
+    },
+    "fields": {
+      "@id": "mif:hasField",
+      "@container": "@id"
+    },
+    "requires": {
+      "@id": "mif:requiresField",
+      "@container": "@list"
+    },
+
+    "relationships": {
+      "@id": "mif:definesRelationship",
+      "@container": "@id"
+    },
+    "from": {
+      "@id": "rdfs:domain",
+      "@container": "@set"
+    },
+    "to": {
+      "@id": "rdfs:range",
+      "@container": "@set"
+    },
+    "symmetric": {
+      "@id": "owl:SymmetricProperty",
+      "@type": "xsd:boolean"
+    },
+
+    "discovery": {
+      "@id": "mif:discoveryConfig"
+    },
+    "enabled": {
+      "@id": "mif:discoveryEnabled",
+      "@type": "xsd:boolean"
+    },
+    "patterns": {
+      "@id": "mif:hasDiscoveryPattern",
+      "@container": "@list"
+    },
+    "confidence_threshold": {
+      "@id": "mif:confidenceThreshold",
+      "@type": "xsd:decimal"
+    },
+    "content_pattern": {
+      "@id": "mif:contentPattern",
+      "@type": "xsd:string"
+    },
+    "file_pattern": {
+      "@id": "mif:filePattern",
+      "@type": "xsd:string"
+    },
+    "suggest_entity": {
+      "@id": "mif:suggestsEntityType",
+      "@type": "@id"
+    },
+    "suggest_namespace": {
+      "@id": "mif:suggestsNamespace",
+      "@type": "xsd:string"
+    }
+  }
+}

--- a/public/schema/1.2.1/ontology/ontology.schema.json
+++ b/public/schema/1.2.1/ontology/ontology.schema.json
@@ -1,0 +1,391 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/ontology/ontology.schema.json",
+  "title": "MIF Ontology Schema",
+  "description": "JSON Schema for validating ontology definition files with cognitive triad namespace hierarchy",
+  "type": "object",
+  "properties": {
+    "ontology": {
+      "type": "object",
+      "description": "Ontology metadata",
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the ontology",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "version": {
+          "type": "string",
+          "description": "Semantic version string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+.*$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "schema_url": {
+          "type": "string",
+          "description": "URL to external schema definition",
+          "format": "uri"
+        },
+        "extends": {
+          "type": "array",
+          "description": "List of ontology IDs this ontology extends (inherits traits and relationships)",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          }
+        }
+      }
+    },
+    "namespaces": {
+      "type": "object",
+      "description": "Hierarchical namespace definitions following cognitive triad",
+      "additionalProperties": {
+        "$ref": "#/$defs/namespace"
+      }
+    },
+    "entity_types": {
+      "type": "array",
+      "description": "Custom entity type definitions",
+      "items": {
+        "$ref": "#/$defs/entityType"
+      }
+    },
+    "traits": {
+      "type": "object",
+      "description": "Reusable trait/mixin definitions",
+      "additionalProperties": {
+        "$ref": "#/$defs/trait"
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "description": "Relationship type definitions",
+      "additionalProperties": {
+        "$ref": "#/$defs/relationship"
+      }
+    },
+    "discovery": {
+      "type": "object",
+      "description": "Entity discovery configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether discovery is enabled",
+          "default": false
+        },
+        "confidence_threshold": {
+          "type": "number",
+          "description": "Minimum confidence for suggestions",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.8
+        },
+        "content_patterns": {
+          "type": "array",
+          "description": "Patterns matched against user prompts and memory content",
+          "items": {
+            "$ref": "#/$defs/contentPattern"
+          }
+        },
+        "file_patterns": {
+          "type": "array",
+          "description": "Patterns matched against file paths being edited",
+          "items": {
+            "$ref": "#/$defs/filePattern"
+          }
+        },
+        "patterns": {
+          "type": "array",
+          "description": "Unified patterns array (alternative to separate content/file arrays)",
+          "items": {
+            "$ref": "#/$defs/unifiedPattern"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "namespace": {
+      "type": "object",
+      "description": "Namespace definition with optional children for hierarchical structure",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Namespace description"
+        },
+        "type_hint": {
+          "type": "string",
+          "description": "Default memory type for this namespace",
+          "enum": ["semantic", "episodic", "procedural"]
+        },
+        "replaces": {
+          "type": "string",
+          "description": "Base namespace this replaces (for migration)"
+        },
+        "children": {
+          "type": "object",
+          "description": "Child namespaces forming hierarchical structure",
+          "additionalProperties": {
+            "$ref": "#/$defs/namespace"
+          }
+        }
+      }
+    },
+    "entityType": {
+      "type": "object",
+      "description": "Entity type definition",
+      "required": ["name", "base"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Entity type name",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "description": {
+          "type": "string",
+          "description": "Entity type description"
+        },
+        "base": {
+          "type": "string",
+          "description": "Base memory type",
+          "enum": ["semantic", "episodic", "procedural"]
+        },
+        "traits": {
+          "type": "array",
+          "description": "Traits this entity type includes",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subtype_of": {
+          "type": "array",
+          "description": "Names of parent entity types this type specializes (subsumption). A subtype is substitutable for any of its supertypes wherever the supertype is admissible (e.g. a relationship endpoint domain); its schema must remain compatible with each parent's (additive). Parents may be declared in this ontology or in an ontology it extends, and the subtype_of graph must be acyclic.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "aliases": {
+          "type": "array",
+          "description": "Synonyms and label variations for this entity type (SKOS altLabel analog), as a structured field distinct from description. Embedding-based classifiers concatenate aliases into the type's positive embedding document alongside description and exemplars.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "exemplars": {
+          "type": "array",
+          "description": "Curated canonical example phrases or instances of this entity type (SKOS example analog; 2-5 recommended), distinct from description. A second, example-grounded positive embedding signal for classifiers.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "negative_examples": {
+          "type": "array",
+          "description": "Curated near-miss examples drawn from this ontology's most confusable type pairs: texts that resemble this entity type but do NOT denote it. For decision-boundary sharpening only; never concatenated into the positive embedding document. Must be human-curated, not auto-mined.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "schema": {
+          "type": "object",
+          "description": "JSON Schema for entity fields",
+          "properties": {
+            "required": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "properties": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/propertySchema"
+              }
+            }
+          }
+        }
+      }
+    },
+    "trait": {
+      "type": "object",
+      "description": "Trait/mixin definition",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "extends": {
+          "type": "array",
+          "description": "List of trait names this trait extends (inherits fields from)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fields": {
+          "type": "object",
+          "description": "Fields provided by this trait",
+          "additionalProperties": {
+            "$ref": "#/$defs/propertySchema"
+          }
+        },
+        "requires": {
+          "type": "array",
+          "description": "MIF fields this trait requires",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "relationship": {
+      "type": "object",
+      "description": "Relationship type definition",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "from": {
+          "type": "array",
+          "description": "Entity types that can be the source",
+          "items": {
+            "type": "string"
+          }
+        },
+        "to": {
+          "type": "array",
+          "description": "Entity types that can be the target",
+          "items": {
+            "type": "string"
+          }
+        },
+        "symmetric": {
+          "type": "boolean",
+          "description": "Whether the relationship is symmetric",
+          "default": false
+        }
+      }
+    },
+    "contentPattern": {
+      "type": "object",
+      "description": "Pattern matched against user prompts and memory content",
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in content"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace to suggest (hierarchical path)"
+        },
+        "namespaces": {
+          "type": "array",
+          "description": "Multiple namespaces to suggest",
+          "items": { "type": "string" }
+        },
+        "suggest_entity": {
+          "type": "string",
+          "description": "Entity type to suggest when pattern matches"
+        },
+        "context": {
+          "type": "string",
+          "description": "Human-readable context hint"
+        }
+      }
+    },
+    "unifiedPattern": {
+      "type": "object",
+      "description": "Unified pattern with content_pattern or file_pattern discriminator",
+      "properties": {
+        "content_pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in content"
+        },
+        "file_pattern": {
+          "type": "string",
+          "description": "Glob pattern to match file paths"
+        },
+        "suggest_namespace": {
+          "type": "string",
+          "description": "Namespace to suggest"
+        },
+        "suggest_entity": {
+          "type": "string",
+          "description": "Entity type to suggest"
+        }
+      }
+    },
+    "filePattern": {
+      "type": "object",
+      "description": "Pattern matched against file paths being edited",
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern to match in file paths"
+        },
+        "namespaces": {
+          "type": "array",
+          "description": "Namespaces to suggest (hierarchical paths)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "context": {
+          "type": "string",
+          "description": "Human-readable context hint for this pattern"
+        },
+        "suggest_entity": {
+          "type": "string",
+          "description": "Entity type to suggest when pattern matches"
+        }
+      }
+    },
+    "propertySchema": {
+      "type": "object",
+      "description": "JSON Schema property definition",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array",
+            "object",
+            "null"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string",
+          "description": "Format hint (e.g., 'uri', 'date-time')"
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Regex pattern for string validation"
+        },
+        "items": {
+          "type": "object",
+          "description": "Schema for array items"
+        },
+        "enum": {
+          "type": "array",
+          "description": "Allowed values"
+        }
+      }
+    }
+  }
+}

--- a/public/schema/context.jsonld
+++ b/public/schema/context.jsonld
@@ -103,7 +103,7 @@
     },
     "accessed": {
       "@id": "mif:accessed",
-      "@type": "xsd:dateTime"
+      "@type": "xsd:date"
     },
     "relevance": {
       "@id": "mif:relevance",

--- a/public/schema/index.json
+++ b/public/schema/index.json
@@ -1,7 +1,7 @@
 {
   "name": "MIF JSON Schema catalog",
   "description": "Machine-readable index of MIF (Modeled Information Format) JSON Schemas served at https://mif-spec.dev/schema/. Canonical $id values are unversioned and stable (ADR-007); the versioned paths below are immutable per-release mirrors whose internal $id is unchanged. Versioning of the canonical $id remains git-tag based.",
-  "specVersion": "1.2.0",
+  "specVersion": "1.2.1",
   "dialect": "https://json-schema.org/draft/2020-12/schema",
   "canonicalBase": "https://mif-spec.dev/schema/",
   "mediaType": {
@@ -9,9 +9,9 @@
     "note": "GitHub Pages serves .json as application/json and does not allow per-file Content-Type overrides; application/schema+json is the intended media type for conforming hosts."
   },
   "aliases": {
-    "latest": "1.2.0",
+    "latest": "1.2.1",
     "v0": "0.1.0",
-    "v1": "1.2.0"
+    "v1": "1.2.1"
   },
   "reserved": {
     "v2": "first 2.x release (not yet published)"
@@ -19,7 +19,8 @@
   "versions": [
     "0.1.0",
     "1.0.0",
-    "1.2.0"
+    "1.2.0",
+    "1.2.1"
   ],
   "schemas": [
     {
@@ -31,7 +32,8 @@
         "latest": "https://mif-spec.dev/schema/latest/mif.schema.json",
         "v0": "https://mif-spec.dev/schema/v0/mif.schema.json",
         "v1": "https://mif-spec.dev/schema/v1/mif.schema.json",
-        "1.2.0": "https://mif-spec.dev/schema/1.2.0/mif.schema.json"
+        "1.2.0": "https://mif-spec.dev/schema/1.2.0/mif.schema.json",
+        "1.2.1": "https://mif-spec.dev/schema/1.2.1/mif.schema.json"
       }
     },
     {
@@ -43,7 +45,8 @@
         "latest": "https://mif-spec.dev/schema/latest/citation.schema.json",
         "v0": "https://mif-spec.dev/schema/v0/citation.schema.json",
         "v1": "https://mif-spec.dev/schema/v1/citation.schema.json",
-        "1.2.0": "https://mif-spec.dev/schema/1.2.0/citation.schema.json"
+        "1.2.0": "https://mif-spec.dev/schema/1.2.0/citation.schema.json",
+        "1.2.1": "https://mif-spec.dev/schema/1.2.1/citation.schema.json"
       }
     },
     {
@@ -55,7 +58,8 @@
         "latest": "https://mif-spec.dev/schema/latest/definitions/entity-reference.schema.json",
         "v0": "https://mif-spec.dev/schema/v0/definitions/entity-reference.schema.json",
         "v1": "https://mif-spec.dev/schema/v1/definitions/entity-reference.schema.json",
-        "1.2.0": "https://mif-spec.dev/schema/1.2.0/definitions/entity-reference.schema.json"
+        "1.2.0": "https://mif-spec.dev/schema/1.2.0/definitions/entity-reference.schema.json",
+        "1.2.1": "https://mif-spec.dev/schema/1.2.1/definitions/entity-reference.schema.json"
       }
     },
     {
@@ -67,7 +71,8 @@
         "latest": "https://mif-spec.dev/schema/latest/ontology/ontology.schema.json",
         "v0": "https://mif-spec.dev/schema/v0/ontology/ontology.schema.json",
         "v1": "https://mif-spec.dev/schema/v1/ontology/ontology.schema.json",
-        "1.2.0": "https://mif-spec.dev/schema/1.2.0/ontology/ontology.schema.json"
+        "1.2.0": "https://mif-spec.dev/schema/1.2.0/ontology/ontology.schema.json",
+        "1.2.1": "https://mif-spec.dev/schema/1.2.1/ontology/ontology.schema.json"
       }
     },
     {
@@ -79,7 +84,8 @@
         "latest": "https://mif-spec.dev/schema/latest/context.jsonld",
         "v0": "https://mif-spec.dev/schema/v0/context.jsonld",
         "v1": "https://mif-spec.dev/schema/v1/context.jsonld",
-        "1.2.0": "https://mif-spec.dev/schema/1.2.0/context.jsonld"
+        "1.2.0": "https://mif-spec.dev/schema/1.2.0/context.jsonld",
+        "1.2.1": "https://mif-spec.dev/schema/1.2.1/context.jsonld"
       }
     },
     {
@@ -91,7 +97,8 @@
         "latest": "https://mif-spec.dev/schema/latest/ontology/ontology.context.jsonld",
         "v0": "https://mif-spec.dev/schema/v0/ontology/ontology.context.jsonld",
         "v1": "https://mif-spec.dev/schema/v1/ontology/ontology.context.jsonld",
-        "1.2.0": "https://mif-spec.dev/schema/1.2.0/ontology/ontology.context.jsonld"
+        "1.2.0": "https://mif-spec.dev/schema/1.2.0/ontology/ontology.context.jsonld",
+        "1.2.1": "https://mif-spec.dev/schema/1.2.1/ontology/ontology.context.jsonld"
       }
     }
   ]

--- a/public/schema/latest/context.jsonld
+++ b/public/schema/latest/context.jsonld
@@ -103,7 +103,7 @@
     },
     "accessed": {
       "@id": "mif:accessed",
-      "@type": "xsd:dateTime"
+      "@type": "xsd:date"
     },
     "relevance": {
       "@id": "mif:relevance",

--- a/public/schema/v1/context.jsonld
+++ b/public/schema/v1/context.jsonld
@@ -103,7 +103,7 @@
     },
     "accessed": {
       "@id": "mif:accessed",
-      "@type": "xsd:dateTime"
+      "@type": "xsd:date"
     },
     "relevance": {
       "@id": "mif:relevance",

--- a/schema/context.jsonld
+++ b/schema/context.jsonld
@@ -103,7 +103,7 @@
     },
     "accessed": {
       "@id": "mif:accessed",
-      "@type": "xsd:dateTime"
+      "@type": "xsd:date"
     },
     "relevance": {
       "@id": "mif:relevance",


### PR DESCRIPTION
Release prep for v1.2.1, the patch release that completes the attested publication of the 1.2 line.

Two things went wrong with v1.2.0's release: the SBOM action's built-in release attach failed the attest run under the read-only job token (fixed in pull request 210, merged), and the failure-recovery attempt to delete and re-publish the release object ran into immutable releases, permanently burning the v1.2.0 release slot. The v1.2.0 tag and all its content remain in place; v1.2.1 tags main, which carries the workflow fix, so the attest chain runs fixed end to end.

Changes: specification 1.2.0 to 1.2.1 in VERSION.json, the immutable public/schema/1.2.1/ mirror snapshotted with latest/ and v1/ refreshed and index.json updated (snapshot-schema-version.py 1.2.1 --check passes), and a changelog entry recording both the workflow fix and the v1.2.0 release-slot note. No schema content changes; the 1.2.1 mirror is byte-identical to 1.2.0's.
