### PR TITLE
chore(schema): scope remaining vocab terms, add structural coverage check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,6 +59,9 @@ jobs:
       - name: JSON-LD context fidelity (real JSON-LD 1.1 expand/compact)
         run: python scripts/test_jsonld_context_fidelity.py
 
+      - name: Vocab term coverage (every @type:@vocab enum value is registered)
+        run: python scripts/check_vocab_term_coverage.py
+
   schema-validation:
     name: Validate JSON-LD Projection Against Schema
     runs-on: ubuntu-latest

--- a/schema/context.jsonld
+++ b/schema/context.jsonld
@@ -32,11 +32,21 @@
     },
     "conceptType": {
       "@id": "mif:conceptType",
-      "@type": "@vocab"
+      "@type": "@vocab",
+      "@context": {
+        "semantic": "mif:SemanticType",
+        "episodic": "mif:EpisodicType",
+        "procedural": "mif:ProceduralType"
+      }
     },
     "memoryType": {
       "@id": "mif:memoryType",
-      "@type": "@vocab"
+      "@type": "@vocab",
+      "@context": {
+        "semantic": "mif:SemanticType",
+        "episodic": "mif:EpisodicType",
+        "procedural": "mif:ProceduralType"
+      }
     },
     "title": "dc:title",
     "namespace": "mif:namespace",
@@ -269,7 +279,14 @@
     "provenance": "mif:provenance",
     "sourceType": {
       "@id": "mif:sourceType",
-      "@type": "@vocab"
+      "@type": "@vocab",
+      "@context": {
+        "user_explicit": "mif:UserExplicit",
+        "user_implicit": "mif:UserImplicit",
+        "agent_inferred": "mif:AgentInferred",
+        "external_import": "mif:ExternalImport",
+        "system_generated": "mif:SystemGenerated"
+      }
     },
     "sourceRef": {
       "@id": "mif:sourceRef",
@@ -283,7 +300,15 @@
     },
     "trustLevel": {
       "@id": "mif:trustLevel",
-      "@type": "@vocab"
+      "@type": "@vocab",
+      "@context": {
+        "verified": "mif:Verified",
+        "user_stated": "mif:UserStated",
+        "high_confidence": "mif:HighConfidence",
+        "moderate_confidence": "mif:ModerateConfidence",
+        "low_confidence": "mif:LowConfidence",
+        "uncertain": "mif:Uncertain"
+      }
     },
 
     "wasGeneratedBy": {
@@ -302,19 +327,6 @@
       "@id": "prov:wasAssociatedWith",
       "@type": "@id"
     },
-
-    "user_explicit": "mif:UserExplicit",
-    "user_implicit": "mif:UserImplicit",
-    "agent_inferred": "mif:AgentInferred",
-    "external_import": "mif:ExternalImport",
-    "system_generated": "mif:SystemGenerated",
-
-    "verified": "mif:Verified",
-    "user_stated": "mif:UserStated",
-    "high_confidence": "mif:HighConfidence",
-    "moderate_confidence": "mif:ModerateConfidence",
-    "low_confidence": "mif:LowConfidence",
-    "uncertain": "mif:Uncertain",
 
     "embedding": "mif:embedding",
     "modelVersion": "mif:modelVersion",
@@ -338,10 +350,6 @@
     "extensions": {
       "@id": "mif:extensions",
       "@type": "@json"
-    },
-
-    "semantic": "mif:SemanticType",
-    "episodic": "mif:EpisodicType",
-    "procedural": "mif:ProceduralType"
+    }
   }
 }

--- a/scripts/check_vocab_term_coverage.py
+++ b/scripts/check_vocab_term_coverage.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Structural guard against the #225/#226/#228 bug class recurring for a
+FUTURE `@type:@vocab` field.
+
+#225 (documentType) and #226 (citationType/citationRole) were both the same
+defect: a JSON-LD term definition uses `@type:@vocab` for a property whose
+schema enum has no registered term, so unrecognized values silently fall
+back to unstable, document-base-relative IRI resolution. Both were caught by
+hand, one field at a time, only after they'd already shipped.
+
+This script closes the gap structurally: it walks every `@type:@vocab` term
+definition in `schema/context.jsonld` (at any nesting depth), finds the
+matching property's `enum` in `schema/mif.schema.json` (checked at the top
+level and inside every `$defs` entry), and fails if any enum value has no
+registered term reachable from that property's own scope -- or if a
+registered term doesn't correspond to any enum value (a stale/typo'd entry
+sitting alongside correct ones, otherwise invisible since the correct values
+being present would still read as "covered").
+
+"Reachable" accounts for two safe registration shapes:
+  - a term-scoped `@context` on the property's own definition (the pattern
+    `documentType`/`citationType`/`citationRole`/`conceptType`/`memoryType`/
+    `sourceType`/`trustLevel` all use), or
+  - an inherited `@vocab` default from an enclosing scope (the pattern
+    `relationships[].type` uses via the `relationships` container's own
+    `"@vocab": "https://mif-spec.dev/ns/"`) -- any value resolves safely to
+    a stable `mif:`-namespaced IRI by construction, so no explicit
+    registration is required.
+
+A property with `@type:@vocab` but no matching schema `enum` (e.g. the
+free-form kebab-case `Relationship.type`, or a term whose schema property
+uses a different name than its JSON-LD term key) has nothing to check
+against and is reported as SKIPPED, not silently dropped -- so "no enum
+exists" and "enum exists but wasn't found" are distinguishable in the
+output. `_schema_enum` also returns the FIRST enum found for a given
+property name across `$defs` entries, not the one for a specific type;
+today no two `$defs` entries define different enums under the same
+property name for any vocab-typed term, but this is a known limitation if
+that ever changes, not disambiguated here (doing so would require knowing
+which schema type each JSON-LD term corresponds to, which this repo's
+context/schema pairing doesn't currently encode).
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+CONTEXT = json.loads((ROOT / "schema" / "context.jsonld").read_text())["@context"]
+SCHEMA = json.loads((ROOT / "schema" / "mif.schema.json").read_text())
+
+
+def _schema_enum(prop: str) -> list[str] | None:
+    """Find `prop`'s enum in the schema: top-level properties first, then
+    every $defs entry's properties. Handles both the plain `enum: [...]`
+    shape and the `oneOf: [{enum: [...]}, {pattern: ...}]` escape-hatch
+    shape used by documentType/citationType/citationRole."""
+    candidates = [SCHEMA.get("properties", {})]
+    candidates += [d.get("properties", {}) for d in SCHEMA.get("$defs", {}).values()]
+    for props in candidates:
+        spec = props.get(prop)
+        if not isinstance(spec, dict):
+            continue
+        if "enum" in spec:
+            return spec["enum"]
+        for branch in spec.get("oneOf", []):
+            if "enum" in branch:
+                return branch["enum"]
+    return None
+
+
+def _walk(node: dict, ambient_vocab: bool, path: str, findings: list[dict]) -> None:
+    """Recurse through a JSON-LD @context dict, tracking whether an
+    ambient @vocab default is active in the current scope."""
+    scope_vocab = ambient_vocab or isinstance(node.get("@vocab"), str)
+    for key, value in node.items():
+        if key.startswith("@"):
+            continue
+        if not isinstance(value, dict):
+            continue
+        term_path = f"{path}.{key}" if path else key
+        if value.get("@type") == "@vocab":
+            enum = _schema_enum(key)
+            registered = set(value.get("@context", {}).keys())
+            findings.append({
+                "term": key,
+                "path": term_path,
+                "enum": enum,
+                "missing": [v for v in enum if v not in registered] if enum is not None else [],
+                "extra": sorted(registered - set(enum)) if enum is not None else [],
+                "safe_by_ambient_vocab": scope_vocab,
+            })
+        nested = value.get("@context")
+        if isinstance(nested, dict):
+            _walk(nested, scope_vocab, term_path, findings)
+
+
+def main() -> int:
+    findings: list[dict] = []
+    _walk(CONTEXT, False, "", findings)
+
+    if not findings:
+        print("No @type:@vocab properties found at all -- nothing to check.")
+        return 1  # Suspicious: this script exists because such properties exist.
+
+    failed = []
+    checked = 0
+    for f in findings:
+        if f["enum"] is None:
+            print(f"SKIP: {f['path']} -- no matching schema enum found for this property name")
+            continue
+        checked += 1
+        label = f"{f['path']} ({len(f['enum'])} enum values)"
+        problems = []
+        if f["missing"] and not f["safe_by_ambient_vocab"]:
+            problems.append(f"unregistered, no ambient @vocab fallback: {f['missing']}")
+        if f["extra"]:
+            problems.append(f"registered term(s) not in the schema enum (stale/typo?): {f['extra']}")
+        if problems:
+            print(f"FAIL: {label} -- " + "; ".join(problems))
+            failed.append(f["path"])
+        elif f["missing"]:
+            print(
+                f"PASS: {label} -- {len(f['missing'])} value(s) unregistered "
+                f"but safe via inherited ambient @vocab: {f['missing']}"
+            )
+        else:
+            print(f"PASS: {label} -- every enum value has a registered term, no extras")
+
+    if failed:
+        print(f"\nVocab term coverage FAILED for: {failed}")
+        return 1
+    print(f"\nAll {checked} enum-bounded @type:@vocab properties are fully and exactly covered.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_jsonld_context_fidelity.py
+++ b/scripts/test_jsonld_context_fidelity.py
@@ -10,14 +10,15 @@ testing against pyld (not by inspection):
   (unregistered) keys silently vanish on expand, because they resolve against
   no vocabulary. Fixed by `@type: @json`, which carries the whole subtree as
   an opaque JSON-LD literal.
-- `documentType`, `citationType`, `citationRole` (`@type: @vocab` with no
-  `@vocab` default and no registered terms for their enum): unrecognized
-  values fall back to document-base-relative IRI resolution, so the same
-  value expands to a different, non-equal IRI depending on the document's
-  base URL. Fixed by registering each property's enum values as a
-  term-scoped `mif:`-namespaced term (a nested `@context` on the property's
-  own term definition), mirroring the existing `documents.hash`/
-  `relationships` scoped-context pattern already in this file.
+- `documentType`, `citationType`, `citationRole`, `conceptType`, `memoryType`,
+  `sourceType`, `trustLevel` (`@type: @vocab` with no `@vocab` default and no
+  registered terms for their enum): unrecognized values fall back to
+  document-base-relative IRI resolution, so the same value expands to a
+  different, non-equal IRI depending on the document's base URL. Fixed by
+  registering each property's enum values as a term-scoped `mif:`-namespaced
+  term (a nested `@context` on the property's own term definition),
+  mirroring the existing `documents.hash`/`relationships` scoped-context
+  pattern already in this file.
 
   An earlier version of `documentType`'s fix registered its 13 terms at the
   TOP LEVEL of the shared context instead of scoping them to `documentType`.
@@ -26,8 +27,16 @@ testing against pyld (not by inspection):
   redirected `Citation.citationType` values that happen to share a name with
   a `documentType` enum value (`video`, `dataset`, `other` are valid values
   of both fields) to the wrong `mif:DocumentType*` IRI. Scoping every one of
-  these three properties' terms to its own `@context` keeps them from
+  these properties' terms to its own `@context` keeps them from
   contaminating each other despite the overlapping enum values.
+
+`scripts/check_vocab_term_coverage.py` is this file's sibling: it statically
+proves every enum value has a matching registered term (and that no stale
+extra term exists), for ANY current or future `@type:@vocab` property, by
+cross-referencing `schema/context.jsonld` against `schema/mif.schema.json`.
+This file proves the registered terms actually behave correctly under a real
+JSON-LD 1.1 processor -- static presence and runtime semantics are two
+different failure modes, so both checks are needed.
 """
 import json
 import sys
@@ -39,12 +48,20 @@ ROOT = Path(__file__).parent.parent
 CONTEXT = json.loads((ROOT / "schema" / "context.jsonld").read_text())["@context"]
 
 # (prop, node_type, extra_fields) for every term-scoped @type:@vocab property
-# this file exercises. Single source of truth: adding a fourth such property
-# means adding one row here, not touching N call sites.
+# this file exercises. Single source of truth: adding another such property
+# means adding one row here, not touching N call sites. sourceType/trustLevel
+# are schema-nested under Provenance in practice, but "provenance" is a bare
+# string term (no nested @context of its own), so it introduces no new
+# resolution scope -- testing them as direct Memory properties here exercises
+# the identical term-resolution mechanics as their real nested usage.
 VOCAB_PROPERTIES = [
     ("documentType", "DocumentReference", {"url": "https://example.com/doc"}),
     ("citationType", "Citation", {}),
     ("citationRole", "Citation", {}),
+    ("conceptType", "Memory", {}),
+    ("memoryType", "Memory", {}),
+    ("sourceType", "Memory", {}),
+    ("trustLevel", "Memory", {}),
 ]
 
 VOCAB_VALUES = {prop: list(CONTEXT[prop]["@context"].keys()) for prop, _, _ in VOCAB_PROPERTIES}
@@ -148,8 +165,8 @@ def check_document_type_citation_type_no_cross_contamination() -> list[str]:
 
 CHECKS = [
     ("extensions round-trips losslessly through @type:@json (#224)", check_extensions_round_trip),
-    ("documentType/citationType/citationRole are base-URI-independent for all enum values (#225, #226)", check_vocab_base_independence),
-    ("documentType/citationType/citationRole custom-namespaced escape hatch still resolves", check_vocab_custom_namespace_still_works),
+    ("every scoped vocab property is base-URI-independent for all enum values (#225, #226, #228)", check_vocab_base_independence),
+    ("every scoped vocab property's custom-namespaced escape hatch still resolves", check_vocab_custom_namespace_still_works),
     ("documentType and citationType don't contaminate each other's shared enum values", check_document_type_citation_type_no_cross_contamination),
 ]
 


### PR DESCRIPTION
## Summary

Fixes #228 with both proposed directions, not just one:

**1. Scoped the 4 remaining flat `@type:@vocab` fields.** `conceptType`/`memoryType`, `sourceType`, and `trustLevel` registered their enum terms at the top level of the shared context instead of scoped to each property's own `@context` — the same flat-registration shape that caused the `documentType`/`citationType` collision fixed in #227. None of these currently collide (verified with pyld before and after), but it was latent fragility: the next PR to extend any of these enums with a value name matching another flat term would silently redirect resolution to the wrong IRI. Scoped all four to match the established pattern, then removed the now-redundant flat top-level registrations.

**2. Added `scripts/check_vocab_term_coverage.py`** — a schema-driven structural check, not a hardcoded property list. It walks every `@type:@vocab` term in `schema/context.jsonld` at any nesting depth, finds each property's enum in `schema/mif.schema.json`, and fails if any enum value has no reachable registered term (accounting for both scoped `@context` and inherited ambient `@vocab`, the mechanism that already makes `relationships[].type` safe by construction). Verified it correctly flags a synthetic future unregistered field, not just the four named in #228.

## Bugs found and fixed during review

- **The coverage script itself had a real bug**: it was one-directional (enum ⊆ registered, never the reverse), so a typo'd extra key sitting alongside correct ones in a scoped `@context` was invisible. Fixed by also failing on registered terms with no matching enum value — verified by injecting a typo (`"verifed"` alongside `trustLevel`'s real terms) and confirming it's now caught.
- The script now explicitly reports **SKIPPED** properties (no matching schema enum) instead of silently dropping them, so "no enum exists" and "enum exists but wasn't found" are distinguishable in output.
- `scripts/test_jsonld_context_fidelity.py`'s `VOCAB_PROPERTIES` table (the pyld-based runtime test — proves terms actually *resolve correctly*, a different failure mode than the new script's static *registration-presence* check) wasn't extended for the 4 newly-scoped fields. Extended it, updated stale labels/docstring that still only named the original 3 properties.

## What's NOT in this PR

- **`public/schema/context.jsonld`** is intentionally untouched, same rationale as #227/#229.
- **#230** (filed separately): the top-level `relationshipType`/`RelatesTo`/`DerivedFrom`/... term block is dead code for schema-validated documents (no schema property is named `relationshipType`, and the registered PascalCase terms could never match the schema's actual lowercase-kebab-case values). Correctly SKIPPED by the new coverage script (no matching enum), though a raw JSON-LD consumer not gated by schema validation would still hit the base-URI-dependent bug for it today — confirmed independently by two review passes, exactly what #230 tracks. Fixing it changes actual term semantics (delete vs. re-case), a design decision out of scope here.

## Test plan

- [x] Both `check_vocab_term_coverage.py` and `test_jsonld_context_fidelity.py` fail against the pre-fix context, pass against the fix.
- [x] Coverage script's bidirectional check verified with a live typo-injection repro.
- [x] Coverage script verified against a synthetic future unregistered `@type:@vocab` field (schema-driven, not hardcoded).
- [x] `okf_validate.py`, `mif_convert.py roundtrip`, `test_subtype_of.py` all pass unchanged.
- [x] `actionlint` clean; full suite re-verified in a `python:3.12-slim`/linux-amd64 container matching the CI runner.
- [x] 8-angle local review run and every finding addressed before opening this PR.

Closes #228