### PR TITLE
fix(schema): register citationType/citationRole vocab terms

### DIFF
--- a/schema/context.jsonld
+++ b/schema/context.jsonld
@@ -86,11 +86,37 @@
     "Citation": "mif:Citation",
     "citationType": {
       "@id": "mif:citationType",
-      "@type": "@vocab"
+      "@type": "@vocab",
+      "@context": {
+        "article": "mif:CitationTypeArticle",
+        "book": "mif:CitationTypeBook",
+        "paper": "mif:CitationTypePaper",
+        "website": "mif:CitationTypeWebsite",
+        "documentation": "mif:CitationTypeDocumentation",
+        "repository": "mif:CitationTypeRepository",
+        "video": "mif:CitationTypeVideo",
+        "podcast": "mif:CitationTypePodcast",
+        "specification": "mif:CitationTypeSpecification",
+        "dataset": "mif:CitationTypeDataset",
+        "tool": "mif:CitationTypeTool",
+        "other": "mif:CitationTypeOther"
+      }
     },
     "citationRole": {
       "@id": "mif:citationRole",
-      "@type": "@vocab"
+      "@type": "@vocab",
+      "@context": {
+        "supports": "mif:CitationRoleSupports",
+        "refutes": "mif:CitationRoleRefutes",
+        "background": "mif:CitationRoleBackground",
+        "methodology": "mif:CitationRoleMethodology",
+        "contradicts": "mif:CitationRoleContradicts",
+        "extends": "mif:CitationRoleExtends",
+        "derived": "mif:CitationRoleDerived",
+        "source": "mif:CitationRoleSource",
+        "example": "mif:CitationRoleExample",
+        "review": "mif:CitationRoleReview"
+      }
     },
     "url": {
       "@id": "schema:url",

--- a/scripts/test_jsonld_context_fidelity.py
+++ b/scripts/test_jsonld_context_fidelity.py
@@ -2,7 +2,7 @@
 """Test that `schema/context.jsonld` round-trips losslessly under a real JSON-LD
 1.1 processor (pyld), independent of this repo's own mif_convert.py serializer.
 
-Regression coverage for two term-definition bugs found by direct expand/compact
+Regression coverage for term-definition bugs found by direct expand/compact
 testing against pyld (not by inspection):
 
 - `extensions` (`@container: @index` with no `@index` property): index-map
@@ -10,25 +10,24 @@ testing against pyld (not by inspection):
   (unregistered) keys silently vanish on expand, because they resolve against
   no vocabulary. Fixed by `@type: @json`, which carries the whole subtree as
   an opaque JSON-LD literal.
-- `documentType` (`@type: @vocab` with no `@vocab` default and no registered
-  terms for its enum): unrecognized values fall back to document-base-relative
-  IRI resolution, so the same value expands to a different, non-equal IRI
-  depending on the document's base URL. Fixed by registering each
-  `DocumentReference.documentType` enum value as a term-scoped `mif:`-namespaced
-  term (a nested `@context` on the `documentType` term definition itself),
-  mirroring the existing `documents.hash`/`relationships` scoped-context
-  pattern already in this file.
+- `documentType`, `citationType`, `citationRole` (`@type: @vocab` with no
+  `@vocab` default and no registered terms for their enum): unrecognized
+  values fall back to document-base-relative IRI resolution, so the same
+  value expands to a different, non-equal IRI depending on the document's
+  base URL. Fixed by registering each property's enum values as a
+  term-scoped `mif:`-namespaced term (a nested `@context` on the property's
+  own term definition), mirroring the existing `documents.hash`/
+  `relationships` scoped-context pattern already in this file.
 
-  An earlier version of this fix registered the same 13 terms at the TOP
-  LEVEL of the shared context instead of scoping them to `documentType`.
+  An earlier version of `documentType`'s fix registered its 13 terms at the
+  TOP LEVEL of the shared context instead of scoping them to `documentType`.
   JSON-LD `@type:@vocab` resolution checks the whole active context, not
   just the property being expanded, so that flat registration silently
   redirected `Citation.citationType` values that happen to share a name with
   a `documentType` enum value (`video`, `dataset`, `other` are valid values
-  of both fields) to the wrong `mif:DocumentType*` IRI. Scoping the terms to
-  `documentType`'s own `@context` keeps `citationType` (still unregistered,
-  still base-URI-dependent -- a separate, pre-existing instance of the same
-  class of bug, out of scope for this fix) unaffected.
+  of both fields) to the wrong `mif:DocumentType*` IRI. Scoping every one of
+  these three properties' terms to its own `@context` keeps them from
+  contaminating each other despite the overlapping enum values.
 """
 import json
 import sys
@@ -39,7 +38,16 @@ from pyld import jsonld
 ROOT = Path(__file__).parent.parent
 CONTEXT = json.loads((ROOT / "schema" / "context.jsonld").read_text())["@context"]
 
-DOCUMENT_TYPES = list(CONTEXT["documentType"]["@context"].keys())
+# (prop, node_type, extra_fields) for every term-scoped @type:@vocab property
+# this file exercises. Single source of truth: adding a fourth such property
+# means adding one row here, not touching N call sites.
+VOCAB_PROPERTIES = [
+    ("documentType", "DocumentReference", {"url": "https://example.com/doc"}),
+    ("citationType", "Citation", {}),
+    ("citationRole", "Citation", {}),
+]
+
+VOCAB_VALUES = {prop: list(CONTEXT[prop]["@context"].keys()) for prop, _, _ in VOCAB_PROPERTIES}
 
 
 def _compact(expanded: object, ctx: dict) -> dict:
@@ -74,64 +82,71 @@ def check_extensions_round_trip() -> list[str]:
     return errors
 
 
-def _expanded_document_type_id(expanded: list, value: str, base_label: str) -> str | None:
+def _expanded_vocab_id(expanded: list, prop: str, value: str, base_label: str) -> str | None:
+    prop_iri = f"https://mif-spec.dev/ns/{prop}"
     try:
-        return expanded[0]["https://mif-spec.dev/ns/documentType"][0]["@id"]
+        return expanded[0][prop_iri][0]["@id"]
     except (IndexError, KeyError, TypeError) as e:
-        return f"<malformed expansion for documentType={value!r} ({base_label}): {e!r}>"
+        return f"<malformed expansion for {prop}={value!r} ({base_label}): {e!r}>"
 
 
-def check_document_type_base_independence() -> list[str]:
+def check_vocab_base_independence() -> list[str]:
     errors = []
-    for value in DOCUMENT_TYPES:
-        doc = {
-            "@context": CONTEXT,
-            "@type": "DocumentReference",
-            "url": "https://example.com/doc",
-            "documentType": value,
-        }
-        expanded_a = jsonld.expand(doc, {"base": "https://host-a.example/"})
-        expanded_b = jsonld.expand(doc, {"base": "https://host-b.example/"})
-        iri_a = _expanded_document_type_id(expanded_a, value, "host-a")
-        iri_b = _expanded_document_type_id(expanded_b, value, "host-b")
-        if iri_a != iri_b:
-            errors.append(
-                f"documentType={value!r} is base-URI-dependent: "
-                f"{iri_a!r} (host-a) != {iri_b!r} (host-b)"
-            )
-        elif iri_a is None or not iri_a.startswith("https://mif-spec.dev/ns/"):
-            errors.append(
-                f"documentType={value!r} did not expand to a stable mif: IRI: {iri_a!r}"
-            )
-        compacted = _compact(expanded_a, CONTEXT)
-        if compacted.get("documentType") != value:
-            errors.append(
-                f"documentType={value!r} did not round-trip: got {compacted.get('documentType')!r}"
-            )
+    for prop, node_type, extra_fields in VOCAB_PROPERTIES:
+        for value in VOCAB_VALUES[prop]:
+            doc = {"@context": CONTEXT, "@type": node_type, **extra_fields, prop: value}
+            expanded_a = jsonld.expand(doc, {"base": "https://host-a.example/"})
+            expanded_b = jsonld.expand(doc, {"base": "https://host-b.example/"})
+            iri_a = _expanded_vocab_id(expanded_a, prop, value, "host-a")
+            iri_b = _expanded_vocab_id(expanded_b, prop, value, "host-b")
+            if iri_a != iri_b:
+                errors.append(
+                    f"{prop}={value!r} is base-URI-dependent: {iri_a!r} (host-a) != {iri_b!r} (host-b)"
+                )
+            elif iri_a is None or not iri_a.startswith("https://mif-spec.dev/ns/"):
+                errors.append(f"{prop}={value!r} did not expand to a stable mif: IRI: {iri_a!r}")
+            compacted = _compact(expanded_a, CONTEXT)
+            if compacted.get(prop) != value:
+                errors.append(f"{prop}={value!r} did not round-trip: got {compacted.get(prop)!r}")
     return errors
 
 
-def check_document_type_custom_namespace_still_works() -> list[str]:
+def check_vocab_custom_namespace_still_works() -> list[str]:
     errors = []
-    doc = {
-        "@context": CONTEXT,
-        "@type": "DocumentReference",
-        "url": "https://example.com/x",
-        "documentType": "subcog:widget",
-    }
-    expanded = jsonld.expand(doc, {"base": "https://host-a.example/"})
-    compacted = _compact(expanded, CONTEXT)
-    if compacted.get("documentType") != "subcog:widget":
-        errors.append(
-            f"custom-namespaced documentType regressed: got {compacted.get('documentType')!r}"
-        )
+    for prop, node_type, extra_fields in VOCAB_PROPERTIES:
+        doc = {"@context": CONTEXT, "@type": node_type, **extra_fields, prop: "subcog:widget"}
+        expanded = jsonld.expand(doc, {"base": "https://host-a.example/"})
+        compacted = _compact(expanded, CONTEXT)
+        if compacted.get(prop) != "subcog:widget":
+            errors.append(f"custom-namespaced {prop} regressed: got {compacted.get(prop)!r}")
+    return errors
+
+
+def check_document_type_citation_type_no_cross_contamination() -> list[str]:
+    """documentType and citationType share enum values (video/dataset/other);
+    each must resolve within its own vocab, never the other's."""
+    errors = []
+    shared = set(VOCAB_VALUES["documentType"]) & set(VOCAB_VALUES["citationType"])
+    if not shared:
+        errors.append("expected documentType/citationType to share at least one enum value to test contamination against")
+        return errors
+    for value in sorted(shared):
+        doc_a = {"@context": CONTEXT, "@type": "DocumentReference", "url": "https://x", "documentType": value}
+        iri_a = _expanded_vocab_id(jsonld.expand(doc_a), "documentType", value, "n/a")
+        if iri_a is not None and "CitationType" in iri_a:
+            errors.append(f"documentType={value!r} contaminated by citationType terms: {iri_a}")
+        doc_b = {"@context": CONTEXT, "@type": "Citation", "citationType": value}
+        iri_b = _expanded_vocab_id(jsonld.expand(doc_b), "citationType", value, "n/a")
+        if iri_b is not None and "DocumentType" in iri_b:
+            errors.append(f"citationType={value!r} contaminated by documentType terms: {iri_b}")
     return errors
 
 
 CHECKS = [
     ("extensions round-trips losslessly through @type:@json (#224)", check_extensions_round_trip),
-    ("documentType is base-URI-independent for all enum values (#225)", check_document_type_base_independence),
-    ("documentType custom-namespaced escape hatch still resolves", check_document_type_custom_namespace_still_works),
+    ("documentType/citationType/citationRole are base-URI-independent for all enum values (#225, #226)", check_vocab_base_independence),
+    ("documentType/citationType/citationRole custom-namespaced escape hatch still resolves", check_vocab_custom_namespace_still_works),
+    ("documentType and citationType don't contaminate each other's shared enum values", check_document_type_citation_type_no_cross_contamination),
 ]
 
 

--- a/scripts/test_jsonld_context_fidelity.py
+++ b/scripts/test_jsonld_context_fidelity.py
@@ -82,12 +82,16 @@ def check_extensions_round_trip() -> list[str]:
     return errors
 
 
-def _expanded_vocab_id(expanded: list, prop: str, value: str, base_label: str) -> str | None:
+def _expanded_vocab_id(expanded: list, prop: str, value: str) -> str | None:
     prop_iri = f"https://mif-spec.dev/ns/{prop}"
     try:
         return expanded[0][prop_iri][0]["@id"]
     except (IndexError, KeyError, TypeError) as e:
-        return f"<malformed expansion for {prop}={value!r} ({base_label}): {e!r}>"
+        # Deliberately base-label-agnostic: two identically-malformed expansions
+        # across different base URLs must produce the SAME placeholder, or the
+        # base-independence check below would misdiagnose them as "base-URI-
+        # dependent" (iri_a != iri_b) instead of "malformed expansion".
+        return f"<malformed expansion for {prop}={value!r}: {e!r}>"
 
 
 def check_vocab_base_independence() -> list[str]:
@@ -97,8 +101,8 @@ def check_vocab_base_independence() -> list[str]:
             doc = {"@context": CONTEXT, "@type": node_type, **extra_fields, prop: value}
             expanded_a = jsonld.expand(doc, {"base": "https://host-a.example/"})
             expanded_b = jsonld.expand(doc, {"base": "https://host-b.example/"})
-            iri_a = _expanded_vocab_id(expanded_a, prop, value, "host-a")
-            iri_b = _expanded_vocab_id(expanded_b, prop, value, "host-b")
+            iri_a = _expanded_vocab_id(expanded_a, prop, value)
+            iri_b = _expanded_vocab_id(expanded_b, prop, value)
             if iri_a != iri_b:
                 errors.append(
                     f"{prop}={value!r} is base-URI-dependent: {iri_a!r} (host-a) != {iri_b!r} (host-b)"
@@ -132,11 +136,11 @@ def check_document_type_citation_type_no_cross_contamination() -> list[str]:
         return errors
     for value in sorted(shared):
         doc_a = {"@context": CONTEXT, "@type": "DocumentReference", "url": "https://x", "documentType": value}
-        iri_a = _expanded_vocab_id(jsonld.expand(doc_a), "documentType", value, "n/a")
+        iri_a = _expanded_vocab_id(jsonld.expand(doc_a), "documentType", value)
         if iri_a is not None and "CitationType" in iri_a:
             errors.append(f"documentType={value!r} contaminated by citationType terms: {iri_a}")
         doc_b = {"@context": CONTEXT, "@type": "Citation", "citationType": value}
-        iri_b = _expanded_vocab_id(jsonld.expand(doc_b), "citationType", value, "n/a")
+        iri_b = _expanded_vocab_id(jsonld.expand(doc_b), "citationType", value)
         if iri_b is not None and "DocumentType" in iri_b:
             errors.append(f"citationType={value!r} contaminated by documentType terms: {iri_b}")
     return errors


### PR DESCRIPTION
## Summary

Fixes #226: `Citation.citationType` and `Citation.citationRole` both used `@type:@vocab` with no registered terms — the same pre-fix defect #225 had for `documentType`. Unrecognized values fell back to document-base-relative IRI resolution, so the same value expanded to a different, non-equal IRI depending on the document's base URL. Confirmed with pyld before fixing.

Registered each enum value (12 `citationType`, 10 `citationRole`) as an explicit `mif:CitationType*`/`mif:CitationRole*` term, **scoped under each property's own `@context`** — not top-level/global. This matters: `citationType` shares `video`/`dataset`/`other` with `documentType`'s enum, and `documentType`'s original fix (#225, landed via #227) hit exactly the collision a flat registration causes; scoping keeps these properties' terms from resolving into each other despite the shared value names.

## Review-driven changes

Local 8-angle review (same process as #227) generalized the previously `documentType`-only base-independence check into a single `VOCAB_PROPERTIES` table that every check function derives from, so a fourth term-scoped vocab property means one new row instead of touching N call sites — and made the cross-contamination check reuse the same malformed-expansion-safe accessor every other check already uses, instead of unguarded inline indexing.

## What's NOT in this PR

- **`public/schema/context.jsonld`** (the mirror served at `mif-spec.dev`) is intentionally untouched, same rationale as #227 — updating it without a real version cut would desync it from `public/schema/latest/` and break the "Mirror alias consistency" required check.
- **#228** (filed): the review surfaced that several *other* `@type:@vocab` fields (`conceptType`/`memoryType`, `relationshipType`, `sourceType`, `trustLevel`) still register their terms flat/top-level rather than scoped. None currently collide or misbehave — verified empirically — but it's the same latent-fragility shape, and the test suite has no structural check that would catch the *next* one. That's a design decision (proactively re-scope vs. add a schema-driven coverage check), out of scope for this narrow fix.
- Also noted, not filed as its own issue (pre-existing, non-regressive, cosmetic): the new `mif:CitationType*`/`mif:CitationRole*` IRIs (like the existing `mif:DocumentType*` ones from #227) aren't yet documented in `public/ns/vocabulary.jsonld`/`ns/README.md`.

## Test plan

- [x] `scripts/test_jsonld_context_fidelity.py` fails against the pre-fix context, passes against the fix.
- [x] `scripts/okf_validate.py`, `scripts/mif_convert.py roundtrip`, `scripts/test_subtype_of.py` all pass unchanged.
- [x] Cross-contamination check verified against a reproduced pre-fix state (flat top-level registration) — confirms it doesn't pass trivially.
- [x] Full install + test suite re-verified in a `python:3.12-slim`/linux-amd64 container matching the CI runner.
- [x] 8-angle local review run and every finding addressed before opening this PR.

Closes #226