### PR TITLE
fix(schema): re-key relationships[].type to real kebab-case values

### DIFF
--- a/schema/context.jsonld
+++ b/schema/context.jsonld
@@ -197,7 +197,18 @@
         "@vocab": "https://mif-spec.dev/ns/",
         "type": {
           "@id": "mif:relationshipType",
-          "@type": "@vocab"
+          "@type": "@vocab",
+          "@context": {
+            "relates-to": "mif:RelatesTo",
+            "derived-from": "mif:DerivedFrom",
+            "supersedes": "mif:Supersedes",
+            "conflicts-with": "mif:ConflictsWith",
+            "part-of": "mif:PartOf",
+            "implements": "mif:Implements",
+            "uses": "mif:Uses",
+            "created": "mif:Created",
+            "mentioned-in": "mif:MentionedIn"
+          }
         },
         "target": {
           "@id": "mif:target",
@@ -209,28 +220,10 @@
         }
       }
     },
-    "relationshipType": {
-      "@id": "mif:relationshipType",
-      "@type": "@vocab"
-    },
-    "target": {
-      "@id": "mif:target",
-      "@type": "@id"
-    },
     "strength": {
       "@id": "mif:strength",
       "@type": "xsd:decimal"
     },
-
-    "RelatesTo": "mif:RelatesTo",
-    "DerivedFrom": "mif:DerivedFrom",
-    "Supersedes": "mif:Supersedes",
-    "ConflictsWith": "mif:ConflictsWith",
-    "PartOf": "mif:PartOf",
-    "Implements": "mif:Implements",
-    "Uses": "mif:Uses",
-    "Created": "mif:Created",
-    "MentionedIn": "mif:MentionedIn",
 
     "temporal": "mif:temporal",
     "validFrom": {

--- a/scripts/test_jsonld_context_fidelity.py
+++ b/scripts/test_jsonld_context_fidelity.py
@@ -37,6 +37,25 @@ cross-referencing `schema/context.jsonld` against `schema/mif.schema.json`.
 This file proves the registered terms actually behave correctly under a real
 JSON-LD 1.1 processor -- static presence and runtime semantics are two
 different failure modes, so both checks are needed.
+
+- `relationships[].type` (`@type: @vocab`, nested inside the `relationships`
+  container's own scoped `@context`): registered the SPECIFICATION.md 8.2
+  "Core Relationship Types" under their PascalCase display names
+  (`RelatesTo`, `DerivedFrom`, ...) as term KEYS, but `Relationship.type`'s
+  actual schema constraint is a free-form lowercase-kebab-case pattern (e.g.
+  `derived-from`), and real documents use exactly that kebab-case form.
+  JSON-LD term lookup is exact-string-match, so no schema-valid value ever
+  matched a registered term -- unlike `documentType`/`citationType`/etc,
+  this wasn't a MISSING registration, it was a registration under the wrong
+  key entirely, silently doing nothing for every real document. The
+  `relationships` container's own ambient `@vocab` default masked the
+  symptom: unregistered values still resolved to a stable-looking `mif:`
+  IRI (base-URI-independent, unlike the documentType/citationType bugs),
+  so this looked fine at a glance -- the real loss was landing on the
+  wrong IRI, `mif:derived-from` instead of the documented, ontology-
+  registered `mif:DerivedFrom`. Fixed by re-keying the scoped `@context`
+  to the real kebab-case values, mapped to the existing `mif:`-namespaced
+  PascalCase IRIs already published in `public/ns/vocabulary.jsonld`.
 """
 import json
 import sys
@@ -143,6 +162,99 @@ def check_vocab_custom_namespace_still_works() -> list[str]:
     return errors
 
 
+# SPECIFICATION.md 8.2 "Core Relationship Types" -- kebab-case value (the
+# schema-valid, real-world form) mapped to the documented ontology IRI's
+# local name (published in public/ns/vocabulary.jsonld).
+RELATIONSHIP_TYPES = {
+    "relates-to": "RelatesTo",
+    "derived-from": "DerivedFrom",
+    "supersedes": "Supersedes",
+    "conflicts-with": "ConflictsWith",
+    "part-of": "PartOf",
+    "implements": "Implements",
+    "uses": "Uses",
+    "created": "Created",
+    "mentioned-in": "MentionedIn",
+}
+
+
+def check_relationship_type_resolves_to_documented_ontology_iri() -> list[str]:
+    errors = []
+    for kebab, pascal in RELATIONSHIP_TYPES.items():
+        doc = {
+            "@context": CONTEXT, "@type": "Memory", "@id": "urn:mif:test", "conceptType": "semantic",
+            "relationships": [{"type": kebab, "target": "/foo.md"}],
+        }
+        expanded_a = jsonld.expand(doc, {"base": "https://host-a.example/"})
+        expanded_b = jsonld.expand(doc, {"base": "https://host-b.example/"})
+        try:
+            iri_a = expanded_a[0]["https://mif-spec.dev/ns/relationships"][0]["https://mif-spec.dev/ns/relationshipType"][0]["@id"]
+            iri_b = expanded_b[0]["https://mif-spec.dev/ns/relationships"][0]["https://mif-spec.dev/ns/relationshipType"][0]["@id"]
+        except (IndexError, KeyError, TypeError) as e:
+            errors.append(f"relationships[].type={kebab!r}: malformed expansion: {e!r}")
+            continue
+        expected = f"https://mif-spec.dev/ns/{pascal}"
+        if iri_a != iri_b:
+            errors.append(f"relationships[].type={kebab!r} is base-URI-dependent: {iri_a!r} != {iri_b!r}")
+        elif iri_a != expected:
+            errors.append(f"relationships[].type={kebab!r} resolved to {iri_a!r}, want documented ontology IRI {expected!r}")
+        compacted = _compact(expanded_a, CONTEXT)
+        if compacted["relationships"][0].get("type") != kebab:
+            errors.append(f"relationships[].type={kebab!r} did not round-trip: got {compacted['relationships'][0].get('type')!r}")
+    return errors
+
+
+def check_relationship_type_custom_namespace_still_works() -> list[str]:
+    errors = []
+    doc = {
+        "@context": CONTEXT, "@type": "Memory", "@id": "urn:mif:test", "conceptType": "semantic",
+        "relationships": [{"type": "subcog:custom-rel", "target": "/foo.md"}],
+    }
+    compacted = _compact(jsonld.expand(doc), CONTEXT)
+    if compacted["relationships"][0].get("type") != "subcog:custom-rel":
+        errors.append(f"custom-namespaced relationships[].type regressed: got {compacted['relationships'][0].get('type')!r}")
+    return errors
+
+
+def check_strength_shared_by_relationship_and_decay() -> list[str]:
+    """`strength` is a plain (non-@vocab) xsd:decimal term shared by two
+    unrelated schema objects: Relationship.strength (relationships[].strength)
+    and TemporalMetadata.decay.strength ("alias for currentStrength"). It must
+    stay a single, shared top-level term -- an earlier version of this fix
+    moved it into relationships[]'s own scoped @context exclusively, which
+    silently dropped decay.strength from expansion entirely (no error), since
+    that scope is inaccessible outside the relationships array. Confirmed
+    against a real fixture (profiles/ai-memory/examples/level-3-citations.md's
+    `decay: {model: none, strength: 1.0}`) before this test existed."""
+    errors = []
+    doc = {
+        "@context": CONTEXT, "@type": "Memory", "@id": "urn:mif:test", "conceptType": "semantic",
+        "temporal": {"decay": {"model": "none", "currentStrength": 0.8, "strength": 1.0}},
+        "relationships": [{"type": "derived-from", "target": "/foo.md", "strength": 0.9}],
+    }
+    expanded = jsonld.expand(doc)
+    try:
+        decay = expanded[0]["https://mif-spec.dev/ns/temporal"][0]["https://mif-spec.dev/ns/decay"][0]
+    except (IndexError, KeyError, TypeError) as e:
+        errors.append(f"malformed expansion reaching temporal.decay: {e!r}")
+        return errors
+    if "https://mif-spec.dev/ns/strength" not in decay:
+        errors.append("temporal.decay.strength was dropped from expansion entirely (no error) -- decay: " + repr(decay))
+    try:
+        rel_strength = expanded[0]["https://mif-spec.dev/ns/relationships"][0]["https://mif-spec.dev/ns/strength"]
+    except (IndexError, KeyError, TypeError) as e:
+        errors.append(f"malformed expansion reaching relationships[].strength: {e!r}")
+        return errors
+    if not rel_strength:
+        errors.append("relationships[].strength was dropped from expansion entirely (no error)")
+    compacted = _compact(expanded, CONTEXT)
+    if compacted.get("temporal", {}).get("decay", {}).get("strength") != 1.0:
+        errors.append(f"temporal.decay.strength did not round-trip: got {compacted.get('temporal', {}).get('decay', {})!r}")
+    if compacted.get("relationships", [{}])[0].get("strength") != 0.9:
+        errors.append(f"relationships[].strength did not round-trip: got {compacted.get('relationships', [{}])[0]!r}")
+    return errors
+
+
 def check_document_type_citation_type_no_cross_contamination() -> list[str]:
     """documentType and citationType share enum values (video/dataset/other);
     each must resolve within its own vocab, never the other's."""
@@ -168,6 +280,9 @@ CHECKS = [
     ("every scoped vocab property is base-URI-independent for all enum values (#225, #226, #228)", check_vocab_base_independence),
     ("every scoped vocab property's custom-namespaced escape hatch still resolves", check_vocab_custom_namespace_still_works),
     ("documentType and citationType don't contaminate each other's shared enum values", check_document_type_citation_type_no_cross_contamination),
+    ("relationships[].type resolves to its documented ontology IRI, not mif:<kebab-value> (#230)", check_relationship_type_resolves_to_documented_ontology_iri),
+    ("relationships[].type custom-namespaced escape hatch still resolves", check_relationship_type_custom_namespace_still_works),
+    ("strength stays shared by relationships[].strength and temporal.decay.strength", check_strength_shared_by_relationship_and_decay),
 ]
 
 

--- a/scripts/test_jsonld_context_fidelity.py
+++ b/scripts/test_jsonld_context_fidelity.py
@@ -178,6 +178,18 @@ RELATIONSHIP_TYPES = {
 }
 
 
+def _compacted_relationship_field(compacted: dict, field: str) -> object:
+    """compacted["relationships"][0].get(field), tolerant of a context
+    regression that drops or reshapes `relationships` during compaction
+    (an empty/missing list, or a non-dict first element) -- returns a
+    descriptive placeholder instead of raising, so callers can report a
+    clear test failure rather than crashing the whole run."""
+    try:
+        return compacted["relationships"][0].get(field)
+    except (IndexError, KeyError, TypeError) as e:
+        return f"<malformed compaction reaching relationships[0].{field}: {e!r}>"
+
+
 def check_relationship_type_resolves_to_documented_ontology_iri() -> list[str]:
     errors = []
     for kebab, pascal in RELATIONSHIP_TYPES.items():
@@ -199,8 +211,9 @@ def check_relationship_type_resolves_to_documented_ontology_iri() -> list[str]:
         elif iri_a != expected:
             errors.append(f"relationships[].type={kebab!r} resolved to {iri_a!r}, want documented ontology IRI {expected!r}")
         compacted = _compact(expanded_a, CONTEXT)
-        if compacted["relationships"][0].get("type") != kebab:
-            errors.append(f"relationships[].type={kebab!r} did not round-trip: got {compacted['relationships'][0].get('type')!r}")
+        round_tripped = _compacted_relationship_field(compacted, "type")
+        if round_tripped != kebab:
+            errors.append(f"relationships[].type={kebab!r} did not round-trip: got {round_tripped!r}")
     return errors
 
 
@@ -211,8 +224,9 @@ def check_relationship_type_custom_namespace_still_works() -> list[str]:
         "relationships": [{"type": "subcog:custom-rel", "target": "/foo.md"}],
     }
     compacted = _compact(jsonld.expand(doc), CONTEXT)
-    if compacted["relationships"][0].get("type") != "subcog:custom-rel":
-        errors.append(f"custom-namespaced relationships[].type regressed: got {compacted['relationships'][0].get('type')!r}")
+    round_tripped = _compacted_relationship_field(compacted, "type")
+    if round_tripped != "subcog:custom-rel":
+        errors.append(f"custom-namespaced relationships[].type regressed: got {round_tripped!r}")
     return errors
 
 


### PR DESCRIPTION
## Summary

Fixes #230. `relationships[].type`'s scoped `@context` registered `SPECIFICATION.md`'s 9 "Core Relationship Types" (§8.2) under their PascalCase display names (`RelatesTo`, `DerivedFrom`, ...) as term keys, but `Relationship.type`'s actual schema constraint is a free-form lowercase-kebab-case pattern (`derived-from`, `relates-to`, ...), and real documents use exactly that kebab-case form. JSON-LD term lookup is exact-string-match, so no schema-valid value ever matched a registered term.

**This was originally filed as "dead code, delete it" — that framing was wrong.** #230's own research never checked `SPECIFICATION.md`, `ns/README.md`, or `public/ns/vocabulary.jsonld`, all of which document `RelatesTo`/`DerivedFrom`/etc. as the org's real, published RDF ontology vocabulary (with `rdfs:label`s and stable `mif:` IRIs). The actual bug is the same #225/#226/#228 class in disguise: an `@type:@vocab` property whose real values weren't mapped to their registered ontology terms — just harder to spot because the container's ambient `@vocab` default made unregistered values still resolve to a *stable-looking* `mif:` IRI, landing on the wrong one (`mif:derived-from` instead of the documented `mif:DerivedFrom`) rather than an obviously-broken base-relative one.

Fixed by re-keying the scoped `@context` to the real kebab-case values, mapped to the existing ontology IRIs, and removing the now-fully-redundant flat top-level `relationshipType`/`target`/`RelatesTo`-family entries.

## A regression caught and fixed during review

An earlier version of this fix also moved `strength` into `relationships[]`'s scoped `@context` exclusively, on the same "redundant duplicate" assumption that was correct for `target` but wrong for `strength`: it's a plain `xsd:decimal` term shared by **two unrelated schema objects** — `Relationship.strength` and `TemporalMetadata.decay.strength` (used in a real fixture, `profiles/ai-memory/examples/level-3-citations.md`). Scoping it exclusively silently dropped `decay.strength` from JSON-LD expansion entirely, no error — confirmed by 5 independent review passes. Reverted: `strength` stays a shared top-level term, as before. Added a permanent regression test, verified it fails against the buggy intermediate state and passes against the fix.

Also confirmed the pre-fix bug was worse than cosmetic: `relationshipType="created"` collided with the pre-existing top-level `"created"` term (a `dc:created` date property) via context inheritance, resolving to `http://purl.org/dc/terms/created` — a date-property IRI, not a relationship type at all.

## What's NOT in this PR

- **`public/schema/context.jsonld`** intentionally untouched, same rationale as prior PRs.
- **#232** (filed): `SPECIFICATION.md` §8.1/8.3 documents a structured `relationship_types` custom-extensibility registry with no corresponding implementation anywhere in this repo. Unrelated to the 9 core types this PR fixes.
- **#233** (filed): `check_vocab_term_coverage.py` structurally can't guard `relationships[].type` (no schema enum to check against, by design) — this fix's core-type mapping has one layer of regression defense instead of the two every other vocab property gets.

## Test plan

- [x] `check_relationship_type_resolves_to_documented_ontology_iri` fails against the pre-fix context (including reproducing the `dc:created` collision), passes against the fix.
- [x] `check_strength_shared_by_relationship_and_decay` fails against the buggy intermediate state (strength scoped exclusively), passes against the final fix.
- [x] Real fixture (`level-3-citations.md`'s `decay.strength`) verified end-to-end through `mif_convert.py to-jsonld` → pyld expand.
- [x] `okf_validate.py`, `mif_convert.py roundtrip`, `test_subtype_of.py`, `check_vocab_term_coverage.py` all pass unchanged.
- [x] Full suite re-verified in a `python:3.12-slim`/linux-amd64 container matching the CI runner.
- [x] 8-angle local review run twice (initial + after the strength regression was found and fixed) before opening this PR.

Closes #230