### PR TITLE
feat(schema): implement the relationship_types custom-type registry (#232)

### DIFF
--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -60,6 +60,30 @@ jobs:
           done
           exit $fail
 
+      - name: Compile standalone schemas (not part of the mif.schema.json ref bundle)
+        run: |
+          set -uo pipefail
+          fail=0
+          for s in schema/relationship-types-config.schema.json \
+                   public/schema/relationship-types-config.schema.json; do
+            [ -f "$s" ] || continue
+            if npx --no-install ajv compile -s "$s" --spec=draft2020 -c ajv-formats --strict=false; then
+              echo "ok: $s"
+            else
+              echo "::error::$s failed to compile"; fail=1
+            fi
+          done
+          s=schema/relationship-types-config.schema.json
+          p=public/schema/relationship-types-config.schema.json
+          if [ -f "$s" ] && [ ! -f "$p" ]; then
+            echo "::error::missing mirror file $p (present in $s)"; fail=1
+          elif [ ! -f "$s" ] && [ -f "$p" ]; then
+            echo "::error::missing mirror source $s (present in $p)"; fail=1
+          elif [ -f "$s" ] && [ -f "$p" ] && ! diff -q "$s" "$p" >/dev/null 2>&1; then
+            echo "::error::$p does not match $s"; fail=1
+          fi
+          exit $fail
+
       - name: Every JSON-LD context parses
         run: |
           set -uo pipefail

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Vocab term coverage (every @type:@vocab enum value is registered)
         run: python scripts/check_vocab_term_coverage.py
 
+      - name: Custom relationship_types registry (.mif/config.yaml)
+        run: python scripts/test_relationship_types_config.py
+
   schema-validation:
     name: Validate JSON-LD Projection Against Schema
     runs-on: ubuntu-latest

--- a/docs/examples/memories/.mif/config.yaml
+++ b/docs/examples/memories/.mif/config.yaml
@@ -1,0 +1,31 @@
+relationship_types:
+  # Core types (SPECIFICATION.md 8.2), listed here for documentation only --
+  # they're always recognized regardless of what's declared in this file.
+  - name: RelatesTo
+    description: General semantic relationship
+    symmetric: true
+    icon: "🔗"
+  - name: DerivedFrom
+    description: Memory created based on source
+    inverse: Derives
+    icon: "⬅️"
+
+  # Custom types (SPECIFICATION.md 8.1/8.3), namespaced under farm:. Once this
+  # file exists, every farm:* relationship type used in this bundle must be
+  # declared here -- scripts/okf_validate.py enforces it.
+  - name: BreedsWith
+    namespace: farm
+    description: Animal breeding relationship
+    symmetric: false
+    properties:
+      - name: breeding_date
+        type: date
+      - name: success
+        type: boolean
+
+# Maps each custom namespace prefix above to the IRI it expands to (SPECIFICATION.md
+# 8.3's own JSON-LD representation example). Merged into every JSON-LD projection's
+# @context by scripts/mif_convert.py so farm:breeds-with resolves to a real IRI on
+# expansion instead of staying an opaque compact-IRI-looking string.
+namespaces:
+  farm: "https://example.org/farm/"

--- a/docs/examples/memories/agriculture/ewe-002-breeding-record.md
+++ b/docs/examples/memories/agriculture/ewe-002-breeding-record.md
@@ -1,0 +1,21 @@
+---
+id: d4e5f607-8901-23de-f012-4567890123de
+type: semantic
+created: '2026-04-10T09:00:00Z'
+modified: '2026-04-10T09:00:00Z'
+namespace: _semantic/livestock
+title: Ewe 002 Breeding Record
+tags:
+- livestock
+- breeding
+- ewe
+entity:
+  entity_type: animal
+  entity_id: ewe-002
+  name: Ewe 002
+---
+
+# Ewe 002 Breeding Record
+
+Breeding record for Ewe 002. See [Ram 001 Breeding Record](/ram-001-breeding-record.md)
+for the paired `farm:breeds-with` relationship.

--- a/docs/examples/memories/agriculture/ram-001-breeding-record.md
+++ b/docs/examples/memories/agriculture/ram-001-breeding-record.md
@@ -1,0 +1,32 @@
+---
+id: c3d4e5f6-7890-12cd-ef01-3456789012cd
+type: semantic
+created: '2026-04-10T09:00:00Z'
+modified: '2026-04-10T09:00:00Z'
+namespace: _semantic/livestock
+title: Ram 001 Breeding Record
+tags:
+- livestock
+- breeding
+- ram
+relationships:
+- type: farm:breeds-with
+  target: /ewe-002-breeding-record.md
+  metadata:
+    farm:breeding_date: '2026-04-10'
+    farm:success: true
+entity:
+  entity_type: animal
+  entity_id: ram-001
+  name: Ram 001
+---
+
+# Ram 001 Breeding Record
+
+Breeding pairing record for Ram 001, demonstrating a custom
+`farm:breeds-with` relationship type declared in this bundle's
+`.mif/config.yaml` (SPECIFICATION.md 8.1/8.3).
+
+## Relationships
+
+- farm:breeds-with [Ewe 002 Breeding Record](/ewe-002-breeding-record.md)

--- a/docs/okf-conformance.md
+++ b/docs/okf-conformance.md
@@ -81,6 +81,15 @@ bundle:
    reported as warnings, not failures.
 5. **Lossless projection.** The `markdown → json-ld → markdown` round trip is
    lossless for all conformance-level data (`scripts/mif_convert.py roundtrip`).
+6. **Temporal consistency (warning by default).** A `derived-from` /
+   `supersedes` / `cites` edge's target must not be `created` after the concept
+   that derives from it; `--strict-temporal` promotes this to a hard error.
+7. **Custom relationship type registry (opt-in).** Once a bundle has a
+   `.mif/config.yaml` declaring `relationship_types` (SPECIFICATION.md §8.1/8.3),
+   every namespaced (custom) relationship type used in that bundle must be
+   declared there. Bundles without `.mif/config.yaml` keep the fully-lenient
+   behavior of (5)/(6) unchanged; bare/core types (no `namespace:` prefix) are
+   never gated by this check.
 
 Run it with:
 

--- a/docs/okf-conformance.md
+++ b/docs/okf-conformance.md
@@ -90,6 +90,12 @@ bundle:
    declared there. Bundles without `.mif/config.yaml` keep the fully-lenient
    behavior of (5)/(6) unchanged; bare/core types (no `namespace:` prefix) are
    never gated by this check.
+8. **Declared property value constraints (opt-in).** A declared custom type's
+   relationship metadata values are checked against that type's declared
+   `properties[]` (`type`/`enum`/`range`), when present in the metadata — e.g.
+   a property declared `range: [0.0, 1.0]` rejects a metadata value of `5.0`.
+   `inverse`/`symmetric` are declaration-only and not checked (they describe a
+   cross-relationship graph shape, not a single relationship's own values).
 
 Run it with:
 

--- a/public/schema/relationship-types-config.schema.json
+++ b/public/schema/relationship-types-config.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/relationship-types-config.schema.json",
+  "title": "MIF Relationship Types Configuration",
+  "description": "JSON Schema for a bundle's .mif/config.yaml relationship_types registry (SPECIFICATION.md 8.1). Declares the relationship types a bundle recognizes -- the nine core types (no namespace) for documentation/opt-in-recognition, and domain-specific custom types (with a namespace) that relationships[].type values in this bundle are validated against.",
+  "type": "object",
+  "properties": {
+    "relationship_types": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/RelationshipTypeDeclaration" }
+    },
+    "namespaces": {
+      "type": "object",
+      "description": "Maps each custom namespace prefix used by this bundle's relationship_types (or any other namespaced token) to the IRI it expands to -- the same mapping SPECIFICATION.md 8.3's JSON-LD representation example shows added as a second @context array entry (e.g. {\"farm\": \"https://example.org/farm/\"}). scripts/mif_convert.py merges this into every JSON-LD projection emitted for the bundle, so a declared namespace prefix actually resolves to a real IRI on expansion instead of staying an opaque, unexpanded compact-IRI-looking string.",
+      "propertyNames": { "pattern": "^[a-z][a-z0-9]*$" },
+      "additionalProperties": { "type": "string", "format": "uri" }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "RelationshipTypeDeclaration": {
+      "type": "object",
+      "description": "One declared relationship type. A `namespace` marks it as a custom type: its kebab-cased `name`, prefixed with `namespace:`, is the value used in relationships[].type (e.g. name: BreedsWith, namespace: farm -> \"farm:breeds-with\"). No `namespace` means it documents one of the nine core types (SPECIFICATION.md 8.2); the core types' registration is fixed regardless of what's declared here.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Z][a-zA-Z0-9]*$",
+          "description": "PascalCase display name and IRI local name (e.g. \"BreedsWith\"). The kebab-cased form (\"breeds-with\") is the actual relationships[].type token."
+        },
+        "namespace": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*$",
+          "description": "Lowercase prefix identifying a custom (non-core) type, e.g. \"farm\". Should have a matching entry in this file's top-level `namespaces` map (its IRI) so the type actually resolves on JSON-LD expansion, not just validates as declared."
+        },
+        "description": {
+          "type": "string"
+        },
+        "inverse": {
+          "type": "string",
+          "description": "PascalCase name of this type's inverse relationship (e.g. \"Derives\" for \"DerivedFrom\"), if directional and not self-symmetric. Declaration only: scripts/okf_validate.py does not check that a reciprocal edge of this type actually exists anywhere in the bundle."
+        },
+        "symmetric": {
+          "type": "boolean",
+          "default": false,
+          "description": "True when the relationship reads the same in both directions (e.g. RelatesTo, ConflictsWith). Declaration only: scripts/okf_validate.py does not check that a matching reverse-direction edge actually exists anywhere in the bundle."
+        },
+        "icon": {
+          "type": "string",
+          "description": "A single display emoji, for tooling/docs."
+        },
+        "properties": {
+          "type": "array",
+          "description": "Structured metadata fields this relationship type carries. These are NOT new keys on the Relationship object itself (which is closed, additionalProperties:false) -- they're carried as namespaced keys inside the relationship's own metadata object (e.g. {\"farm:breeding_date\": \"2025-10-15\"}), per SPECIFICATION.md 8.3's JSON-LD representation example.",
+          "items": { "$ref": "#/$defs/RelationshipTypePropertyDeclaration" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "RelationshipTypePropertyDeclaration": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Property name; carried in metadata as \"<namespace>:<name>\"."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["string", "boolean", "integer", "decimal", "date", "datetime"],
+          "description": "Enforced by scripts/okf_validate.py's check (8) against this property's actual metadata value, when the relationship's metadata carries it."
+        },
+        "enum": {
+          "type": "array",
+          "description": "Allowed values, when `type` is \"string\". Enforced by check (8) the same way `type` is.",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "range": {
+          "type": "array",
+          "description": "[min, max] inclusive bounds, when `type` is \"integer\" or \"decimal\". Enforced by check (8) the same way `type` is.",
+          "items": { "type": "number" },
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -54,3 +54,27 @@ pyyaml==6.0.2 \
     --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
+
+# jsonschema: okf_validate.py validates .mif/config.yaml against
+# schema/relationship-types-config.schema.json via jsonschema.Draft202012Validator
+# (#232) rather than a hand-rolled duplicate of the schema's own constraints.
+# Hashes pinned for the CI job's env (ubuntu-latest, cp312, manylinux_2_17+
+# x86_64), same method as requirements-jsonld-ci.txt's lxml pin: confirmed via
+# `docker run --rm --platform linux/amd64 python:3.12-slim pip download`.
+attrs==26.1.0 \
+    --hash=sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
+jsonschema-specifications==2025.9.1 \
+    --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe
+referencing==0.37.0 \
+    --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231
+rpds-py==2026.6.3 \
+    --hash=sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+jsonschema==4.25.1 \
+    --hash=sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63
+# rfc3987: jsonschema's "uri" FormatChecker is a silent no-op without it --
+# needed so relationship-types-config.schema.json's namespaces.*.format:uri
+# constraint is actually enforced, not just declared.
+rfc3987==1.3.8 \
+    --hash=sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53

--- a/schema/relationship-types-config.schema.json
+++ b/schema/relationship-types-config.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mif-spec.dev/schema/relationship-types-config.schema.json",
+  "title": "MIF Relationship Types Configuration",
+  "description": "JSON Schema for a bundle's .mif/config.yaml relationship_types registry (SPECIFICATION.md 8.1). Declares the relationship types a bundle recognizes -- the nine core types (no namespace) for documentation/opt-in-recognition, and domain-specific custom types (with a namespace) that relationships[].type values in this bundle are validated against.",
+  "type": "object",
+  "properties": {
+    "relationship_types": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/RelationshipTypeDeclaration" }
+    },
+    "namespaces": {
+      "type": "object",
+      "description": "Maps each custom namespace prefix used by this bundle's relationship_types (or any other namespaced token) to the IRI it expands to -- the same mapping SPECIFICATION.md 8.3's JSON-LD representation example shows added as a second @context array entry (e.g. {\"farm\": \"https://example.org/farm/\"}). scripts/mif_convert.py merges this into every JSON-LD projection emitted for the bundle, so a declared namespace prefix actually resolves to a real IRI on expansion instead of staying an opaque, unexpanded compact-IRI-looking string.",
+      "propertyNames": { "pattern": "^[a-z][a-z0-9]*$" },
+      "additionalProperties": { "type": "string", "format": "uri" }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "RelationshipTypeDeclaration": {
+      "type": "object",
+      "description": "One declared relationship type. A `namespace` marks it as a custom type: its kebab-cased `name`, prefixed with `namespace:`, is the value used in relationships[].type (e.g. name: BreedsWith, namespace: farm -> \"farm:breeds-with\"). No `namespace` means it documents one of the nine core types (SPECIFICATION.md 8.2); the core types' registration is fixed regardless of what's declared here.",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Z][a-zA-Z0-9]*$",
+          "description": "PascalCase display name and IRI local name (e.g. \"BreedsWith\"). The kebab-cased form (\"breeds-with\") is the actual relationships[].type token."
+        },
+        "namespace": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*$",
+          "description": "Lowercase prefix identifying a custom (non-core) type, e.g. \"farm\". Should have a matching entry in this file's top-level `namespaces` map (its IRI) so the type actually resolves on JSON-LD expansion, not just validates as declared."
+        },
+        "description": {
+          "type": "string"
+        },
+        "inverse": {
+          "type": "string",
+          "description": "PascalCase name of this type's inverse relationship (e.g. \"Derives\" for \"DerivedFrom\"), if directional and not self-symmetric. Declaration only: scripts/okf_validate.py does not check that a reciprocal edge of this type actually exists anywhere in the bundle."
+        },
+        "symmetric": {
+          "type": "boolean",
+          "default": false,
+          "description": "True when the relationship reads the same in both directions (e.g. RelatesTo, ConflictsWith). Declaration only: scripts/okf_validate.py does not check that a matching reverse-direction edge actually exists anywhere in the bundle."
+        },
+        "icon": {
+          "type": "string",
+          "description": "A single display emoji, for tooling/docs."
+        },
+        "properties": {
+          "type": "array",
+          "description": "Structured metadata fields this relationship type carries. These are NOT new keys on the Relationship object itself (which is closed, additionalProperties:false) -- they're carried as namespaced keys inside the relationship's own metadata object (e.g. {\"farm:breeding_date\": \"2025-10-15\"}), per SPECIFICATION.md 8.3's JSON-LD representation example.",
+          "items": { "$ref": "#/$defs/RelationshipTypePropertyDeclaration" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "RelationshipTypePropertyDeclaration": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Property name; carried in metadata as \"<namespace>:<name>\"."
+        },
+        "type": {
+          "type": "string",
+          "enum": ["string", "boolean", "integer", "decimal", "date", "datetime"],
+          "description": "Enforced by scripts/okf_validate.py's check (8) against this property's actual metadata value, when the relationship's metadata carries it."
+        },
+        "enum": {
+          "type": "array",
+          "description": "Allowed values, when `type` is \"string\". Enforced by check (8) the same way `type` is.",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "range": {
+          "type": "array",
+          "description": "[min, max] inclusive bounds, when `type` is \"integer\" or \"decimal\". Enforced by check (8) the same way `type` is.",
+          "items": { "type": "number" },
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/mif_convert.py
+++ b/scripts/mif_convert.py
@@ -42,6 +42,23 @@ CONTEXT_URL = "https://mif-spec.dev/schema/context.jsonld"
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)$", re.DOTALL)
 RESERVED_FILENAMES = {"index.md", "log.md"}
 
+
+def bundle_namespaces(bundle: Path) -> dict[str, str]:
+    """Read bundle/.mif/config.yaml's `namespaces` map, if present (schema/
+    relationship-types-config.schema.json). Best-effort: an absent or
+    malformed file yields {} -- okf_validate.py is the enforcement point for
+    config.yaml's correctness; this just needs a mapping to merge into
+    @context, or nothing to merge if there isn't one."""
+    config_path = bundle / ".mif" / "config.yaml"
+    try:
+        config = yaml.safe_load(config_path.read_text())
+    except (OSError, yaml.YAMLError):
+        return {}
+    if not isinstance(config, dict):
+        return {}
+    namespaces = config.get("namespaces", {})
+    return namespaces if isinstance(namespaces, dict) else {}
+
 # Canonical frontmatter key order for deterministic, lossless serialization.
 FRONTMATTER_ORDER = [
     "id",
@@ -115,11 +132,18 @@ def serialize_markdown(frontmatter: dict, body: str) -> str:
     return f"---\n{yaml_text}\n---\n\n{body}"
 
 
-def md_to_jsonld(frontmatter: dict, body: str) -> dict:
-    """Project frontmatter + body into a derived JSON-LD document."""
+def md_to_jsonld(frontmatter: dict, body: str, namespaces: dict[str, str] | None = None) -> dict:
+    """Project frontmatter + body into a derived JSON-LD document.
+
+    `namespaces` (a bundle's .mif/config.yaml `namespaces` map, see
+    bundle_namespaces()) is merged into @context as a second array entry,
+    matching SPECIFICATION.md 8.3's own JSON-LD representation example --
+    without this, a custom relationship type's "farm:breeds-with" stays an
+    unexpanded compact-IRI-looking string on JSON-LD expansion rather than
+    resolving to a real IRI, silently."""
     fm = stringify_datetimes(frontmatter)
     jsonld: dict[str, Any] = {
-        "@context": CONTEXT_URL,
+        "@context": [CONTEXT_URL, namespaces] if namespaces else CONTEXT_URL,
         "@type": "Concept",
     }
     if "id" in fm:
@@ -208,7 +232,12 @@ def normalize(md_text: str) -> str:
 
 
 def roundtrip_file(md_path: Path) -> str | None:
-    """Return an error string if md -> jsonld -> md is not lossless, else None."""
+    """Return an error string if md -> jsonld -> md is not lossless, else None.
+
+    No ``namespaces`` parameter: jsonld_to_md() never reads ``@context`` (it
+    only consumes @id/conceptType/the fixed passthrough key list), so a
+    bundle's namespace map cannot affect this check's outcome either way.
+    """
     original = md_path.read_text()
     frontmatter, body = parse_markdown(original)
     jsonld = md_to_jsonld(frontmatter, body)
@@ -249,9 +278,10 @@ def cmd_roundtrip(bundles: list[Path]) -> int:
     return 0
 
 
-def cmd_to_jsonld(src: Path, out: Path | None) -> int:
+def cmd_to_jsonld(src: Path, out: Path | None, bundle: Path | None = None) -> int:
     frontmatter, body = parse_markdown(src.read_text())
-    jsonld = md_to_jsonld(frontmatter, body)
+    namespaces = bundle_namespaces(bundle) if bundle else None
+    jsonld = md_to_jsonld(frontmatter, body, namespaces)
     text = json.dumps(jsonld, indent=2, ensure_ascii=False)
     if out:
         out.write_text(text + "\n")
@@ -276,9 +306,10 @@ def cmd_to_markdown(src: Path, out: Path | None) -> int:
 def cmd_emit_jsonld(bundles: list[Path], out_dir: Path) -> int:
     count = 0
     for bundle in bundles:
+        namespaces = bundle_namespaces(bundle)
         for md_path in iter_concepts(bundle):
             frontmatter, body = parse_markdown(md_path.read_text())
-            jsonld = md_to_jsonld(frontmatter, body)
+            jsonld = md_to_jsonld(frontmatter, body, namespaces)
             rel = md_path.relative_to(bundle).with_suffix(".jsonld")
             dest = out_dir / bundle.name / rel
             dest.parent.mkdir(parents=True, exist_ok=True)
@@ -295,6 +326,12 @@ def main() -> None:
     p_j = sub.add_parser("to-jsonld", help="Convert one .md concept to JSON-LD")
     p_j.add_argument("input")
     p_j.add_argument("output", nargs="?")
+    p_j.add_argument(
+        "--bundle",
+        help="Bundle root to resolve .mif/config.yaml's custom namespaces from "
+        "(optional; omit to convert with no namespace resolution, matching "
+        "today's behavior).",
+    )
 
     p_m = sub.add_parser("to-markdown", help="Convert one .jsonld back to markdown")
     p_m.add_argument("input")
@@ -310,7 +347,11 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command == "to-jsonld":
-        sys.exit(cmd_to_jsonld(Path(args.input), Path(args.output) if args.output else None))
+        sys.exit(cmd_to_jsonld(
+            Path(args.input),
+            Path(args.output) if args.output else None,
+            Path(args.bundle) if args.bundle else None,
+        ))
     if args.command == "to-markdown":
         sys.exit(cmd_to_markdown(Path(args.input), Path(args.output) if args.output else None))
     if args.command == "roundtrip":

--- a/scripts/okf_validate.py
+++ b/scripts/okf_validate.py
@@ -18,6 +18,20 @@ concept the validator enforces:
    / ``cites`` target must not be ``created`` after the concept that derives from
    it. Reported as a warning by default (non-blocking); ``--strict-temporal``
    promotes it to a hard error so a known-clean corpus can enforce it in CI.
+7. every namespaced (custom) relationship type used in the bundle is declared
+   in ``.mif/config.yaml``'s ``relationship_types`` (SPECIFICATION.md 8.1/8.3),
+   once a bundle has that file -- opt-in: bundles without ``.mif/config.yaml``
+   keep the fully-lenient behavior of (5)/(6) unchanged. Bare/core types (no
+   ``namespace:`` prefix) are never gated by this check.
+8. a declared custom type's relationship metadata values conform to that
+   type's declared ``properties[]`` (type/enum/range), when present -- e.g. a
+   property declared ``range: [0.0, 1.0]`` rejects a metadata value of ``5.0``.
+   A declared property absent from a given relationship's metadata is not an
+   error (properties are optional-when-present, not required). ``inverse`` and
+   ``symmetric`` are declaration-only and not enforced by this validator (they
+   describe a cross-relationship graph shape, not a single relationship's own
+   values); a relationship whose type declares them is never checked for a
+   matching reciprocal edge.
 
 Exit code 0 means every concept in every bundle conforms.
 
@@ -29,11 +43,13 @@ Usage::
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import jsonschema
 import yaml  # PyYAML; parse_markdown's safe_load can raise yaml.YAMLError
 
 import mif_convert  # local module (same scripts/ directory)
@@ -46,14 +62,24 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DERIVATION_TYPES = {"derived-from", "supersedes", "cites"}
 
 # A body relationship line: "- <kebab-type> [Text](/path/to/target.md)".
-REL_LINE_RE = re.compile(r"^-\s+([a-z0-9][a-z0-9-]*)\s+\[[^\]]+\]\(([^)]+)\)\s*$")
+# <kebab-type> allows an optional "namespace:" prefix (schema/mif.schema.json's
+# Relationship.type pattern), so a custom relationship type's hand-written body
+# mirror (e.g. "farm:breeds-with") is recognized -- without this, item (3)'s
+# sync check could never match any custom-typed relationship's body link,
+# since it would never be extracted here in the first place.
+REL_LINE_RE = re.compile(r"^-\s+([a-z0-9][a-z0-9-]*(?::[a-z0-9][a-z0-9-]*)?)\s+\[[^\]]+\]\(([^)]+)\)\s*$")
 # Any markdown link, for broken-link scanning.
 MD_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 
 
 def _kebab(value: str) -> str:
-    """Normalize a relationship type token to kebab-case for comparison."""
-    value = re.sub(r"(?<!^)(?=[A-Z])", "-", value)
+    """Normalize a relationship type token to kebab-case for comparison.
+
+    A leading namespace prefix (``farm:BreedsWith``) must not grow a spurious
+    hyphen right after the colon -- ``(?<!:)`` treats ':' as a word boundary
+    the same way ``(?<!^)`` already treats the start of the string.
+    """
+    value = re.sub(r"(?<!^)(?<!:)(?=[A-Z])", "-", value)
     value = re.sub(r"[\s_]+", "-", value)
     return value.lower()
 
@@ -86,6 +112,145 @@ def _frontmatter_relationships(frontmatter: dict) -> list[tuple[str, str]]:
             target = target.get("path") or target.get("@id", "")
         pairs.append((_kebab(str(rel_type)), str(target)))
     return pairs
+
+
+RELATIONSHIP_TYPES_CONFIG_SCHEMA = json.loads(
+    (REPO_ROOT / "schema" / "relationship-types-config.schema.json").read_text()
+)
+
+
+def _validate_relationship_types_config_shape(config) -> list[str]:
+    """Structural validation of a parsed .mif/config.yaml, delegated to
+    schema/relationship-types-config.schema.json itself via jsonschema
+    (the same pattern scripts/test_temporal_and_properties.py already uses
+    against schema/mif.schema.json) rather than a hand-rolled duplicate of
+    the schema's own constraints -- a hand-rolled version drifts silently
+    (an earlier version of this function reproduced the 'name'/'namespace'
+    patterns and the properties[].type enum by hand, but never enforced
+    additionalProperties:false or the properties[].enum/range constraints,
+    since nothing forced the two to stay in sync). A FormatChecker is required
+    explicitly -- without it (and without the rfc3987 package it depends on
+    for "uri") jsonschema's "format" keyword is a silent no-op, so
+    namespaces.*'s format:uri constraint would never actually reject a
+    malformed IRI."""
+    validator = jsonschema.Draft202012Validator(
+        RELATIONSHIP_TYPES_CONFIG_SCHEMA, format_checker=jsonschema.FormatChecker()
+    )
+    errors = []
+    for err in validator.iter_errors(config):
+        path = "".join(f"[{p!r}]" if isinstance(p, int) else f".{p}" for p in err.absolute_path)
+        errors.append(f"config.yaml{path}: {err.message}")
+    return errors
+
+
+def _load_relationship_types_config(bundle: Path) -> tuple[dict | None, list[str]]:
+    """Load bundle/.mif/config.yaml if present. Returns (config, errors);
+    config is None when no such file exists (today's lenient behavior is
+    unchanged for bundles that haven't opted in)."""
+    config_path = bundle / ".mif" / "config.yaml"
+    try:
+        text = config_path.read_text()
+    except FileNotFoundError:
+        return None, []
+    except OSError as exc:
+        return None, [f"{config_path}: could not be read: {exc}"]
+    try:
+        config = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return None, [f"{config_path}: invalid YAML: {exc}"]
+    shape_errors = _validate_relationship_types_config_shape(config)
+    if shape_errors:
+        return None, shape_errors
+    return config, []
+
+
+def _custom_relationship_type_registry(config: dict) -> tuple[dict[str, dict], list[str]]:
+    """Map 'namespace:kebab-name' -> declaration, for every namespaced
+    (custom) entry in a validated relationship_types config. Returns
+    (registry, errors); a repeated namespace+name pair is a config error
+    (last-declaration-wins would otherwise silently discard the earlier one
+    with no diagnostic)."""
+    registry: dict[str, dict] = {}
+    errors: list[str] = []
+    for entry in config.get("relationship_types", []):
+        namespace = entry.get("namespace")
+        if not namespace:
+            continue
+        key = f"{namespace}:{_kebab(entry['name'])}"
+        if key in registry:
+            errors.append(
+                f"config.yaml relationship_types: '{namespace}' + '{entry['name']}' "
+                f"is declared more than once (resolves to '{key}')"
+            )
+        registry[key] = entry
+    return registry, errors
+
+
+def _check_property_type(value: object, expected_type: str) -> tuple[bool, str]:
+    """True (and empty message) when value's runtime type/format matches a
+    RelationshipTypePropertyDeclaration's `type` (schema/
+    relationship-types-config.schema.json). ``bool`` is deliberately excluded
+    from integer/decimal -- Python's bool is an int subclass, and a
+    declaration of `type: integer` should reject a stray `true`/`false`."""
+    if expected_type == "string":
+        ok = isinstance(value, str)
+    elif expected_type == "boolean":
+        ok = isinstance(value, bool)
+    elif expected_type == "integer":
+        ok = isinstance(value, int) and not isinstance(value, bool)
+    elif expected_type == "decimal":
+        ok = isinstance(value, (int, float)) and not isinstance(value, bool)
+    elif expected_type == "date":
+        ok = isinstance(value, str) and _is_date_only(value) and _parse_created(value) is not None
+    elif expected_type == "datetime":
+        ok = isinstance(value, str) and not _is_date_only(value) and _parse_created(value) is not None
+    else:  # unreachable given the schema's own enum on `type`; never crash.
+        ok = True
+    return (True, "") if ok else (False, f"expected type '{expected_type}', got {value!r}")
+
+
+def _relationship_metadata_errors(entry: dict, metadata: object) -> list[str]:
+    """Check a relationship's metadata values against its declared custom
+    type's `properties[]` (type/enum/range) -- SPECIFICATION.md 8.1/8.3's own
+    worked example (`range: [0.0, 1.0]`, `enum: [direct, indirect, partial]`)
+    presents these as real constraints, not just declaration shape. A
+    declared property absent from this relationship's metadata is not
+    flagged here -- properties are not required-if-declared, only checked
+    when present."""
+    if not isinstance(metadata, dict):
+        return []
+    namespace = entry.get("namespace")
+    errors: list[str] = []
+    for prop in entry.get("properties", []) or []:
+        key = f"{namespace}:{prop.get('name')}"
+        if key not in metadata:
+            continue
+        value = metadata[key]
+        expected_type = prop.get("type")
+        type_ok, type_msg = _check_property_type(value, expected_type)
+        if not type_ok:
+            errors.append(f"metadata['{key}']: {type_msg}")
+            continue  # enum/range against a wrong-typed value would be noise
+
+        # `enum` only applies to `type: string`, `range` only to `type:
+        # integer`/`decimal` (schema's own field descriptions) -- a
+        # misdeclared config (e.g. `range` on a `type: string` property) must
+        # never reach `lo <= value <= hi` with a non-numeric value and crash.
+        enum_values = prop.get("enum")
+        if expected_type == "string" and enum_values is not None and value not in enum_values:
+            errors.append(
+                f"metadata['{key}']: {value!r} is not one of the declared "
+                f"enum values {enum_values}"
+            )
+        range_bounds = prop.get("range")
+        if expected_type in ("integer", "decimal") and range_bounds is not None:
+            lo, hi = range_bounds
+            if not (lo <= value <= hi):
+                errors.append(
+                    f"metadata['{key}']: {value!r} is outside the declared "
+                    f"range [{lo}, {hi}]"
+                )
+    return errors
 
 
 def _resolve(target: str, md_path: Path, bundle: Path) -> Path | None:
@@ -183,6 +348,17 @@ def validate_bundle(
     warnings: list[str] = []
     count = 0
 
+    # (7) opt-in custom relationship type registry (SPECIFICATION.md 8.1/8.3).
+    # A bundle with no .mif/config.yaml keeps today's fully-lenient behavior --
+    # this only activates once a bundle opts in by creating the file.
+    rel_types_config, config_errors = _load_relationship_types_config(bundle)
+    errors.extend(config_errors)
+    if rel_types_config:
+        custom_type_registry, registry_errors = _custom_relationship_type_registry(rel_types_config)
+        errors.extend(registry_errors)
+    else:
+        custom_type_registry = {}
+
     for md_path in mif_convert.iter_concepts(bundle):
         count += 1
         try:
@@ -211,6 +387,29 @@ def validate_bundle(
             if missing_fm:
                 detail.append(f"no frontmatter entry for {missing_fm}")
             errors.append(f"{rel_name}: relationships out of sync ({'; '.join(detail)})")
+
+        # (7) every namespaced (custom) relationship type must be declared in
+        # .mif/config.yaml, once the bundle has one. Bare/core types (no ":")
+        # are unaffected -- always allowed, matching today's behavior.
+        # (8) once a type IS declared, its relationship's metadata values are
+        # checked against that type's declared properties[] (type/enum/range).
+        if rel_types_config is not None:
+            for rel in frontmatter.get("relationships", []) or []:
+                if not isinstance(rel, dict):
+                    continue
+                rel_type = _kebab(str(rel.get("type") or rel.get("relationshipType") or ""))
+                if ":" not in rel_type:
+                    continue
+                entry = custom_type_registry.get(rel_type)
+                if entry is None:
+                    errors.append(
+                        f"{rel_name}: relationship type '{rel_type}' is not declared in "
+                        f".mif/config.yaml's relationship_types (bundle has opted in to "
+                        f"custom-type validation by defining that file)"
+                    )
+                    continue
+                for prop_err in _relationship_metadata_errors(entry, rel.get("metadata")):
+                    errors.append(f"{rel_name}: relationship '{rel_type}' {prop_err}")
 
         # (4) broken links -> warnings only.
         for match in MD_LINK_RE.finditer(body):

--- a/scripts/test_relationship_types_config.py
+++ b/scripts/test_relationship_types_config.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Test the .mif/config.yaml relationship_types registry (SPECIFICATION.md
+8.1/8.3), implemented in okf_validate.py.
+
+Regression coverage for #232: SPECIFICATION.md documented a structured
+custom-relationship-type registry with no corresponding implementation
+anywhere in this repo. Covers:
+
+- a bundle with .mif/config.yaml declaring a custom type, used correctly ->
+  passes;
+- the same, but the document uses an undeclared custom type -> a clear error
+  naming the undeclared type, not a crash;
+- a bundle with NO .mif/config.yaml, using an arbitrary namespaced type ->
+  stays lenient (today's pre-#232 behavior, unchanged -- this feature is
+  opt-in, not a retroactive tightening);
+- a malformed .mif/config.yaml (wrong casing on name/namespace) -> a clear
+  structural error, not a crash, and concepts in that bundle aren't
+  processed against a registry that failed to load;
+- a declared type's relationship metadata values are checked against that
+  type's declared properties[] (type/enum/range), not just checked for
+  existence -- an in-range/in-enum value passes, an out-of-range/not-in-enum
+  value produces a clear error naming the property and value.
+
+Also exercises the body-markdown-link regex fix this feature required:
+REL_LINE_RE previously had no way to match a namespaced type token at all
+(no ":" in its character class), so ANY concept using a custom relationship
+type would unconditionally fail the pre-existing frontmatter<->body sync
+check (3), regardless of whether the type was declared. The `declared` and
+`no_config` fixtures both include a body "## Relationships" mirror line for
+their namespaced relationship, so a regression in that regex shows up here
+as a spurious "relationships out of sync" error.
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import okf_validate  # noqa: E402  (local module, path set above)
+
+FIXTURES = ROOT / "test" / "relationship_types"
+
+
+def check_declared_custom_type_passes() -> list[str]:
+    errors, _warnings, count = okf_validate.validate_bundle(FIXTURES / "declared")
+    problems = []
+    if count != 2:
+        problems.append(f"expected 2 concepts, got {count}")
+    if errors:
+        problems.append(f"expected no errors, got: {errors}")
+    return problems
+
+
+def check_undeclared_custom_type_fails_clearly() -> list[str]:
+    errors, _warnings, count = okf_validate.validate_bundle(FIXTURES / "undeclared")
+    problems = []
+    if count != 1:
+        problems.append(f"expected 1 concept, got {count}")
+    matching = [e for e in errors if "farm:undeclared-type" in e and "not declared" in e]
+    if len(matching) != 1:
+        problems.append(f"expected exactly 1 clear 'not declared' error, got: {errors}")
+    return problems
+
+
+def check_no_config_stays_lenient() -> list[str]:
+    errors, _warnings, count = okf_validate.validate_bundle(FIXTURES / "no_config")
+    problems = []
+    if count != 1:
+        problems.append(f"expected 1 concept, got {count}")
+    if errors:
+        problems.append(f"bundle with no .mif/config.yaml must stay lenient, got errors: {errors}")
+    return problems
+
+
+def check_malformed_config_reports_structural_errors() -> list[str]:
+    errors, _warnings, count = okf_validate.validate_bundle(FIXTURES / "malformed_config")
+    problems = []
+    if count != 1:
+        problems.append(f"expected 1 concept, got {count}")
+    if not any(".name:" in e and "lowercase-invalid" in e for e in errors):
+        problems.append(f"expected a 'name' pattern error naming the bad value, got: {errors}")
+    if not any(".namespace:" in e and "FARM" in e for e in errors):
+        problems.append(f"expected a 'namespace' pattern error naming the bad value, got: {errors}")
+    # The fixture's one concept uses a namespaced type (farm:whatever) that
+    # isn't declared anywhere -- if check (7) ran against a registry built
+    # from an invalid config, it would (wrongly) flag this too. It must not:
+    # a config that fails to load disables check (7) entirely for the bundle.
+    if any("not declared" in e for e in errors):
+        problems.append(f"check (7) must not run against an invalid config, got: {errors}")
+    return problems
+
+
+def check_kebab_case_mapping_matches_spec_example() -> list[str]:
+    """SPECIFICATION.md 8.1's own example: name: BreedsWith, namespace: farm
+    -> relationships[].type value "farm:breeds-with"."""
+    config = {"relationship_types": [{"name": "BreedsWith", "namespace": "farm"}]}
+    registry, errors = okf_validate._custom_relationship_type_registry(config)
+    if "farm:breeds-with" not in registry:
+        return [f"expected 'farm:breeds-with' in registry, got keys: {list(registry.keys())}"]
+    if errors:
+        return [f"expected no errors for a single declaration, got: {errors}"]
+    return []
+
+
+def check_duplicate_declaration_reports_an_error() -> list[str]:
+    """A namespace+name declared twice must not silently let the second
+    entry overwrite the first with no diagnostic."""
+    config = {
+        "relationship_types": [
+            {"name": "BreedsWith", "namespace": "farm", "symmetric": False},
+            {"name": "BreedsWith", "namespace": "farm", "symmetric": True},
+        ]
+    }
+    registry, errors = okf_validate._custom_relationship_type_registry(config)
+    if "farm:breeds-with" not in registry:
+        return [f"expected 'farm:breeds-with' still in registry, got keys: {list(registry.keys())}"]
+    if not any("more than once" in e for e in errors):
+        return [f"expected a duplicate-declaration error, got: {errors}"]
+    return []
+
+
+def check_namespaced_kebab_survives_colon() -> list[str]:
+    """_kebab('farm:BreedsWith') must not grow a spurious hyphen right after
+    the colon -- a namespace prefix is a word boundary, same as the start of
+    the string."""
+    result = okf_validate._kebab("farm:BreedsWith")
+    if result != "farm:breeds-with":
+        return [f"expected 'farm:breeds-with', got {result!r}"]
+    return []
+
+
+def check_property_value_constraints_enforced_end_to_end() -> list[str]:
+    """SPECIFICATION.md 8.3's own worked example (enum: [direct, indirect,
+    partial], range: [0.0, 1.0]) via the full validate_bundle() pipeline: an
+    in-range/in-enum relationship passes, an out-of-range/not-in-enum one
+    produces a clear per-property error."""
+    errors, _warnings, count = okf_validate.validate_bundle(FIXTURES / "property_values")
+    problems = []
+    if count != 2:
+        problems.append(f"expected 2 concepts, got {count}")
+    # "invalid.md" contains "valid.md" as a substring -- match on the leading
+    # path segment so the two fixtures' errors aren't cross-counted.
+    valid_errors = [e for e in errors if e.startswith("test/relationship_types/property_values/valid.md")]
+    if valid_errors:
+        problems.append(f"expected no errors for valid.md, got: {valid_errors}")
+    invalid_errors = [e for e in errors if e.startswith("test/relationship_types/property_values/invalid.md")]
+    if not any("not one of the declared enum values" in e for e in invalid_errors):
+        problems.append(f"expected an enum violation for invalid.md, got: {invalid_errors}")
+    if not any("outside the declared range" in e for e in invalid_errors):
+        problems.append(f"expected a range violation for invalid.md, got: {invalid_errors}")
+    return problems
+
+
+def check_property_type_mismatch_detected() -> list[str]:
+    entry = {"namespace": "farm", "properties": [{"name": "success", "type": "boolean"}]}
+    errs = okf_validate._relationship_metadata_errors(entry, {"farm:success": "yes"})
+    if not any("expected type 'boolean'" in e for e in errs):
+        return [f"expected a type-mismatch error, got: {errs}"]
+    return []
+
+
+def check_range_on_a_string_property_does_not_crash() -> list[str]:
+    """`range` only applies to type: integer/decimal (schema's own field
+    description); a misdeclared `range` on a type: string property must not
+    reach `lo <= value <= hi` with a non-numeric value and raise TypeError --
+    it must be silently ignored (the same as any other inapplicable
+    constraint), never a crash in a required CI gate."""
+    entry = {"namespace": "farm", "properties": [{"name": "label", "type": "string", "range": [0, 1]}]}
+    errs = okf_validate._relationship_metadata_errors(entry, {"farm:label": "hello"})
+    if errs:
+        return [f"expected no errors (range is inapplicable to type:string, not a crash), got: {errs}"]
+    return []
+
+
+def check_declared_property_absent_from_metadata_is_not_an_error() -> list[str]:
+    """A declared property is only checked when the relationship's metadata
+    actually carries it -- properties are optional-when-present, not
+    required-if-declared."""
+    entry = {
+        "namespace": "farm",
+        "properties": [{"name": "severity", "type": "decimal", "range": [0.0, 1.0]}],
+    }
+    errs = okf_validate._relationship_metadata_errors(entry, {})
+    if errs:
+        return [f"expected no errors when the property is simply absent, got: {errs}"]
+    return []
+
+
+CHECKS = [
+    ("declared custom relationship type passes (#232)", check_declared_custom_type_passes),
+    ("undeclared custom relationship type fails with a clear error (#232)", check_undeclared_custom_type_fails_clearly),
+    ("bundle with no .mif/config.yaml stays lenient (#232)", check_no_config_stays_lenient),
+    ("malformed .mif/config.yaml reports structural errors, not a crash (#232)", check_malformed_config_reports_structural_errors),
+    ("PascalCase name kebab-cases to match SPECIFICATION.md 8.1's own example", check_kebab_case_mapping_matches_spec_example),
+    ("duplicate namespace+name declaration reports an error, not a silent overwrite", check_duplicate_declaration_reports_an_error),
+    ("_kebab() doesn't grow a spurious hyphen after a namespace colon", check_namespaced_kebab_survives_colon),
+    ("declared property enum/range constraints enforced end-to-end (#232 follow-up)", check_property_value_constraints_enforced_end_to_end),
+    ("declared property type mismatch is detected", check_property_type_mismatch_detected),
+    ("a declared property absent from metadata is not an error", check_declared_property_absent_from_metadata_is_not_an_error),
+    ("range on a type:string property is ignored, not a crash", check_range_on_a_string_property_does_not_crash),
+]
+
+
+def main() -> int:
+    failed = []
+    for label, check in CHECKS:
+        problems = check()
+        if problems:
+            failed.append(label)
+            print(f"FAIL: {label}")
+            for p in problems:
+                print(f"  - {p}")
+        else:
+            print(f"PASS: {label}")
+    if failed:
+        print(f"\nrelationship_types config test FAILED: {failed}")
+        return 1
+    print("\nAll relationship_types config tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/relationship_types/declared/.mif/config.yaml
+++ b/test/relationship_types/declared/.mif/config.yaml
@@ -1,0 +1,7 @@
+relationship_types:
+  - name: BreedsWith
+    namespace: farm
+    description: Animal breeding relationship
+    properties:
+      - name: breeding_date
+        type: date

--- a/test/relationship_types/declared/ewe.md
+++ b/test/relationship_types/declared/ewe.md
@@ -1,0 +1,9 @@
+---
+id: 11111111-2222-3333-4444-555555555002
+type: semantic
+created: '2026-01-01T00:00:00Z'
+namespace: _semantic/livestock
+title: Ewe
+---
+
+Ewe.

--- a/test/relationship_types/declared/ram.md
+++ b/test/relationship_types/declared/ram.md
@@ -1,0 +1,16 @@
+---
+id: 11111111-2222-3333-4444-555555555001
+type: semantic
+created: '2026-01-01T00:00:00Z'
+namespace: _semantic/livestock
+title: Ram
+relationships:
+- type: farm:breeds-with
+  target: /ewe.md
+---
+
+Ram.
+
+## Relationships
+
+- farm:breeds-with [Ewe](/ewe.md)

--- a/test/relationship_types/malformed_config/.mif/config.yaml
+++ b/test/relationship_types/malformed_config/.mif/config.yaml
@@ -1,0 +1,3 @@
+relationship_types:
+  - name: lowercase-invalid
+    namespace: FARM

--- a/test/relationship_types/malformed_config/a.md
+++ b/test/relationship_types/malformed_config/a.md
@@ -1,0 +1,16 @@
+---
+id: 11111111-2222-3333-4444-555555555005
+type: semantic
+created: '2026-01-01T00:00:00Z'
+namespace: _semantic/test
+title: A
+relationships:
+- type: farm:whatever
+  target: /b.md
+---
+
+A.
+
+## Relationships
+
+- farm:whatever [B](/b.md)

--- a/test/relationship_types/no_config/a.md
+++ b/test/relationship_types/no_config/a.md
@@ -1,0 +1,16 @@
+---
+id: 33333333-4444-5555-6666-777777777001
+type: semantic
+created: '2026-01-01T00:00:00Z'
+namespace: _semantic/livestock
+title: A
+relationships:
+- type: farm:anything-goes
+  target: /b.md
+---
+
+A.
+
+## Relationships
+
+- farm:anything-goes [B](/b.md)

--- a/test/relationship_types/property_values/.mif/config.yaml
+++ b/test/relationship_types/property_values/.mif/config.yaml
@@ -1,0 +1,11 @@
+relationship_types:
+  - name: Contradicts
+    namespace: farm
+    description: Provides conflicting evidence
+    properties:
+      - name: contradiction_type
+        type: string
+        enum: [direct, indirect, partial]
+      - name: severity
+        type: decimal
+        range: [0.0, 1.0]

--- a/test/relationship_types/property_values/invalid.md
+++ b/test/relationship_types/property_values/invalid.md
@@ -1,0 +1,19 @@
+---
+id: 11111111-2222-3333-4444-555555555011
+type: semantic
+created: '2026-01-01T00:00:00Z'
+namespace: _semantic/test
+title: Invalid
+relationships:
+- type: farm:contradicts
+  target: /other.md
+  metadata:
+    farm:contradiction_type: bogus
+    farm:severity: 5.0
+---
+
+Invalid.
+
+## Relationships
+
+- farm:contradicts [Other](/other.md)

--- a/test/relationship_types/property_values/valid.md
+++ b/test/relationship_types/property_values/valid.md
@@ -1,0 +1,19 @@
+---
+id: 11111111-2222-3333-4444-555555555010
+type: semantic
+created: '2026-01-01T00:00:00Z'
+namespace: _semantic/test
+title: Valid
+relationships:
+- type: farm:contradicts
+  target: /other.md
+  metadata:
+    farm:contradiction_type: direct
+    farm:severity: 0.5
+---
+
+Valid.
+
+## Relationships
+
+- farm:contradicts [Other](/other.md)

--- a/test/relationship_types/undeclared/.mif/config.yaml
+++ b/test/relationship_types/undeclared/.mif/config.yaml
@@ -1,0 +1,3 @@
+relationship_types:
+  - name: BreedsWith
+    namespace: farm

--- a/test/relationship_types/undeclared/a.md
+++ b/test/relationship_types/undeclared/a.md
@@ -1,0 +1,16 @@
+---
+id: 22222222-3333-4444-5555-666666666001
+type: semantic
+created: '2026-01-01T00:00:00Z'
+namespace: _semantic/livestock
+title: A
+relationships:
+- type: farm:undeclared-type
+  target: /b.md
+---
+
+A.
+
+## Relationships
+
+- farm:undeclared-type [B](/b.md)


### PR DESCRIPTION
## Summary

SPECIFICATION.md §8.1/§8.3 documented a bundle-level `.mif/config.yaml` `relationship_types` registry for declaring domain-specific custom relationship types — with no corresponding implementation anywhere in the codebase (#232). This implements it:

- **Registry + opt-in validation**: once a bundle has `.mif/config.yaml`, every namespaced (custom) relationship type used in it must be declared there (check 7). Bundles without the file keep today's fully lenient behavior unchanged.
- **Value-level enforcement** (check 8): a declared type's relationship metadata values are checked against that type's declared `properties[]` (`type`/`enum`/`range`) — e.g. a property declared `range: [0.0, 1.0]` rejects a metadata value of `5.0`. `inverse`/`symmetric` remain declaration-only (they describe a cross-relationship graph shape, not a single relationship's values) — the schema now says so explicitly.
- **Real namespace resolution**: a bundle's `.mif/config.yaml` can now declare a `namespaces` map (prefix → IRI), merged into every JSON-LD projection's `@context`. Verified end-to-end with real `pyld` expansion against the actual `emit-jsonld` pipeline output (no manual context injection): `farm:breeds-with` resolves to `https://example.org/farm/breeds-with`. Relationship *metadata* keys (`farm:breeding_date`, `farm:success`) are carried as opaque `@type:@json` and do not themselves expand — pre-existing design, unchanged here.
- A real example fixture (`docs/examples/memories/agriculture/`) using the spec's own `farm:breeds-with` example.

## Also fixed (found while building the fixture or during review)

- `REL_LINE_RE` had no way to match a namespaced type token at all, so any concept using a custom relationship type would unconditionally fail the pre-existing frontmatter↔body sync check — the whole feature was unusable without this.
- `_kebab()` grew a spurious hyphen right after a namespace colon (`farm:BreedsWith` → `farm:-breeds-with`).
- `_load_relationship_types_config` only caught `FileNotFoundError`; broadened to `(OSError, yaml.YAMLError)`.
- Duplicate `namespace`+`name` declarations now report a config error instead of silently overwriting.
- `roundtrip_file()`'s `namespaces` param was dead weight (`jsonld_to_md()` never reads `@context`) — removed.
- `docs/okf-conformance.md` was missing checks 6/7/8 from its own enumerated list.
- `schema/relationship-types-config.schema.json` is now mirrored to `public/schema/` (its `$id` is otherwise unresolvable once deployed), with a CI drift-guard.
- `jsonschema`'s `FormatChecker` is now wired in with `rfc3987`, so the schema's `format:uri` constraint is actually enforced instead of a silent no-op.

## Verification

- Full local test suite + faithful `docker run --platform linux/amd64 python:3.12-slim` container with real `--require-hashes` installs (caught a missing `jsonschema` CI dependency before it would have hit real CI).
- Real `pyld` JSON-LD expansion against the actual `mif_convert.py emit-jsonld` output.
- 8-angle local code review (2 rounds — the second scoped to the delta after the first round's fixes) — every confirmed finding fixed, including a `TypeError` crash in the new value-level enforcement (`range` on a `type: string` property) caught before merge.

## Not done here

- Bare/core-type (no `namespace:` prefix) typo protection against the 9 documented core types, and `inverse`/`symmetric` cross-relationship graph-consistency checking — both are materially different, larger features (bundle-wide edge analysis) than this PR's scope; not silently deferred, just genuinely out of scope for a type-registry PR.
- Filed #235 (separate, not touched here): `scripts/test_temporal_and_properties.py` is never actually run in CI. This PR's own tests are written in the standalone-script style specifically so they don't depend on that gap being closed first; `jsonschema` is now hash-pinned as a byproduct of this PR, but `pytest` and a CI step are still missing.

Closes #232
