### PR TITLE
docs: retrofit audit citations to durable anchors, batch 1 of 4

### DIFF
--- a/adr/ADR-002-dual-format-design.md
+++ b/adr/ADR-002-dual-format-design.md
@@ -318,19 +318,28 @@ changed from peer-equivalence to source-and-projection.
 
 ## Audit
 
+Findings cite durable anchors (heading / field name / enclosing construct),
+not raw line numbers — line numbers in `SPECIFICATION.md` and
+`scripts/mif_convert.py` shift as unrelated content is added, which had
+already made this entry's original citations stale by the 2026-07-11 audit
+below (see that entry's Summary). `grep -n` for the quoted anchor text to
+find its current line.
+
 ### 2026-06-18
+
+**Audited revision:** `7f8d2de6c671cf5f354e4034b1524c0c112ddf1f`
 
 **Status:** Compliant
 
 **Findings:**
 
-| Finding | Files | Lines | Assessment |
-|---------|-------|-------|------------|
-| Dual representation (`.md` human-readable, `.jsonld` machine-processable) defined as first-class | `SPECIFICATION.md` | L103-L108 | compliant |
-| "Both representations MUST be losslessly convertible to each other" (the convertibility claim this ADR makes) | `SPECIFICATION.md` | L110 | compliant |
-| Refinement: Markdown is the source of truth (Invariant 2) and JSON-LD is a *derived* projection — basis for the ADR-011 amendment | `scripts/mif_convert.py` | L2-L9 | compliant |
-| Converter implements `to-jsonld` / `to-markdown` and lossless `roundtrip` over bundles | `scripts/mif_convert.py` | L19-L22, L286-L295 | compliant |
-| Derived-projection emitter (`emit-jsonld`) regenerates `.jsonld` from canonical `.md` | `scripts/mif_convert.py` | L267-L279 | compliant |
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Dual representation (`.md` human-readable, `.jsonld` machine-processable) defined as first-class | `SPECIFICATION.md` | heading `### 2.1 Dual Representation` and its enumerated list (`1. **Markdown Format** (`.md`)`, `2. **JSON-LD Format** (`.jsonld`)`) | compliant |
+| "Both representations MUST be losslessly convertible to each other" (the convertibility claim this ADR makes) | `SPECIFICATION.md` | sentence "Both representations MUST be losslessly convertible to each other." immediately under `### 2.1 Dual Representation` | compliant |
+| Refinement: Markdown is the source of truth (Invariant 2) and JSON-LD is a *derived* projection — basis for the ADR-011 amendment | `scripts/mif_convert.py` | module docstring, bullets "The `.md` concept file is the source of truth (Invariant 2)." and "JSON-LD is a *derived* projection, reproducible by running this converter (Invariant 2) and lossless on a `markdown -> json-ld -> markdown` round trip for all conformance-level data (Invariant 4)." | compliant |
+| Converter implements `to-jsonld` / `to-markdown` and lossless `roundtrip` over bundles | `scripts/mif_convert.py` | functions `cmd_to_jsonld`, `cmd_to_markdown`, `cmd_roundtrip`; CLI subcommands `to-jsonld`, `to-markdown`, `roundtrip` registered via `add_parser(...)` in `main()` | compliant |
+| Derived-projection emitter (`emit-jsonld`) regenerates `.jsonld` from canonical `.md` | `scripts/mif_convert.py` | function `cmd_emit_jsonld`; CLI subcommand `emit-jsonld` registered via `add_parser("emit-jsonld", ...)` in `main()` | compliant |
 
 **Summary:** The dual-representation design and the lossless-convertibility
 requirement are both stated normatively in SPECIFICATION.md §2.1. The
@@ -344,7 +353,7 @@ emitter described in this ADR.
 
 ### 2026-07-11
 
-**Audited revision:** 88b4a8f20d87773286abbc64644f4d5c762f6ce8
+**Audited revision:** `88b4a8f20d87773286abbc64644f4d5c762f6ce8`
 
 **Status:** Compliant, with two documentation-drift notes (see Summary) — neither is a CI-gating regression
 

--- a/adr/ADR-002-dual-format-design.md
+++ b/adr/ADR-002-dual-format-design.md
@@ -10,7 +10,7 @@ tags:
   - interoperability
 status: accepted
 created: 2026-01-27
-updated: 2026-06-18
+updated: 2026-07-11
 author: MIF Maintainers
 project: MIF
 technologies:
@@ -341,3 +341,60 @@ the converter implements both the round-trip verification and the derived-JSON-L
 emitter described in this ADR.
 
 **Action Required:** None.
+
+### 2026-07-11
+
+**Audited revision:** 88b4a8f20d87773286abbc64644f4d5c762f6ce8
+
+**Status:** Compliant, with two documentation-drift notes (see Summary) — neither is a CI-gating regression
+
+**Findings:**
+
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Dual representation (`.md` human-readable, `.jsonld` machine-processable) defined as first-class | `SPECIFICATION.md` | heading `### 2.1 Dual Representation` and its enumerated list (`1. **Markdown Format** (`.md`)`, `2. **JSON-LD Format** (`.jsonld`)`) | compliant — but see Summary: this section's own prose ("MIF defines two equivalent representations") was never reconciled with ADR-011's canonical/derived refinement, unlike the Abstract and §6 heading in the same file |
+| "Both representations MUST be losslessly convertible to each other" (the convertibility claim this ADR makes) | `SPECIFICATION.md` | sentence "Both representations MUST be losslessly convertible to each other." immediately under `### 2.1 Dual Representation` | compliant |
+| Refinement: Markdown is the source of truth (Invariant 2) and JSON-LD is a *derived* projection — basis for the ADR-011 amendment | `scripts/mif_convert.py` | module docstring, bullets "The `.md` concept file is the source of truth (Invariant 2)." and "JSON-LD is a *derived* projection, reproducible by running this converter (Invariant 2) and lossless on a `markdown -> json-ld -> markdown` round trip for all conformance-level data (Invariant 4)." | compliant |
+| Converter implements `to-jsonld` / `to-markdown` and lossless `roundtrip` over bundles | `scripts/mif_convert.py` | functions `cmd_to_jsonld`, `cmd_to_markdown`, `cmd_roundtrip`; CLI subcommands `to-jsonld`, `to-markdown`, `roundtrip` registered via `add_parser(...)` in `main()` | compliant |
+| Derived-projection emitter (`emit-jsonld`) regenerates `.jsonld` from canonical `.md` | `scripts/mif_convert.py` | function `cmd_emit_jsonld`; CLI subcommand `emit-jsonld` registered via `add_parser("emit-jsonld", ...)` in `main()` | compliant |
+
+**Summary:** Re-verified all five findings against current file state rather
+than just re-anchoring the 2026-06-18 line numbers. All five claims still hold:
+`SPECIFICATION.md` §2.1 still defines the dual representation and the lossless-
+convertibility requirement verbatim (the requirement sentence is unchanged word
+for word since 2026-06-18), and `scripts/mif_convert.py` still carries the
+canonical/derived module docstring and still implements `to-jsonld`,
+`to-markdown`, `roundtrip`, and `emit-jsonld` (the file gained an unrelated
+`bundle_namespaces()` feature — merging a bundle's custom relationship-type
+namespaces into `@context` — between the two audits, but none of the cited
+behavior changed).
+
+Two documentation-drift issues surfaced during re-verification that the
+2026-06-18 audit's narrower line-citation scope didn't catch, neither of which
+touches this ADR's own Findings-table claims:
+
+1. `SPECIFICATION.md` §2.1's own prose ("MIF defines two equivalent
+   representations") still reflects the original ADR-002 co-equal framing and
+   was never updated for ADR-011, even though the Abstract ("Markdown-canonical
+   ... Invariant 2") and §6's heading ("JSON-LD Projection (derived)") in the
+   same document were. Low-severity internal inconsistency, not a broken
+   invariant.
+2. This ADR's own `## Related Decisions` entry for ADR-003 ("the Markdown
+   format is designed to be valid Obsidian notes...") is now factually stale:
+   ADR-003 was superseded by ADR-017 (commit `f353268`), which is also the
+   commit that changed `SPECIFICATION.md` §2.1 item 1 from
+   "Obsidian-compatible" to "plain CommonMark". ADR-002's `related:`
+   frontmatter also doesn't list ADR-017, even though ADR-017's `related:`
+   list does list ADR-002 (a one-way link, not the bidirectional link
+   `adr/README.md` point 5 asks for).
+
+Filed as [#251](https://github.com/modeled-information-format/MIF/issues/251)
+rather than fixed inline here, since correcting ADR-002's own body prose and
+frontmatter is a real editorial decision about wording and scope, not a
+mechanical citation-format change — the same reasoning ADR-012's audit used
+for its own filed-not-amended discrepancy (#240).
+
+**Action Required:** #251 (reconcile `SPECIFICATION.md` §2.1's prose with the
+ADR-011 canonical/derived framing already used elsewhere in the same
+document; update this ADR's Related Decisions bullet for ADR-003 and its
+`related:` frontmatter to reflect ADR-003's supersession by ADR-017).

--- a/adr/ADR-004-three-tier-trait-inheritance.md
+++ b/adr/ADR-004-three-tier-trait-inheritance.md
@@ -10,7 +10,7 @@ tags:
   - composition
 status: accepted
 created: 2026-01-27
-updated: 2026-06-18
+updated: 2026-07-11
 author: MIF Maintainers
 project: MIF
 technologies:
@@ -22,6 +22,8 @@ audience:
 related:
   - ADR-006-entitydata-vs-entityreference.md
   - ADR-001-cognitive-triad-taxonomy.md
+  - ADR-018-ontology-corpus-dedicated-repository-and-serving.md
+  - ADR-019-deploy-time-attested-ontology-vendoring.md
 ---
 
 # ADR-004: Three-Tier Trait Inheritance
@@ -171,7 +173,7 @@ field; entity types compose individual traits through a `traits` array.
 - The three-tier limit is a deliberate constraint; a domain that wants a fourth
   conceptual layer must fold it into Tier 3.
 - Trait conflicts still require a documented resolution strategy
-  (see SPECIFICATION.md Section 6.3).
+  (see SPECIFICATION.md Section 10.8.6).
 
 **Risk Assessment**:
 
@@ -239,7 +241,7 @@ entity_types:
    must collapse it into Tier 3 rather than extend the chain.
 2. **Conflict resolution required**: Composing traits from multiple tiers can
    surface field conflicts, which need a documented resolution strategy
-   (SPECIFICATION.md Section 6.3).
+   (SPECIFICATION.md Section 10.8.6).
 3. **Chain literacy required**: Readers must understand the three-tier chain to
    know where a given field originates.
 
@@ -258,7 +260,7 @@ ontologies extending both base tiers). The fixed depth keeps the secondary
 driver of reasoning simplicity intact. Mitigations:
 
 - Trait conflicts are handled by the documented resolution strategy in
-  SPECIFICATION.md Section 6.3.
+  SPECIFICATION.md Section 10.8.6.
 - The `extends`/`traits` split is consistent across all shipped ontologies, so
   the declaration model is uniform for tooling and authors alike.
 
@@ -266,6 +268,8 @@ driver of reasoning simplicity intact. Mitigations:
 
 - [ADR-006: EntityData vs EntityReference](ADR-006-entitydata-vs-entityreference.md) — EntityData relies on the trait system to give structured entities their field schemas.
 - [ADR-001: Cognitive Triad Taxonomy](ADR-001-cognitive-triad-taxonomy.md) — the base knowledge types that traits extend and enrich.
+- [ADR-018: Ontology Corpus: Dedicated Repository, Flat Layout, and Versioned Serving](ADR-018-ontology-corpus-dedicated-repository-and-serving.md) — relocated `mif-base`/`shared-traits` and every domain ontology this ADR's traits live in to the dedicated `ontologies` repo as sole source of record.
+- [ADR-019: Deploy-Time, Attestation-Verified Ontology Vendoring](ADR-019-deploy-time-attested-ontology-vendoring.md) — the mechanism by which this repo consumes the relocated ontology content at deploy time.
 
 ## Links
 
@@ -274,7 +278,7 @@ None.
 ## More Information
 
 - **Date:** 2026-06-18
-- **Source:** `ontologies/mif-base.ontology.yaml` (Tier 1), `ontologies/shared-traits.ontology.yaml` (Tier 2), `ontologies/examples/csi-5w1h.ontology.yaml` (Tier 3 example); SPECIFICATION.md Section 6.3 (Trait Conflict Resolution).
+- **Source:** `ontologies/mif-base.ontology.yaml` (Tier 1), `ontologies/shared-traits.ontology.yaml` (Tier 2), `ontologies/examples/csi-5w1h.ontology.yaml` (Tier 3 example); SPECIFICATION.md Section 10.8.6 (Trait Conflict Resolution).
 - **Related ADRs:** ADR-006, ADR-001
 
 ## Audit
@@ -302,3 +306,47 @@ this conversion cites the file-accurate names. The three-tier *model* — the
 substance of the decision — is fully compliant.
 
 **Action Required:** None.
+
+### 2026-07-11
+
+**Audited revision:** `88b4a8f20d87773286abbc64644f4d5c762f6ce8` (this repo); `bfed8cc17e08da4091e9b6c483cf03a150983cff` (`modeled-information-format/ontologies`, the external repo all four ontology-content findings now depend on — see note)
+
+**Status:** Compliant. The specific Tier 3 exemplar this ADR originally cited was deleted, but the three-tier pattern it illustrated is independently confirmed and now more widely used.
+
+**Findings:**
+
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Tier 1 `mif-base` defines the MIF-core reusable traits (`timestamped`, `confidence`, `provenance`) | `mif-base.ontology.yaml` (`modeled-information-format/ontologies`) | the `traits:` block's `timestamped`, `confidence`, and `provenance` keys | compliant |
+| Tier 2 `shared-traits` extends `mif-base` via the `extends` field | `shared-traits.ontology.yaml` (`modeled-information-format/ontologies`) | the `ontology.extends:` list (`- mif-base`) | compliant |
+| Tier 2 cross-domain mixins present (`lifecycle`, `auditable`, `certified`, `located`, `bounded`, `owned`, `scheduled`, `transactional`, `measured`) | `shared-traits.ontology.yaml` (`modeled-information-format/ontologies`) | the `traits:` block's nine keys: `lifecycle`, `auditable`, `certified`, `located`, `bounded`, `owned`, `transactional`, `scheduled`, `measured` | compliant |
+| Tier 3 domain ontology extends both base tiers (`extends: [mif-base, shared-traits]`) | previously `ontologies/examples/csi-5w1h.ontology.yaml` — **that file no longer exists** (see note); now cited via any of 7 current exemplars, e.g. `biology-research-lab.ontology.yaml` | the `ontology.extends:` list (`- mif-base`, `- shared-traits`) | compliant, via a different (and now more numerous) exemplar than originally cited |
+
+**Note on the deleted Tier 3 exemplar:** `ontologies/examples/csi-5w1h.ontology.yaml`, the file this ADR's finding 4 originally cited, was permanently removed from the `modeled-information-format/ontologies` repo in commit `90975d9` ("refactor: flatten ontology corpus and add JSON-LD projections"), which deleted the entire `ontologies/examples/` tree. This is a real, confirmed discrepancy in the *citation* — the named file is gone, not merely moved. It is **not** a discrepancy in the *finding*: re-verified directly against the ontologies repo's current `main` (`bfed8cc17e08da4091e9b6c483cf03a150983cff`), 7 domain ontologies now extend both `mif-base` and `shared-traits` directly (`agriculture`, `biology-research-lab`, `engineering-base`, `market-research`, `regulatory-legal`, `research`, `trend-analysis`) — up from the single illustrative example this ADR originally pointed at. The three-tier pattern is more heavily used today than when this ADR was written, just no longer demonstrated by the specific file name in the audit trail.
+
+**Summary:** Re-verified all four findings against current state — three (Tier 1
+traits, Tier 2 `extends`, Tier 2 mixins) directly in `modeled-information-format/ontologies`,
+which now holds sole source-of-record for ontology content per ADR-018/ADR-019
+(2026-07-01/07-02); this repo (`MIF`) has no local ontology corpus for these
+to be re-verified against (the only local ontology YAML is
+`test/subtype_of/`'s small synthetic fixture set for resolver unit testing,
+unrelated to this ADR's real corpus). All three remain true. The fourth
+finding's cited file was deleted in the ontologies repo's "flatten ontology
+corpus" refactor; re-verified via 7 current exemplars instead, confirming the
+pattern itself is intact and now more widely adopted.
+
+Also found: this ADR's body text cited "SPECIFICATION.md Section 6.3" for
+trait-conflict resolution in four places (Option 4 Disadvantages, Consequences
+Negative #2, Decision Outcome, More Information Source line) — that content
+now lives at `#### 10.8.6 Trait Inheritance and Conflict Resolution` (content
+unchanged, only the section number moved). Fixed inline in this same PR as a
+mechanical citation-number correction, not an editorial change. This ADR's
+`related:` frontmatter (previously ADR-006, ADR-001 only) is updated in this
+same PR to add ADR-018 and ADR-019, since those are what relocated the source
+of record for the traits this ADR defines — ADR-018 already names ADR-004 as
+related in the other direction.
+
+**Action Required:** None. The deleted-exemplar citation is corrected above;
+the stale section-number citations and the one-way `related:` link are both
+fixed in this same PR (not deferred), since both are mechanical corrections
+rather than editorial-scope decisions.

--- a/adr/ADR-004-three-tier-trait-inheritance.md
+++ b/adr/ADR-004-three-tier-trait-inheritance.md
@@ -283,18 +283,29 @@ None.
 
 ## Audit
 
+Findings cite durable anchors (field name / enclosing construct), not raw
+line numbers — the files these originally cited also physically relocated
+out of this repo entirely (see the 2026-07-11 entry below), which is a more
+severe version of the staleness raw line numbers alone would already have
+suffered. `grep -n` for the quoted anchor text in the file's current home to
+find its current line.
+
 ### 2026-06-18
+
+**Audited revision:** `7f8d2de6c671cf5f354e4034b1524c0c112ddf1f` (this repo — at
+this date, the cited `ontologies/` paths were still local to this repo, before
+ADR-018/ADR-019 relocated them; see the 2026-07-11 entry for their current home)
 
 **Status:** Compliant
 
 **Findings:**
 
-| Finding | Files | Lines | Assessment |
-|---------|-------|-------|------------|
-| Tier 1 `mif-base` defines the MIF-core reusable traits (`timestamped`, `confidence`, `provenance`) | `ontologies/mif-base.ontology.yaml` | L82-L110 | compliant |
-| Tier 2 `shared-traits` extends `mif-base` via the `extends` field | `ontologies/shared-traits.ontology.yaml` | L22-L23 | compliant |
-| Tier 2 cross-domain mixins present (`lifecycle`, `auditable`, `certified`, `located`, `bounded`, `owned`, `scheduled`, `transactional`, `measured`) | `ontologies/shared-traits.ontology.yaml` | L29-L355 | compliant |
-| Tier 3 domain ontology extends both base tiers (`extends: [mif-base, shared-traits]`) | `ontologies/examples/csi-5w1h.ontology.yaml` | L32-L34 | compliant |
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Tier 1 `mif-base` defines the MIF-core reusable traits (`timestamped`, `confidence`, `provenance`) | `ontologies/mif-base.ontology.yaml` (path as it existed in this repo at this date) | the `traits:` block's `timestamped`, `confidence`, and `provenance` keys | compliant |
+| Tier 2 `shared-traits` extends `mif-base` via the `extends` field | `ontologies/shared-traits.ontology.yaml` (path as it existed in this repo at this date) | the `ontology.extends:` list (`- mif-base`) | compliant |
+| Tier 2 cross-domain mixins present (`lifecycle`, `auditable`, `certified`, `located`, `bounded`, `owned`, `scheduled`, `transactional`, `measured`) | `ontologies/shared-traits.ontology.yaml` (path as it existed in this repo at this date) | the `traits:` block's nine keys: `lifecycle`, `auditable`, `certified`, `located`, `bounded`, `owned`, `transactional`, `scheduled`, `measured` | compliant |
+| Tier 3 domain ontology extends both base tiers (`extends: [mif-base, shared-traits]`) | `ontologies/examples/csi-5w1h.ontology.yaml` (path as it existed in this repo at this date — this specific file no longer exists anywhere, see 2026-07-11 entry) | the `ontology.extends:` list (`- mif-base`, `- shared-traits`) | compliant |
 
 **Summary:** The three-tier chain is present and verifiable in the shipped
 ontologies: `mif-base` supplies Tier 1 core traits, `shared-traits` extends it

--- a/adr/ADR-006-entitydata-vs-entityreference.md
+++ b/adr/ADR-006-entitydata-vs-entityreference.md
@@ -10,7 +10,7 @@ tags:
   - json-ld
 status: accepted
 created: 2026-01-27
-updated: 2026-06-18
+updated: 2026-07-11
 author: MIF Maintainers
 project: MIF
 technologies:
@@ -329,3 +329,56 @@ therefore describes the `ontology` reference as the accompanying, EntityData-
 defining artifact rather than a schema-enforced requirement.
 
 **Action Required:** None.
+
+### 2026-07-11
+
+**Audited revision:** 88b4a8f20d87773286abbc64644f4d5c762f6ce8
+
+**Status:** Compliant
+
+**Findings:**
+
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| EntityReference is a closed schema (`additionalProperties: false`), required `["@type", "entity"]`, fields `entityType`/`name`/`role`, with an `entity.@id` matching `^urn:mif:entity:` | `schema/definitions/entity-reference.schema.json` | the top-level `"required": ["@type", "entity"]` array; the `entity.properties["@id"].pattern` field (`^urn:mif:entity:`); the schema's closing `"additionalProperties": false` (root object, immediately after the `role` property) | compliant |
+| EntityReference core types are the closed set Person/Organization/Technology/Concept/File, plus a lowercase-kebab custom-type pattern | `schema/definitions/entity-reference.schema.json` | the `entityType.oneOf` enum (`["Person", "Organization", "Technology", "Concept", "File"]`) and its sibling custom-type `"pattern": "^[a-z][a-z0-9-]*$"` | compliant |
+| EntityData is an open schema (`additionalProperties: true`), requires only `name`, offers lowercase-kebab `entity_type` and `entity_id` | `schema/mif.schema.json` | the `"EntityData":` `$def` — `"required": ["name"]` plus its `entity_type`/`entity_id` properties and trailing `"additionalProperties": true` | compliant |
+| The two shapes occupy distinct top-level slots: singular `entity` (EntityData) alongside the `ontology` reference, and `entities[]` (array of EntityReference) | `schema/mif.schema.json` | the top-level `"ontology":`, `"entity":` (`"$ref": "#/$defs/EntityData"`), and `"entities":` (`items.$ref: "#/$defs/EntityReference"`) properties | compliant |
+| The main schema's `EntityReference` `$def` delegates to the dedicated definition file | `schema/mif.schema.json` | the `"EntityReference":` `$def` (`"$ref": "./definitions/entity-reference.schema.json"`) | compliant |
+
+**Summary:** Re-verified every finding against current file state, not just
+re-anchored at today's line numbers. All five findings' underlying claims are
+still true and unchanged in substance since 2026-06-18: EntityReference's
+closed shape and core-type enum, EntityData's open shape, the two shapes'
+distinct top-level slots, and the `$ref` delegation all hold. What changed is
+only *position*: `schema/mif.schema.json` grew as new `$defs` (vendor-neutral
+`DocumentReference` #84, the W3C-PROV provenance layer #85, and
+temporal-consistency/scalar-property additions #79 — all landed between
+2026-06-18 and this audit) were inserted ahead of `EntityData`/`EntityReference`
+in the `$defs` block. That pushed `EntityData` from L452-L472 to L597-L617 and
+the `EntityReference` delegation `$def` from L244-L246 to L348-L350 — both raw
+citations in the 2026-06-18 entry are now stale, exactly the failure mode this
+durable-anchor retrofit exists to prevent. `schema/definitions/entity-reference.schema.json`
+is untouched since 2026-06-18 (its two findings' old line ranges still happen
+to resolve correctly). The top-level `entity`/`entities`/`ontology` properties
+in `mif.schema.json` haven't moved either, since they sit in the `properties`
+block near the top of the file, ahead of the growing `$defs` section.
+
+Also checked ADR-006's two related ADRs for drift: ADR-004 (Three-Tier Trait
+Inheritance) is unchanged — still `accepted`, no amendment, still correctly
+cross-references ADR-006. ADR-002 (Dual-Format Design) was refined by ADR-011
+after ADR-006 was written: the "co-equal formats" framing ADR-006's Related
+Decisions section leans on ("both entity representations carry through the
+Markdown and JSON-LD projections") is now more precisely "JSON-LD is a derived
+projection of canonical Markdown, lossless on round-trip" per ADR-002's own
+Amendment section. This doesn't break ADR-006's claim — both EntityReference
+and EntityData still carry through the derived projection without
+special-casing — but ADR-006 doesn't cite ADR-011 anywhere, which is a minor
+staleness in its own right.
+
+**Action Required:** None blocking. One cosmetic, non-blocking suggestion:
+consider adding ADR-011 to ADR-006's `related:` frontmatter / Related
+Decisions, since the "both formats carry through" claim it relies on was
+refined there. Left as an editorial call rather than fixed inline here, per
+the same reasoning ADR-012's audit used for its own filed-not-amended
+discrepancy (#240).

--- a/adr/ADR-006-entitydata-vs-entityreference.md
+++ b/adr/ADR-006-entitydata-vs-entityreference.md
@@ -302,19 +302,27 @@ patterns:
 
 ## Audit
 
+Findings cite durable anchors (field name / enclosing construct), not raw
+line numbers — line numbers in `schema/mif.schema.json` shift as unrelated
+`$defs` are added, which had already made this entry's original citations
+stale by the 2026-07-11 audit below (see that entry's Summary). `grep -n`
+for the quoted anchor text to find its current line.
+
 ### 2026-06-18
+
+**Audited revision:** `7f8d2de6c671cf5f354e4034b1524c0c112ddf1f`
 
 **Status:** Compliant
 
 **Findings:**
 
-| Finding | Files | Lines | Assessment |
-|---------|-------|-------|------------|
-| EntityReference is a closed schema (`additionalProperties: false`), required `["@type", "entity"]`, fields `entityType`/`name`/`role`, with an `entity.@id` matching `^urn:mif:entity:` | `schema/definitions/entity-reference.schema.json` | L7-L48 | compliant |
-| EntityReference core types are the closed set Person/Organization/Technology/Concept/File, plus a lowercase-kebab custom-type pattern | `schema/definitions/entity-reference.schema.json` | L28-L37 | compliant |
-| EntityData is an open schema (`additionalProperties: true`), requires only `name`, offers lowercase-kebab `entity_type` and `entity_id` | `schema/mif.schema.json` | L452-L472 | compliant |
-| The two shapes occupy distinct top-level slots: singular `entity` (EntityData) alongside the `ontology` reference, and `entities[]` (array of EntityReference) | `schema/mif.schema.json` | L68-L94 | compliant |
-| The main schema's `EntityReference` `$def` delegates to the dedicated definition file | `schema/mif.schema.json` | L244-L246 | compliant |
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| EntityReference is a closed schema (`additionalProperties: false`), required `["@type", "entity"]`, fields `entityType`/`name`/`role`, with an `entity.@id` matching `^urn:mif:entity:` | `schema/definitions/entity-reference.schema.json` | the top-level `"required": ["@type", "entity"]` array; the `entity.properties["@id"].pattern` field (`^urn:mif:entity:`); the schema's closing `"additionalProperties": false` (root object, immediately after the `role` property) | compliant |
+| EntityReference core types are the closed set Person/Organization/Technology/Concept/File, plus a lowercase-kebab custom-type pattern | `schema/definitions/entity-reference.schema.json` | the `entityType.oneOf` enum (`["Person", "Organization", "Technology", "Concept", "File"]`) and its sibling custom-type `"pattern": "^[a-z][a-z0-9-]*$"` | compliant |
+| EntityData is an open schema (`additionalProperties: true`), requires only `name`, offers lowercase-kebab `entity_type` and `entity_id` | `schema/mif.schema.json` | the `"EntityData":` `$def` — `"required": ["name"]` plus its `entity_type`/`entity_id` properties and trailing `"additionalProperties": true` | compliant |
+| The two shapes occupy distinct top-level slots: singular `entity` (EntityData) alongside the `ontology` reference, and `entities[]` (array of EntityReference) | `schema/mif.schema.json` | the top-level `"ontology":`, `"entity":` (`"$ref": "#/$defs/EntityData"`), and `"entities":` (`items.$ref: "#/$defs/EntityReference"`) properties | compliant |
+| The main schema's `EntityReference` `$def` delegates to the dedicated definition file | `schema/mif.schema.json` | the `"EntityReference":` `$def` (`"$ref": "./definitions/entity-reference.schema.json"`) | compliant |
 
 **Summary:** The two-representation model is present and enforced in the v1.0
 schema exactly as described: EntityReference is closed with a fixed core-type
@@ -323,8 +331,8 @@ the two live in distinct top-level slots (`entities[]` vs `entity`).
 
 **Note:** The original ADR phrased EntityData as "Requires `ontology` reference."
 At the JSON-Schema level this is a *semantic* coupling, not a hard constraint:
-the top-level `required` array (`schema/mif.schema.json` L7) does not list
-`ontology`, and the `EntityData` object itself requires only `name`. This ADR
+`mif.schema.json`'s top-level `required` array does not list `ontology`, and
+the `EntityData` object itself requires only `name`. This ADR
 therefore describes the `ontology` reference as the accompanying, EntityData-
 defining artifact rather than a schema-enforced requirement.
 
@@ -332,7 +340,7 @@ defining artifact rather than a schema-enforced requirement.
 
 ### 2026-07-11
 
-**Audited revision:** 88b4a8f20d87773286abbc64644f4d5c762f6ce8
+**Audited revision:** `88b4a8f20d87773286abbc64644f4d5c762f6ce8`
 
 **Status:** Compliant
 

--- a/adr/ADR-009-okf-compliance-superset.md
+++ b/adr/ADR-009-okf-compliance-superset.md
@@ -222,19 +222,27 @@ independence (own governance). Mitigations:
 
 ## Audit
 
+Findings cite durable anchors (heading text), not raw line numbers — line
+numbers in `SPECIFICATION.md` and `docs/okf-conformance.md` shift as
+unrelated content is added, which had already made this entry's original
+citations stale by the 2026-07-11 audit below (see that entry's Summary).
+`grep -n` for the quoted anchor text to find its current line.
+
 ### 2026-06-18
+
+**Audited revision:** `7f8d2de6c671cf5f354e4034b1524c0c112ddf1f`
 
 **Status:** Compliant
 
 **Findings:**
 
-| Finding | Files | Lines | Assessment |
-|---------|-------|-------|------------|
-| Superset-not-subordination and "no normative dependency / pin OKF v0.1" stated normatively | `SPECIFICATION.md` | L29-L34 | compliant |
-| Invariant 5 ("normative within MIF") pinned criteria document present | `docs/okf-conformance.md` | L3-L19 | compliant |
-| Pinned OKF v0.1 criteria enumerated (bundle shape, required `type`, reserved filenames, concept graph, broken-links-tolerated) | `docs/okf-conformance.md` | L25-L41 | compliant |
-| MIF → OKF mapping (typed relationships overlay OKF links; `.jsonld` outside `*.md` glob) | `docs/okf-conformance.md` | L52-L65 | compliant |
-| "MIF answers OKF's open questions" positioning table | `SPECIFICATION.md` | L49-L57 | compliant |
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Superset-not-subordination and "no normative dependency / pin OKF v0.1" stated normatively | `SPECIFICATION.md` | the Abstract paragraph beginning "OKF compliance is achieved as a **superset, not by subordination**" | compliant |
+| Invariant 5 ("normative within MIF") pinned criteria document present | `docs/okf-conformance.md` | document heading "# OKF Conformance (pinned)" plus the phrase "**normative within MIF**" in the sentence following it | compliant |
+| Pinned OKF v0.1 criteria enumerated (bundle shape, required `type`, reserved filenames, concept graph, broken-links-tolerated) | `docs/okf-conformance.md` | heading "## 1. Pinned OKF v0.1 criteria" | compliant |
+| MIF → OKF mapping (typed relationships overlay OKF links; `.jsonld` outside `*.md` glob) | `docs/okf-conformance.md` | heading "## 2. MIF → OKF mapping" | compliant |
+| "MIF answers OKF's open questions" positioning table | `SPECIFICATION.md` | heading "### MIF answers OKF's open questions" | compliant |
 
 **Summary:** The superset relationship, the pinned-v0.1 / no-floating-dependency
 rule (Invariant 5), and the MIF→OKF mapping are all present and normative in the

--- a/adr/ADR-009-okf-compliance-superset.md
+++ b/adr/ADR-009-okf-compliance-superset.md
@@ -11,7 +11,7 @@ tags:
   - governance
 status: accepted
 created: 2026-06-18
-updated: 2026-06-18
+updated: 2026-07-11
 author: MIF Maintainers
 project: MIF
 technologies:
@@ -241,3 +241,51 @@ rule (Invariant 5), and the MIF→OKF mapping are all present and normative in t
 specification and the pinned conformance document.
 
 **Action Required:** None.
+
+### 2026-07-11
+
+**Audited revision:** `88b4a8f20d87773286abbc64644f4d5c762f6ce8`
+
+**Status:** Compliant
+
+**Findings:**
+
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Superset-not-subordination and "no normative dependency / pin OKF v0.1" stated normatively | `SPECIFICATION.md` | the Abstract paragraph beginning "OKF compliance is achieved as a **superset, not by subordination**" | compliant |
+| Invariant 5 ("normative within MIF") pinned criteria document present | `docs/okf-conformance.md` | document heading "# OKF Conformance (pinned)" plus the phrase "**normative within MIF**" in the sentence following it | compliant |
+| Pinned OKF v0.1 criteria enumerated (bundle shape, required `type`, reserved filenames, concept graph, broken-links-tolerated) | `docs/okf-conformance.md` | heading "## 1. Pinned OKF v0.1 criteria" | compliant |
+| MIF → OKF mapping (typed relationships overlay OKF links; `.jsonld` outside `*.md` glob) | `docs/okf-conformance.md` | heading "## 2. MIF → OKF mapping" | compliant |
+| "MIF answers OKF's open questions" positioning table | `SPECIFICATION.md` | heading "### MIF answers OKF's open questions" | compliant |
+
+**Summary:** Re-verified every finding against current file content, not just
+against a resolving citation. Both cited source files (`SPECIFICATION.md`,
+`docs/okf-conformance.md`) are functionally unchanged since 2026-06-18.
+`SPECIFICATION.md` still self-declares "**Last Updated**: 2026-06-18";
+`docs/okf-conformance.md` carries no such field (it instead self-declares
+"Conforms to OKF v0.1, criteria copied 2026-06"), but its content is likewise
+unchanged since the 2026-06-18 audit. The only observed drift is line-number
+shift from unrelated edits elsewhere in the same files (e.g. the positioning
+table moved from ~L49-57 to ~L50-58), exactly the class of churn durable
+anchors are meant to survive. The pinned-OKF-v0.1 criteria (§1), the
+MIF→OKF mapping (§2), and the positioning table's row content (`Supersedes`/
+`ConflictsWith`, `sourceType`/`trustLevel`, TTL/freshness) were spot-checked
+against SPECIFICATION.md §8 and the schema, not just re-cited — all still
+match. All five related ADRs (ADR-010, ADR-011, ADR-012, ADR-001, ADR-008)
+remain `status: accepted`; none have been superseded or renumbered, so no
+update to this ADR's `related:` frontmatter or Related Decisions section is
+needed. ADR-012's own 2026-07-11 re-audit found one real discrepancy
+(`validate-ontologies` job scope, tracked as #240), but that finding is
+scoped to `.github/workflows/validate.yml`, which this ADR does not cite —
+it does not affect any finding here. One pre-existing, non-blocking gap
+independently confirmed during this audit (not a change since 2026-06-18):
+"Invariant 5" and "Invariant 2" (and others, 1-6, cited across the repo) are
+referenced by number in prose throughout `SPECIFICATION.md` and several
+ADRs, but no enumerated invariants list exists anywhere defining them
+collectively — filed as
+[#252](https://github.com/modeled-information-format/MIF/issues/252). This
+doesn't invalidate the finding above (the citation itself resolves fine); it
+is a gap in what the citation points at, not in this ADR.
+
+**Action Required:** None for this ADR. See #252 for the separately-tracked
+"Invariant 5 cited but not enumerated" gap.

--- a/adr/ADR-014-document-reference-not-embed.md
+++ b/adr/ADR-014-document-reference-not-embed.md
@@ -205,15 +205,17 @@ current line.
 
 ### 2026-06-26
 
+**Audited revision:** `42eee4b506fb7906d31a50e9a09a7d29262cfcb4`
+
 **Status:** Compliant
 
 **Findings:**
 
-| Finding | Files | Lines | Assessment |
-|---------|-------|-------|------------|
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
 | `$defs.DocumentReference` is vendor-neutral, `@type` const, located by `url` or `id` via `anyOf`, `additionalProperties: false` | `schema/mif.schema.json` | `$defs.DocumentReference` | compliant |
 | Optional top-level `documents` array references `#/$defs/DocumentReference` | `schema/mif.schema.json` | `properties.documents` | compliant |
-| `documents` added to `FRONTMATTER_ORDER` and both passthrough lists | `scripts/mif_convert.py` | L64, L148, L192 | compliant |
+| `documents` added to `FRONTMATTER_ORDER` and both passthrough lists | `scripts/mif_convert.py` | `FRONTMATTER_ORDER` list entry `"documents"`; `md_to_jsonld()`'s `passthrough` list entry `"documents"`; `jsonld_to_md()`'s `passthrough` list entry `"documents"` | compliant |
 | Context maps `documents`, `DocumentReference`, and DocumentReference fields | `schema/context.jsonld` | `documents`/`DocumentReference` block | compliant |
 | Example carries a `documents:` entry that round-trips | `profiles/ai-memory/examples/level-3-citations.md` | `documents:` | compliant |
 

--- a/adr/ADR-014-document-reference-not-embed.md
+++ b/adr/ADR-014-document-reference-not-embed.md
@@ -11,7 +11,7 @@ tags:
   - integrity
 status: accepted
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-07-11
 author: MIF Maintainers
 project: MIF
 technologies:
@@ -195,6 +195,14 @@ schema gates (ADR-012) cover the new field.
 
 ## Audit
 
+Findings cite durable anchors (job id / step `name:` / heading / field name /
+enclosing construct name), not raw line numbers — line numbers in
+`scripts/mif_convert.py` and `schema/mif.schema.json` shift as unrelated
+fields are added, which had already made the 2026-06-26 entry's
+`scripts/mif_convert.py` line citations stale by the 2026-07-11 audit below
+(see that entry's Summary). `grep -n` for the quoted anchor text to find its
+current line.
+
 ### 2026-06-26
 
 **Status:** Compliant
@@ -215,3 +223,57 @@ new terms. The round-trip, OKF, schema-compile, and projection gates were run
 locally to green in this session.
 
 **Action Required:** None.
+
+### 2026-07-11
+
+**Audited revision:** `88b4a8f20d87773286abbc64644f4d5c762f6ce8`
+
+**Status:** Compliant
+
+**Findings:**
+
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| `$defs.DocumentReference` is vendor-neutral, `@type` const, located by `url` or `id` via `anyOf`, `additionalProperties: false` | `schema/mif.schema.json` | `$defs.DocumentReference` | compliant |
+| Optional top-level `documents` array references `#/$defs/DocumentReference` | `schema/mif.schema.json` | `properties.documents` | compliant |
+| `documents` added to `FRONTMATTER_ORDER` and both passthrough lists | `scripts/mif_convert.py` | `FRONTMATTER_ORDER` list entry `"documents"`; `md_to_jsonld()`'s `passthrough` list entry `"documents"`; `jsonld_to_md()`'s `passthrough` list entry `"documents"` | compliant |
+| Context maps `documents`, `DocumentReference`, and DocumentReference fields, with `documentType`'s enum values individually resolvable and base-URI-independent | `schema/context.jsonld` | `"documents":` term block; `"DocumentReference": "mif:DocumentReference"`; `documentType`'s scoped `@context` | compliant — see Summary for a since-fixed regression that briefly affected this exact mapping |
+| Example carries a `documents:` entry that round-trips | `profiles/ai-memory/examples/level-3-citations.md` | `documents:` frontmatter key | compliant — `python3 scripts/mif_convert.py roundtrip profiles/ai-memory/examples` run locally this session: `Round-trip: tested 4 concept(s) across 1 bundle(s)` / `Round-trip lossless: PASS` |
+
+**Summary:** All five 2026-06-26 findings were re-verified against current file
+state, not merely re-anchored, and all still hold. Two things changed since
+the original audit:
+
+1. **Line-number drift** — the 2026-06-26 entry's `scripts/mif_convert.py`
+   citations (L64, L148, L192) no longer point at the `documents` entries
+   they claimed; an unrelated later change (the `relationship_types`
+   custom-type registry, #232/#236) shifted the file so those same three
+   list entries now read `"documents"` at L81, L171, L214. The claim itself
+   (documents is present in `FRONTMATTER_ORDER` and both passthrough lists)
+   is unaffected — only the raw line numbers were stale. Re-anchored above to
+   the enclosing construct name (`grep -n '"documents"' scripts/mif_convert.py`
+   finds all three, disambiguated by which function/list they sit in).
+2. **A real, already-fixed regression in the exact JSON-LD mapping finding 4
+   certifies.** `DocumentReference.documentType` used `@type: @vocab` with no
+   registered terms from this construct's introduction (#84) until PR #227
+   (merged 2026-07-10). Under JSON-LD 1.1 `@vocab` expansion, an unregistered
+   enum value falls back to document-base-relative IRI resolution, so the
+   same `documentType` value (e.g. `"video"`) expanded to a different,
+   non-equal IRI depending on the consuming document's base URL — a genuine
+   conformance defect in the construct this ADR introduced, silent for
+   roughly two weeks because this repo's own round-trip/schema checks don't
+   exercise real JSON-LD 1.1 expand/compact semantics (only a real processor
+   like `pyld` sees it). PR #227 fixed it by scoping every `documentType`
+   enum value to an explicit `mif:DocumentType*` term nested in
+   `documentType`'s own `@context`, and added
+   `scripts/test_jsonld_context_fidelity.py` (pyld-driven) plus
+   `scripts/check_vocab_term_coverage.py`, both wired into the
+   `okf-conformance` CI job (ADR-012) — so this regression class is now
+   caught mechanically. At the pinned revision the mapping is fixed and
+   CI-guarded; no open discrepancy remains on this ADR. Related ADRs
+   (ADR-006, ADR-009, ADR-010) were checked and remain `accepted` and
+   unamended — the Related Decisions section is still accurate.
+
+**Action Required:** None. The `documentType` vocab-mapping bug is already
+closed (#224/#225/#227) and gated by CI per ADR-012; no follow-up needed on
+this ADR.


### PR DESCRIPTION
Closes #246. Batch 1 of 4 for #245 (the retrofit Story under #241).

## What

Re-verifies and re-anchors the Audit tables of ADR-014, ADR-004, ADR-009, ADR-002, and ADR-006 — the lowest-citation-count group in #245's build order. Every finding was re-checked against current repo state (not just re-anchored at today's line number), converted to durable anchors (job id / step name / heading / field name / enclosing construct), and pinned with an Audited revision SHA — the methodology established in #238/PR #242.

## Real discrepancies found (not papered over)

- **ADR-014**: documents a real, already-fixed JSON-LD `@vocab` regression (`documentType`, silent ~2 weeks, closed by PR #227) that the original audit trail never recorded.
- **ADR-004**: all four ontology-content findings now live in `modeled-information-format/ontologies` (ADR-018/ADR-019). Three re-verified directly against that repo's current `main`. The fourth's cited exemplar (`examples/csi-5w1h.ontology.yaml`) was permanently deleted in that repo's corpus-flatten refactor — confirmed via its git history — but the pattern is intact and now used by 7 domain ontologies (up from the original 1). Also fixed inline: three stale "SPECIFICATION.md Section 6.3" citations (→ 10.8.6) and a one-way `related:` link to ADR-018/ADR-019.
- **ADR-002**: filed [#251](https://github.com/modeled-information-format/MIF/issues/251) for a stale `related:` bullet (cites superseded ADR-003) and a pre-ADR-011 framing left in SPECIFICATION.md §2.1 — editorial-scope, not fixed inline.
- **ADR-009**: filed [#252](https://github.com/modeled-information-format/MIF/issues/252) — SPECIFICATION.md's numbered "Invariant N" references (1–6) are never enumerated anywhere.
- **ADR-006**: no discrepancy; confirmed fully compliant, only citations moved due to unrelated schema growth.

## Testing

- `python3 scripts/check_adr_audit_citations.py --base origin/main --head HEAD` — clean.
- Ran `python3 scripts/mif_convert.py roundtrip profiles/ai-memory/examples` to verify ADR-014's round-trip claim directly.
- Every durable anchor and every "compliant" claim across all 5 files was independently re-verified against current file content by a separate pass before this PR was opened (including a live checkout of the `ontologies` repo for ADR-004's cross-repo findings) — one real inaccuracy found and fixed before push (ADR-009's Summary misattributed a "Last Updated" field to a file that doesn't have one).