### PR TITLE
fix: wire pytest CI gate + relationship-type vocab coverage check (#233, #235)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,8 +62,14 @@ jobs:
       - name: Vocab term coverage (every @type:@vocab enum value is registered)
         run: python scripts/check_vocab_term_coverage.py
 
+      - name: Relationship-type vocab coverage (context.jsonld terms are registered in vocabulary.jsonld)
+        run: python scripts/check_relationship_type_vocab_coverage.py
+
       - name: Custom relationship_types registry (.mif/config.yaml)
         run: python scripts/test_relationship_types_config.py
+
+      - name: Temporal consistency + properties construct regression suite
+        run: python -m pytest scripts/test_temporal_and_properties.py -q
 
   schema-validation:
     name: Validate JSON-LD Projection Against Schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **[Tooling]**: `scripts/check_relationship_type_vocab_coverage.py` — cross-checks
+  `schema/context.jsonld`'s `relationships.type.@context` term mapping against
+  `public/ns/vocabulary.jsonld`'s registered `rdfs:Class` terms, guarding against
+  the #230 defect class (a relationship-type term declared in one file but never
+  wired to the other) recurring. Wired into the `okf-conformance` CI job. (#233)
+- **[Tooling]**: `scripts/test_temporal_and_properties.py` (temporal-consistency
+  and `properties`-construct regression suite) is now run in the `okf-conformance`
+  CI job via `pytest`; previously it only ran if a contributor had `pytest`
+  installed locally and remembered to invoke it by hand. (#235)
+
 ## [1.2.2] - 2026-07-04
 
 ### Fixed

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -78,3 +78,19 @@ jsonschema==4.25.1 \
 # constraint is actually enforced, not just declared.
 rfc3987==1.3.8 \
     --hash=sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53
+
+# pytest: runs scripts/test_temporal_and_properties.py (#235) as a real CI gate
+# instead of a script that only executes if a contributor happens to have it
+# installed locally. Pure-python wheels (py3-none-any), same pin method as
+# lxml/jsonschema above: `docker run --rm --platform linux/amd64
+# python:3.12-slim pip download pytest==<ver>`.
+iniconfig==2.3.0 \
+    --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
+pluggy==1.6.0 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+pygments==2.20.0 \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+pytest==9.1.1 \
+    --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c

--- a/scripts/check_relationship_type_vocab_coverage.py
+++ b/scripts/check_relationship_type_vocab_coverage.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Structural guard for the #230 bug class recurring: a `relationships[].type`
 core term declared in `schema/context.jsonld` but never actually registered
-in `public/ns/vocabulary.jsonld` (or vice versa), so it silently resolves to
-nothing a JSON-LD consumer can dereference.
+in `public/ns/vocabulary.jsonld`, so it silently resolves to nothing a
+JSON-LD consumer can dereference. One-directional by design -- see below.
 
 `check_vocab_term_coverage.py` (#231) proves every `@type:@vocab` property's
 schema `enum` has a matching registered JSON-LD term, by cross-referencing

--- a/scripts/check_relationship_type_vocab_coverage.py
+++ b/scripts/check_relationship_type_vocab_coverage.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Structural guard for the #230 bug class recurring: a `relationships[].type`
+core term declared in `schema/context.jsonld` but never actually registered
+in `public/ns/vocabulary.jsonld` (or vice versa), so it silently resolves to
+nothing a JSON-LD consumer can dereference.
+
+`check_vocab_term_coverage.py` (#231) proves every `@type:@vocab` property's
+schema `enum` has a matching registered JSON-LD term, by cross-referencing
+`context.jsonld` against `mif.schema.json`. `relationships[].type` has no
+schema `enum` -- only a free-form kebab-case `pattern`, since
+`.mif/config.yaml`'s `relationship_types` registry (#232) allows custom
+namespaced types by design -- so that script correctly and structurally
+SKIPs it (see its own docstring). This is a genuinely different check
+shape: not schema-enum-driven, but ontology-file-driven. It is deliberately
+a separate script rather than a branch inside that one, so the two checks
+don't have to share one `findings` schema built around an `enum` that only
+one of them actually has (see #233's discussion of the two options).
+
+This script cross-checks the OTHER source of truth for the same 9 core
+relationship types: it walks `context.jsonld`'s `relationships.type.@context`
+term-scoped mapping (the kebab-case-key -> `mif:PascalCase` pairs) and
+confirms every target IRI is actually declared as an `rdfs:Class` in
+`vocabulary.jsonld`'s `@graph`. A term present in one file but not the
+other is exactly the #230 defect shape (context.jsonld's top-level term
+block was declared but never wired to anything real).
+
+Deliberately one-directional: `vocabulary.jsonld` also declares `mif:*`
+classes for document types, concept types, etc. that have nothing to do
+with `relationships[].type`, so there's no reliable way to detect an
+"extra" relationship-type class sitting unmapped in the ontology without
+also tagging *why* a given `rdfs:Class` exists -- vocabulary.jsonld doesn't
+currently encode that. Catching a declared-but-unregistered term (the
+actual historical bug) doesn't need that; it's covered.
+
+Deliberately hardcoded to `relationships.type`, not a generalized
+ontology-coverage framework: today it's the only `@type:@vocab` property
+`check_vocab_term_coverage.py` SKIPs for lacking a schema enum. If a
+second such property shows up later, generalize both scripts' discovery
+then -- building that generality now, for one property, would be solving
+a problem that doesn't exist yet.
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+CONTEXT = json.loads((ROOT / "schema" / "context.jsonld").read_text())["@context"]
+VOCABULARY = json.loads((ROOT / "public" / "ns" / "vocabulary.jsonld").read_text())
+
+
+def _registered_class_ids() -> set[str]:
+    return {
+        entry["@id"]
+        for entry in VOCABULARY.get("@graph", [])
+        if entry.get("@type") == "rdfs:Class" and isinstance(entry.get("@id"), str)
+    }
+
+
+def _relationship_type_terms() -> dict[str, str]:
+    """The kebab-case-key -> `mif:PascalCase` mapping term-scoped onto
+    `relationships.type` in context.jsonld. Returns {} (not an error) if
+    the shape has changed -- main() reports that as its own failure."""
+    relationships = CONTEXT.get("relationships", {})
+    type_term = relationships.get("@context", {}).get("type", {})
+    return type_term.get("@context", {}) if isinstance(type_term, dict) else {}
+
+
+def main() -> int:
+    terms = _relationship_type_terms()
+    if not terms:
+        print(
+            "FAIL: schema/context.jsonld's relationships.type.@context term "
+            "mapping is missing or empty -- expected the 9 core relationship "
+            "types (relates-to, derived-from, ...) to be registered there."
+        )
+        return 1
+
+    registered = _registered_class_ids()
+    missing = sorted(
+        f"{kebab_key} -> {iri}" for kebab_key, iri in terms.items() if iri not in registered
+    )
+
+    if missing:
+        print(
+            f"FAIL: {len(missing)} of {len(terms)} relationship-type term(s) "
+            f"declared in context.jsonld are not registered as an rdfs:Class "
+            f"in public/ns/vocabulary.jsonld:"
+        )
+        for entry in missing:
+            print(f"  - {entry}")
+        return 1
+
+    print(
+        f"All {len(terms)} relationship-type terms declared in "
+        f"context.jsonld's relationships.type.@context are registered in "
+        f"public/ns/vocabulary.jsonld."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two independent follow-up gaps discovered during #232's implementation, tracked under Epic #237.

**#235** (mechanical): `scripts/test_temporal_and_properties.py` was a real 23-test pytest suite covering temporal-consistency and the `properties` construct, but neither `pytest` nor `jsonschema` was wired into any CI gate — it only ran if a contributor happened to have both installed locally. Added `pytest` (jsonschema was already pinned via #232) to `requirements-ci.txt`, hash-pinned via the same `docker run --rm --platform linux/amd64 python:3.12-slim pip download` method as the existing lxml/jsonschema pins, and wired a `python -m pytest scripts/test_temporal_and_properties.py -q` step into the `okf-conformance` job.

**#233** (design call): `check_vocab_term_coverage.py` structurally can't guard `relationships[].type` — it's schema-enum-driven, and `Relationship.type` has no enum (free-form kebab-case pattern, by design, since `.mif/config.yaml`'s custom-type registry allows namespaced types). Added a new sibling script, `scripts/check_relationship_type_vocab_coverage.py`, rather than extending the existing one: it's a genuinely different check shape (ontology-file-driven — cross-checks `context.jsonld`'s `relationships.type.@context` term mapping against `vocabulary.jsonld`'s registered `rdfs:Class` terms), and this repo's convention is one script per check shape. Verified it actually catches the #230 regression class by deleting a class from a throwaway copy of `vocabulary.jsonld` and confirming FAIL.

## Verification

- Both new checks + the full existing `okf-conformance` suite pass locally, including in a `python:3.12-slim` container matching the CI runner (hash-pinned installs succeed).
- `actionlint` clean on the modified workflow.
- Ran an 8-angle local code review; fixed a missing CHANGELOG `[Unreleased]` entry (this repo's established `[Tooling]` convention) as part of this PR. Filed #238 separately for a pre-existing, out-of-scope gap the review surfaced (ADR-012's dated audit trail drifting from `validate.yml`'s real line numbers) — a re-audit is its own editorial scope decision, not a mechanical fix bundled here.
- Considered and declined two review suggestions: job-scoping the new pytest deps into their own requirements file (the repo's actual precedent for `requirements-jsonld-ci.txt`'s separation is compiled-C-extension cost, not general job-scoping — `jsonschema`, also okf-conformance-only, isn't job-scoped either) and generalizing the new script into a framework for hypothetical future no-enum vocab properties (none exist today; added a docstring note instead).

Closes #233
Closes #235