### PR TITLE
feat: diff-scoped CI guardrail against new raw-line ADR citations (#243)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,7 @@ name: Validate MIF Bundles and Schemas
       - 'test/**'
       - 'docs/**'
       - 'src/content/docs/**'
+      - 'adr/**'
       - 'package.json'
       - 'astro.config.mjs'
     # No path filter on PRs: this is a required branch-protection gate, so it
@@ -164,3 +165,47 @@ jobs:
 
       - name: Test subtype_of integrity
         run: python scripts/test_subtype_of.py
+
+  adr-audit-citation-lint:
+    # Diff-scoped guardrail against the #241 bug class: flags a NEWLY ADDED
+    # raw L\d+ line-number citation in an adr/*.md Audit table (#238's
+    # durable-anchor convention, documented in adr/README.md). Deliberately
+    # does not check the 11 ADRs #241 catalogued as already using raw line
+    # numbers -- retrofitting those is separate, tracked work (#241), not
+    # something this check demands overnight.
+    name: ADR Audit Citation Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history, not the default shallow depth-1: the diff below needs
+          # a resolvable merge-base against an arbitrary-distance PR base branch
+          # (`git diff base...head`), which a shallow clone can't guarantee.
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Check for newly-added raw line-number citations
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          NULL_SHA="0000000000000000000000000000000000000000"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE="origin/$BASE_REF"
+          elif [ "$EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "$NULL_SHA" ]; then
+            BASE="$BEFORE_SHA"
+          else
+            # workflow_dispatch, or a push with no resolvable prior state (a
+            # brand-new branch's first push has BEFORE_SHA=$NULL_SHA): there is
+            # no single prior commit to diff against. Compare against
+            # origin/main instead of silently producing an empty (and falsely
+            # "clean") base...head range.
+            echo "No PR base or resolvable prior push state (event=$EVENT_NAME) -- comparing against origin/main instead."
+            BASE="origin/main"
+          fi
+          python scripts/check_adr_audit_citations.py --base "$BASE" --head HEAD

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -191,12 +191,17 @@ jobs:
       - name: Check for newly-added raw line-number citations
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
+          # The PR base SHA, not a branch name: actions/checkout with
+          # fetch-depth: 0 fetches the history needed to reach this exact
+          # commit, but does not reliably create an `origin/<branch>`
+          # remote-tracking ref for it -- diffing against the SHA directly
+          # sidesteps that ref-resolution question entirely.
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BEFORE_SHA: ${{ github.event.before }}
         run: |
           NULL_SHA="0000000000000000000000000000000000000000"
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            BASE="origin/$BASE_REF"
+            BASE="$PR_BASE_SHA"
           elif [ "$EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "$NULL_SHA" ]; then
             BASE="$BEFORE_SHA"
           else

--- a/scripts/check_adr_audit_citations.py
+++ b/scripts/check_adr_audit_citations.py
@@ -44,13 +44,24 @@ HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
 
 def run_diff(base: str, head: str) -> str:
-    result = subprocess.run(
-        ["git", "diff", "--unified=0", f"{base}...{head}", "--", "adr/*.md"],
-        cwd=ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    # Two pathspecs, not one: 'adr/*.md' alone misses nothing today (ADRs are
+    # flat), but 'adr/**/*.md' alone matches ZERO files against that same flat
+    # layout (git's `**` requires at least one directory level) -- confirmed
+    # via `git ls-files`. Passing both covers flat files today and any future
+    # adr/<subdir>/*.md without silently going blind either way.
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--unified=0", f"{base}...{head}", "--", "adr/*.md", "adr/**/*.md"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"FAIL: `git diff {base}...{head}` failed (exit {exc.returncode}).", file=sys.stderr)
+        if exc.stderr:
+            print(exc.stderr, file=sys.stderr)
+        raise SystemExit(1) from None
     return result.stdout
 
 

--- a/scripts/check_adr_audit_citations.py
+++ b/scripts/check_adr_audit_citations.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Diff-scoped guardrail against the #241 bug class recurring: a NEW raw
+`L\\d+` / `L\\d+-L\\d+` line-number citation added to an ADR's Audit table.
+
+#238 fixed ADR-012's own Audit table to cite durable anchors (job id, step
+`name:`, heading text, field name) instead of raw line numbers, because a
+line number into a file that keeps changing (a CI workflow, a schema, a
+script) silently drifts as the file is edited -- the citation stops
+pointing at what it claims to, while still reading as authoritative.
+`adr/README.md` documents the durable-anchor convention as the standard
+going forward (see its "Creating New ADRs" section).
+
+This script is deliberately NOT a repo-wide check of every ADR's existing
+citations -- #241 catalogued 11 ADRs that still use the raw-line-number
+style, and retrofitting them is real, separately-scoped work (tracked in
+#241 itself), not something a blocking lint should demand overnight. This
+script only looks at lines *added* by the diff being checked: it lets
+existing citations be, and blocks only a *new* one from being introduced
+the same way.
+
+Does not (yet) catch ADR-019's bare-unlabeled-number citation style (a
+number with no `L` prefix, e.g. "23" or "4-7") -- that pattern is far more
+prone to false positives (any number in prose or a version string would
+match) and needs a narrower, table-column-aware heuristic than this first
+pass implements. See #241.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+# A markdown table row: starts with `|`, and somewhere in it a raw line-number
+# citation like `L46` or `L46-L58`. Word-bounded so `SLSA` or `URL` don't match.
+TABLE_ROW = re.compile(r"^\s*\|")
+RAW_LINE_CITATION = re.compile(r"\bL\d+(?:-L\d+)?\b")
+
+DIFF_HEADER = re.compile(r"^\+\+\+ b/(.+)$")
+HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def run_diff(base: str, head: str) -> str:
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", f"{base}...{head}", "--", "adr/*.md"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def find_violations(diff_text: str) -> list[tuple[str, int, str]]:
+    """Returns (file, new_line_number, line_content) for every added line in
+    an adr/*.md file that is a table row containing a raw L\\d+ citation."""
+    violations: list[tuple[str, int, str]] = []
+    current_file = None
+    next_line = None
+
+    for line in diff_text.splitlines():
+        header_match = DIFF_HEADER.match(line)
+        if header_match:
+            current_file = header_match.group(1)
+            next_line = None
+            continue
+
+        hunk_match = HUNK_HEADER.match(line)
+        if hunk_match:
+            next_line = int(hunk_match.group(1))
+            continue
+
+        if current_file is None or next_line is None:
+            continue
+
+        if line.startswith("+") and not line.startswith("+++"):
+            added = line[1:]
+            if TABLE_ROW.match(added) and RAW_LINE_CITATION.search(added):
+                violations.append((current_file, next_line, added.strip()))
+            next_line += 1
+        # Removed ("-") lines don't consume a new-file line number, and
+        # context lines are absent entirely under --unified=0 -- both fall
+        # through here with no action, which is correct.
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main", help="base ref to diff against")
+    parser.add_argument("--head", default="HEAD", help="head ref being checked")
+    args = parser.parse_args()
+
+    diff_text = run_diff(args.base, args.head)
+    violations = find_violations(diff_text)
+
+    if not violations:
+        print(f"No new raw line-number citations added to adr/*.md Audit tables ({args.base}...{args.head}).")
+        return 0
+
+    print(
+        f"FAIL: {len(violations)} newly-added raw line-number citation(s) in "
+        f"adr/*.md Audit table(s) ({args.base}...{args.head}):\n"
+    )
+    for file, line_no, content in violations:
+        print(f"  {file}:{line_no}: {content}")
+    print(
+        "\nCite a durable anchor instead (job id, step `name:`, heading text, "
+        "field name -- something `grep -n` still finds after the file "
+        "changes), per adr/README.md's Audit-citation guidance. Raw line "
+        "numbers into a file that keeps changing silently drift; see #238 "
+        "and #241 for why this is enforced."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

#243: the scoped-down MVP piece of #241 (per user decision: guardrail only, not the full 11-ADR retrofit). A new CI job flags any **newly-added** raw `L\d+`/`L\d+-L\d+` line-number citation in a changed `adr/*.md` Audit table — the pattern #238 fixed ADR-012 away from, and #241 catalogued in 11 other ADRs.

Diff-scoped by design: `scripts/check_adr_audit_citations.py` parses `git diff --unified=0 <base>...<head> -- adr/*.md` and only looks at added lines. It does **not** touch or fail on the 11 existing ADRs' current citations — those stay tracked as separate, larger work under #241.

## What local code review caught and fixed

An 8-angle review (this is real parsing/CI logic, not docs) found two genuine bugs before this ever reached Copilot:

1. **Silent false-pass on `workflow_dispatch`**: both `BASE_REF` and `BEFORE_SHA` are empty on that trigger, so the diff range collapsed to `...HEAD` (empty) and the check reported "clean" even with a real violation present. Fixed: falls back to `origin/main` with an explicit log line, for any event where neither a PR base nor a resolvable prior push SHA exists.
2. **Uncaught crash on a new branch's first push**: `github.event.before` is the git null SHA in that case, and diffing against it crashed with a raw `CalledProcessError` traceback. Same fallback fixes this.
3. Also added `adr/**` to the `push` trigger's `paths:` filter — it was missing, so a direct admin push (this repo has `enforce_admins: false`) touching only ADR files would never have run this workflow at all, silently bypassing the exact pathway a guardrail matters most for.
4. Removed a genuinely dead `elif` branch in the diff parser and added a comment explaining why `fetch-depth: 0` is needed (three-dot diff needs a resolvable merge-base against an arbitrary-distance PR base).

## Known, deliberate scope limits (not fixed here)

- **This job is not yet in branch protection's required checks.** As-is, it can go red on a PR and the PR still merges. Adding a required check is an admin-level branch-protection change I didn't make unilaterally — flagging it here for an explicit decision rather than silently leaving it or silently doing it.
- **Only catches the `L\d+` citation spelling.** ADR-019's bare-unlabeled-number style (`23`, `4-7`, no `L` prefix) isn't covered — a narrower, more false-positive-prone pattern deferred to #241, per the review's altitude-angle finding. A stricter allowlist-of-durable-anchor-shapes check (instead of this blocklist-of-one-known-bad-shape) would close the whole class instead of one member of it; noted as a possible direction for #241, not built here.

## Verification

- Tested both directions live: injected a synthetic raw-line citation into an ADR's Audit table → caught with correct file/line; injected prose containing "L46" in a URL and a version string → correctly ignored (table-row guard holds).
- Tested all three base-ref resolution paths directly (`pull_request`, normal `push`, `workflow_dispatch`/null-SHA) after the fix — all resolve correctly.
- `actionlint` clean; no `${{ github.* }}` interpolated directly into a `run:` block (fixed a semgrep-flagged shell-injection pattern from an earlier draft, verified via the repo's own pre-commit hook).
- Full existing `okf-conformance` suite (okf_validate, vocab coverage, relationship-type vocab coverage, pytest suite) unaffected and still green.

Closes #243