### PR TITLE
docs: retrofit audit citations to durable anchors, batch 2 of 4

### DIFF
--- a/adr/ADR-001-cognitive-triad-taxonomy.md
+++ b/adr/ADR-001-cognitive-triad-taxonomy.md
@@ -9,7 +9,7 @@ tags:
   - cognitive-science
 status: accepted
 created: 2026-01-27
-updated: 2026-06-18
+updated: 2026-07-11
 author: MIF Maintainers
 project: MIF
 technologies:
@@ -174,8 +174,8 @@ keeping the base set fixed at three while permitting local vocabulary.
 
 - Encoded as the `conceptType` enum `["semantic", "episodic", "procedural"]` in
   the JSON Schema, with `memoryType` retained as a deprecated v0.1 alias.
-- Each base type carries a namespace hint (`semantic/*`, `episodic/*`,
-  `procedural/*`) that downstream conventions build on.
+- Each base type carries a namespace hint (`_semantic/*`, `_episodic/*`,
+  `_procedural/*`) that downstream conventions build on.
 - Each typed concept remains a valid OKF concept: the `type` value satisfies
   OKF's required field while supplying meaning OKF leaves open.
 
@@ -281,25 +281,74 @@ Mitigations:
 
 ## Audit
 
+Findings cite durable anchors (heading / field name), not raw line numbers —
+line numbers in `SPECIFICATION.md` and the schema files shift as unrelated
+content is added. `grep -n` for the quoted anchor text to find its current
+line.
+
 ### 2026-06-18
+
+**Audited revision:** `7f8d2de6c671cf5f354e4034b1524c0c112ddf1f`
 
 **Status:** Compliant
 
 **Findings:**
 
-| Finding | Files | Lines | Assessment |
-|---------|-------|-------|------------|
-| Base concept-type enum `["semantic", "episodic", "procedural"]` is normative in the schema (`conceptType`) | `schema/mif.schema.json` | L30-L34 | compliant |
-| `memoryType` retained as a deprecated v0.1 alias of `conceptType` (same triad enum) | `schema/mif.schema.json` | L35-L38 | compliant |
-| Same triad enum enforced in the ontology schema | `schema/ontology/ontology.schema.json` | L122, L154 | compliant |
-| Three base memory types defined with descriptions and namespace hints | `SPECIFICATION.md` | L234-L250 | compliant |
-| Ontology-extended types specialize a declared `base` (keeps base set fixed at three) | `SPECIFICATION.md` | L252-L263 | compliant |
-| "MIF answers OKF's open questions" table: triad is MIF's answer to OKF's absent concept-type taxonomy | `SPECIFICATION.md` | L49-L51 | compliant |
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Base concept-type enum `["semantic", "episodic", "procedural"]` is normative in the schema (`conceptType`) | `schema/mif.schema.json` | the `conceptType` property definition | compliant |
+| `memoryType` retained as a deprecated v0.1 alias of `conceptType` (same triad enum) | `schema/mif.schema.json` | the `memoryType` property definition | compliant |
+| Same triad enum enforced in the ontology schema | `schema/ontology/ontology.schema.json` | `$defs.namespace` field `type_hint`; `$defs.entityType` field `base` | compliant |
+| Three base memory types defined with descriptions and namespace hints | `SPECIFICATION.md` | heading `### 4.2 Memory Types` | compliant |
+| Ontology-extended types specialize a declared `base` (keeps base set fixed at three) | `SPECIFICATION.md` | heading `#### 4.2.1 Ontology-Extended Types` | compliant |
+| "MIF answers OKF's open questions" table: triad is MIF's answer to OKF's absent concept-type taxonomy | `SPECIFICATION.md` | heading `### MIF answers OKF's open questions` | compliant |
 
 **Summary:** The cognitive triad is present and normative as the `conceptType`
 enum in `schema/mif.schema.json`, mirrored in the ontology schema, defined with
 namespace hints and extension rules in SPECIFICATION.md §4.2 / §4.2.1, and
 positioned in the SPECIFICATION's "MIF answers OKF's open questions" table as
 MIF's answer to OKF's deliberately-absent concept-type system.
+
+**Action Required:** None.
+
+### 2026-07-11
+
+**Audited revision:** `d2b0c577f59b30beadb12ffc45bf8e303b602377`
+
+**Status:** Compliant
+
+**Findings:**
+
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Base concept-type enum `["semantic", "episodic", "procedural"]` is normative in the schema | `schema/mif.schema.json` | the `conceptType` property definition | compliant |
+| `memoryType` retained as a deprecated v0.1 alias of `conceptType` (same triad enum) | `schema/mif.schema.json` | the `memoryType` property definition | compliant |
+| Same triad enum enforced in the ontology schema (namespace `type_hint` default and entity-type `base`) | `schema/ontology/ontology.schema.json` | `$defs.namespace` field `type_hint`; `$defs.entityType` field `base` | compliant |
+| Three base memory types defined with descriptions and namespace hints | `SPECIFICATION.md` | headings `### 4.2 Memory Types` and `#### Base Type Descriptions` | compliant |
+| Ontology-extended types specialize a declared `base` (keeps base set fixed at three) | `SPECIFICATION.md` | heading `#### 4.2.1 Ontology-Extended Types` | compliant |
+| "MIF answers OKF's open questions" table: triad is MIF's answer to OKF's absent concept-type taxonomy | `SPECIFICATION.md` | heading `### MIF answers OKF's open questions`, table row "No concept-type taxonomy" | compliant |
+| Base-type triad still in live downstream use in ontology-corpus content (post ADR-018/019 relocation) | `ontologies/*.ontology.yaml` (`modeled-information-format/ontologies` repo) | `base:` field values (`semantic`/`episodic`/`procedural`) across ontology entity-type definitions | compliant |
+
+**Summary:** No material change since 2026-06-18. All six original findings
+re-verified against current file content and remain accurate; this entry
+re-anchors them to durable field names/headings rather than re-citing raw
+line numbers. ADR-018/ADR-019 (2026-07-01/07-02) does not affect this ADR:
+they relocated ontology *corpus* content, not the normative
+`ontology.schema.json`/JSON-LD context, which stay in this repo — so the
+schema finding above is unaffected. Added a seventh finding this pass,
+confirming the triad is still in live use in the relocated ontology corpus
+(spot-checked via `ontologies/health.ontology.yaml`'s `base:` field values).
+All five related ADRs (ADR-004, ADR-005, ADR-008, ADR-009, ADR-010) remain
+`status: accepted`, none renumbered or superseded.
+
+A real discrepancy was found and fixed in this same PR, not in this ADR's
+Audit table but in its own Decision text: Option 4's "Technical
+Characteristics" bullet stated the namespace hint as `semantic/*`,
+`episodic/*`, `procedural/*` — missing the underscore prefix that both
+`SPECIFICATION.md`'s §4.2 table and
+[ADR-005: Underscore Namespace Prefix](ADR-005-underscore-namespace-prefix.md)
+(listed in this ADR's own `related:` frontmatter) establish as the actual
+convention (`_semantic/*`, `_episodic/*`, `_procedural/*`). Corrected inline
+in this PR — a one-line, mechanical fix, not an editorial-scope decision.
 
 **Action Required:** None.

--- a/adr/ADR-005-underscore-namespace-prefix.md
+++ b/adr/ADR-005-underscore-namespace-prefix.md
@@ -9,7 +9,7 @@ tags:
   - filesystem
 status: accepted
 created: 2026-01-27
-updated: 2026-06-18
+updated: 2026-07-11
 author: MIF Maintainers
 project: MIF
 technologies:
@@ -20,6 +20,7 @@ audience:
 related:
   - ADR-001-cognitive-triad-taxonomy.md
   - ADR-003-obsidian-compatibility.md
+  - ADR-018-ontology-corpus-dedicated-repository-and-serving.md
 ---
 
 # ADR-005: Underscore Namespace Prefix Convention
@@ -230,6 +231,7 @@ burden:
 
 - [ADR-001: Cognitive Triad Taxonomy](ADR-001-cognitive-triad-taxonomy.md) — the prefix convention exists because the three base types it names are the cognitive-triad categories.
 - [ADR-003: Obsidian Compatibility](ADR-003-obsidian-compatibility.md) — the underscore prefix stays visible and well-behaved inside Obsidian vaults, where a dot prefix would not.
+- [ADR-018: Ontology Corpus: Dedicated Repository, Flat Layout, and Versioned Serving](ADR-018-ontology-corpus-dedicated-repository-and-serving.md) — the corpus layout this convention applies to now lives in the dedicated `ontologies` repo.
 
 ## Links
 
@@ -243,19 +245,27 @@ burden:
 
 ## Audit
 
+Findings cite durable anchors (field values / function name / comment
+text), not raw line numbers, and — for ontology content — the external
+`modeled-information-format/ontologies` repo (source of record since
+ADR-018/ADR-019) rather than paths inside this repo. `grep -n` for the
+quoted anchor text to find its current line.
+
 ### 2026-06-18
+
+**Audited revision:** `7f8d2de6c671cf5f354e4034b1524c0c112ddf1f`
 
 **Status:** Compliant
 
 **Findings:**
 
-| Finding | Files | Lines | Assessment |
-|---------|-------|-------|------------|
-| Underscore-prefixed `_semantic/...` base type used in domain ontology `suggest_namespace` values | `ontologies/examples/regenerative-agriculture.ontology.jsonld` | L1487, L1494 | compliant |
-| Underscore-prefixed `_episodic/...` base type used in domain ontology `suggest_namespace` values | `ontologies/examples/software-engineering.ontology.jsonld` | L850 | compliant |
-| Underscore-prefixed `_procedural/...` base type used in domain ontology `suggest_namespace` values | `ontologies/examples/software-engineering.ontology.jsonld` | L815 | compliant |
-| Domain sub-namespaces stay unprefixed beneath the prefixed base type (`_semantic/land`, `_procedural/animal-welfare`) | `ontologies/examples/regenerative-agriculture.ontology.jsonld` | L1487, L1522 | compliant |
-| Namespace validator treats `_semantic`/`_episodic`/`_procedural` base types as always-available parents that domain sub-namespaces inherit from | `scripts/validate-namespaces.py` | L92-L116 | compliant |
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Underscore-prefixed `_semantic/...` base type used in domain ontology `suggest_namespace` values | `ontologies/examples/regenerative-agriculture.ontology.jsonld` (path as it existed in this repo at this date) | `discovery.patterns[]` entries with `"suggest_namespace": "_semantic/land"` | compliant |
+| Underscore-prefixed `_episodic/...` base type used in domain ontology `suggest_namespace` values | `ontologies/examples/software-engineering.ontology.jsonld` (path as it existed in this repo at this date) | `discovery.patterns[]` entry with `"suggest_namespace": "_episodic/incidents"` | compliant |
+| Underscore-prefixed `_procedural/...` base type used in domain ontology `suggest_namespace` values | `ontologies/examples/software-engineering.ontology.jsonld` (path as it existed in this repo at this date) | `discovery.patterns[]` entries with `"suggest_namespace": "_procedural/runbooks"` | compliant |
+| Domain sub-namespaces stay unprefixed beneath the prefixed base type (`_semantic/land`, `_procedural/animal-welfare`) | `ontologies/examples/regenerative-agriculture.ontology.jsonld` (path as it existed in this repo at this date) | `discovery.patterns[]` entries `"suggest_namespace": "_semantic/land"` and `"suggest_namespace": "_procedural/animal-welfare"` | compliant |
+| Namespace validator treats `_semantic`/`_episodic`/`_procedural` base types as always-available parents that domain sub-namespaces inherit from | `scripts/validate-namespaces.py` | function `validate_memory_namespace`, the `if parent in mif_base_namespaces:` block | compliant |
 
 **Summary:** The underscore-prefix convention is applied uniformly across the
 shipped ontology examples — base types carry the `_` prefix and domain
@@ -264,3 +274,63 @@ encodes the same base-type-versus-domain distinction when resolving a memory's
 declared namespace.
 
 **Action Required:** None.
+
+### 2026-07-11
+
+**Audited revision:** `d2b0c577f59b30beadb12ffc45bf8e303b602377` (this repo);
+`bfed8cc17e08da4091e9b6c483cf03a150983cff` (`modeled-information-format/ontologies`,
+verified current against `origin/main` tip `99c984c78c5153f9ec697db8818e01adac42674f`
+— the intervening commits touch only CI/dependency pins, not ontology content)
+
+**Status:** Compliant
+
+**Findings:**
+
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Underscore-prefixed `_semantic/...` base type used in domain ontology `suggest_namespace` values | `regenerative-agriculture.ontology.jsonld` (`modeled-information-format/ontologies` repo) | `discovery.patterns[]` entries with `"suggest_namespace": "_semantic/land"` | compliant |
+| Underscore-prefixed `_episodic/...` base type used in domain ontology `suggest_namespace` values | `software-engineering.ontology.jsonld` (`ontologies` repo) | `discovery.patterns[]` entry `"suggest_namespace": "_episodic/incidents"` | compliant |
+| Underscore-prefixed `_procedural/...` base type used in domain ontology `suggest_namespace` values | `software-engineering.ontology.jsonld` (`ontologies` repo) | `discovery.patterns[]` entries `"suggest_namespace": "_procedural/runbooks"` | compliant |
+| Domain sub-namespaces stay unprefixed beneath the prefixed base type (`_semantic/land`, `_procedural/animal-welfare`) | `regenerative-agriculture.ontology.jsonld` (`ontologies` repo) | `discovery.patterns[]` entries `"suggest_namespace": "_semantic/land"` and `"suggest_namespace": "_procedural/animal-welfare"` | compliant |
+| Namespace validator treats `_semantic`/`_episodic`/`_procedural` base types as always-available parents that domain sub-namespaces inherit from | `scripts/validate-namespaces.py` | function `validate_memory_namespace`, the `if parent in mif_base_namespaces:` block (comment `# Check parent namespace (e.g., _semantic from _semantic/preferences)`) | compliant — see Summary for a tooling-wiring change since 2026-06-18 |
+
+**Summary:** Two material changes since 2026-06-18, neither breaking the
+underlying convention:
+
+1. **Ontology example content moved cross-repo.** `ontologies/examples/` no
+   longer exists in this repo — per ADR-018/ADR-019, ontology corpus content
+   is now sourced-of-record in `modeled-information-format/ontologies`.
+   Re-verified the underscore-prefix claim directly against that repo. The
+   convention is not just intact but more uniformly applied than the
+   original 2-file sample showed: swept all `*.ontology.jsonld` files in
+   that repo's current corpus and every `suggest_namespace` value across
+   all of them is underscore-prefixed at the base-type level with domain
+   sub-namespaces unprefixed beneath it, zero exceptions found. That repo
+   has also since documented its own parallel decision record for the same
+   convention (`docs/decisions/0001-underscore-prefixed-base-namespaces.md`,
+   accepted 2026-06-30) — corroborating, not superseding, this ADR.
+2. **`validate-namespaces.py` dropped from CI gating (logic unaffected).**
+   The script's `validate_memory_namespace` logic is unchanged in intent and
+   still correctly treats `_semantic`/`_episodic`/`_procedural` as
+   always-available parent namespaces. Per ADR-019's own 2026-07-02 audit
+   entry, this script was removed from `.github/workflows/validate.yml`'s
+   required check that same day: it hardcoded a scan path that no longer
+   exists in this repo. It is now a standalone script requiring an explicit
+   `--path` pointed at a real ontology corpus. This ADR's Decision Outcome
+   only ever claimed the script encodes the distinction in tooling — not
+   that it is CI-gating — so this finding stays compliant; already tracked
+   in ADR-019's own audit trail, no separate action needed here.
+
+Two related-decision linkage issues were found during this audit and are
+fixed in this same PR, not deferred: this ADR's `related:` frontmatter and
+Related Decisions section were missing a backlink to ADR-018 (which lists
+this ADR as related — "the corpus model the layout serves" — a one-way
+link `adr/README.md` requires be bidirectional), added above. Separately,
+this ADR's Context and Decision sections both cited ADR-003 as a live
+Obsidian-compatibility guarantee, stale since ADR-017 superseded ADR-003 —
+filed as [#251](https://github.com/modeled-information-format/MIF/issues/251)
+(shared with the identical issue found on ADR-002) rather than fixed inline,
+since correcting that prose is an editorial-scope decision.
+
+**Action Required:** None for the findings above. See #251 for the
+ADR-003/ADR-017 prose correction.

--- a/adr/ADR-011-markdown-canonical-derived-jsonld.md
+++ b/adr/ADR-011-markdown-canonical-derived-jsonld.md
@@ -11,7 +11,7 @@ tags:
   - lossless
 status: accepted
 created: 2026-06-18
-updated: 2026-06-18
+updated: 2026-07-11
 author: MIF Maintainers
 project: MIF
 technologies:
@@ -251,29 +251,89 @@ Mitigations:
 ## More Information
 
 - **Date:** 2026-06-18
-- **Source:** SPECIFICATION.md L38-L39 (Markdown-canonical / Invariant 2) and §6 "JSON-LD Projection (derived)" L624-L629; `scripts/mif_convert.py` (`emit-jsonld`, `roundtrip`).
+- **Source:** SPECIFICATION.md's **Markdown-canonical** design-goal bullet (Abstract, Invariant 2) and its `## 6. JSON-LD Projection (derived)` heading/callout; `scripts/mif_convert.py` (`emit-jsonld`, `roundtrip`).
 - **Related ADRs:** ADR-002, ADR-009, ADR-007, ADR-012
 
 ## Audit
 
+Findings cite durable anchors (heading / callout text / function name), not
+raw line numbers — line numbers in `SPECIFICATION.md` and
+`scripts/mif_convert.py` shift as unrelated content is added, which had
+already made every citation in this section's original entry stale (one by
+48 lines, two by landing inside unrelated functions entirely) by the
+2026-07-11 audit below. `grep -n` for the quoted anchor text to find its
+current line.
+
 ### 2026-06-18
+
+**Audited revision:** `7f8d2de6c671cf5f354e4034b1524c0c112ddf1f`
 
 **Status:** Compliant
 
 **Findings:**
 
-| Finding | Files | Lines | Assessment |
-|---------|-------|-------|------------|
-| Markdown-canonical stated normatively: ".md file is the source of truth; JSON-LD is a derived projection (Invariant 2)" | `SPECIFICATION.md` | L38-L39 | compliant |
-| JSON-LD section titled "JSON-LD Projection (derived)" and callout "Markdown is canonical (Invariant 2)... If the two disagree, markdown wins" | `SPECIFICATION.md` | L624-L629 | compliant |
-| Projection MUST NOT use the `.md` extension so OKF's `*.md` glob never ingests it; MUST round-trip losslessly | `SPECIFICATION.md` | L628-L629 | compliant |
-| One-directional derive: `emit-jsonld` reads each concept `.md` and writes a `.jsonld` projection (never hand-authored) | `scripts/mif_convert.py` | L267-L279 | compliant |
-| Lossless `markdown → json-ld → markdown` round-trip asserted by the `roundtrip` subcommand | `scripts/mif_convert.py` | L201-L213 | compliant |
-| `roundtrip` and `emit-jsonld` registered as CLI subcommands | `scripts/mif_convert.py` | L294-L297 | compliant |
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Markdown-canonical stated normatively: ".md file is the source of truth; JSON-LD is a derived projection (Invariant 2)" | `SPECIFICATION.md` | the `**Markdown-canonical**` bullet in the "MIF is designed to be:" list (Abstract section) | compliant |
+| JSON-LD section titled "JSON-LD Projection (derived)" and callout "Markdown is canonical (Invariant 2)... If the two disagree, markdown wins" | `SPECIFICATION.md` | heading `## 6. JSON-LD Projection (derived)`, callout opener "Markdown is canonical (Invariant 2)." | compliant |
+| Projection MUST NOT use the `.md` extension so OKF's `*.md` glob never ingests it; MUST round-trip losslessly | `SPECIFICATION.md` | same callout under `## 6. JSON-LD Projection (derived)`, sentence "MUST NOT use the `.md` extension ... If the two disagree, markdown wins." | compliant |
+| One-directional derive: `emit-jsonld` reads each concept `.md` and writes a `.jsonld` projection (never hand-authored) | `scripts/mif_convert.py` | function `cmd_emit_jsonld` | compliant |
+| Lossless `markdown → json-ld → markdown` round-trip asserted by the `roundtrip` subcommand | `scripts/mif_convert.py` | function `cmd_roundtrip` (calls `roundtrip_file`) | compliant |
+| `roundtrip` and `emit-jsonld` registered as CLI subcommands | `scripts/mif_convert.py` | `main()`, `sub.add_parser("roundtrip", ...)` and `sub.add_parser("emit-jsonld", ...)` calls | compliant |
 
 **Summary:** The Markdown-canonical / derived-JSON-LD relationship (Invariant 2),
 the `.jsonld` (never `.md`) extension rule, the lossless round-trip requirement, and
 the one-directional `emit-jsonld` derive plus the `roundtrip` losslessness assertion
 are all present and normative in the specification and the conversion tooling.
+
+**Action Required:** None.
+
+### 2026-07-11
+
+**Audited revision:** `d2b0c577f59b30beadb12ffc45bf8e303b602377`
+
+**Status:** Compliant
+
+**Findings:**
+
+| Finding | Files | Reference | Assessment |
+|---------|-------|-----------|------------|
+| Markdown-canonical stated normatively: ".md file is the source of truth; JSON-LD is a derived projection (Invariant 2)" | `SPECIFICATION.md` | the `**Markdown-canonical**` bullet in the "MIF is designed to be:" list (Abstract section) | compliant |
+| JSON-LD section titled "JSON-LD Projection (derived)" and callout "Markdown is canonical (Invariant 2)... If the two disagree, markdown wins" | `SPECIFICATION.md` | heading `## 6. JSON-LD Projection (derived)`, callout opener "Markdown is canonical (Invariant 2)." | compliant |
+| Projection MUST NOT use the `.md` extension so OKF's `*.md` glob never ingests it; MUST round-trip losslessly | `SPECIFICATION.md` | same callout under `## 6. JSON-LD Projection (derived)`, sentence "MUST NOT use the `.md` extension ... If the two disagree, markdown wins." | compliant |
+| One-directional derive: `emit-jsonld` reads each concept `.md` and writes a `.jsonld` projection (never hand-authored) | `scripts/mif_convert.py` | function `cmd_emit_jsonld` | compliant |
+| Lossless `markdown → json-ld → markdown` round-trip asserted by the `roundtrip` subcommand | `scripts/mif_convert.py` | function `cmd_roundtrip` (calls `roundtrip_file`, which performs the `md → jsonld → md` diff) | compliant |
+| `roundtrip` and `emit-jsonld` registered as CLI subcommands | `scripts/mif_convert.py` | `main()`, the `sub.add_parser("roundtrip", ...)` and `sub.add_parser("emit-jsonld", ...)` calls | compliant |
+
+**Summary:** Re-verified every 2026-06-18 finding against current file
+content, not just re-anchored at today's line numbers — all six still hold
+true with no material drift in behavior: `scripts/mif_convert.py`'s module
+docstring still states ".md concept file is the source of truth (Invariant 2)"
+and JSON-LD as "derived"; `roundtrip_file`
+still genuinely converts md → jsonld → md and diffs the result;
+`cmd_emit_jsonld` still writes only `.jsonld` (never `.md`) via
+`Path.with_suffix(".jsonld")`; both `roundtrip` and `emit-jsonld` are still
+wired into `.github/workflows/validate.yml`'s `okf-conformance` and
+`schema-validation` jobs (cross-checked against ADR-012's own 2026-07-11
+audit of that same workflow). Nothing renumbered/superseded among the
+related ADRs: ADR-002's `## Amendment` ("Refined by ADR-011") matches
+ADR-011's own "refines and amends ADR-002" framing with no contradiction;
+ADR-007 and ADR-009 are both still `accepted`, and ADR-007's `mif-spec.dev`
+domain amendment matches the live `CONTEXT_URL` in `scripts/mif_convert.py`.
+
+What did drift, severely, is the raw line-number citations themselves —
+exactly the problem this retrofit exists to fix. The `SPECIFICATION.md` §6
+callout moved from L624-L629 to L672-L677 (48 lines).
+`scripts/mif_convert.py` drifted even further: the old `L201-L213` citation
+for the round-trip assertion landed inside `jsonld_to_md()`'s
+passthrough-key list — unrelated code — and the old `L294-L297` citation
+for the CLI subparser registrations landed inside `cmd_to_markdown()`'s
+body, also unrelated. Both are concrete demonstrations of exactly why raw
+line-number citations are dangerous: they still resolved to *something*,
+but that something was no longer what the finding was about. This ADR's own
+`## More Information` `**Source:**` line carried the identical stale
+`L38-L39`/`L624-L629` citations outside the Audit table itself — corrected
+in this same PR alongside the table, since it's the same defect in the same
+file.
 
 **Action Required:** None.

--- a/adr/ADR-011-markdown-canonical-derived-jsonld.md
+++ b/adr/ADR-011-markdown-canonical-derived-jsonld.md
@@ -259,10 +259,11 @@ Mitigations:
 Findings cite durable anchors (heading / callout text / function name), not
 raw line numbers — line numbers in `SPECIFICATION.md` and
 `scripts/mif_convert.py` shift as unrelated content is added, which had
-already made every citation in this section's original entry stale (one by
-48 lines, two by landing inside unrelated functions entirely) by the
-2026-07-11 audit below. `grep -n` for the quoted anchor text to find its
-current line.
+already made every citation in this section's original entry stale by the
+2026-07-11 audit below, several of them landing inside unrelated code
+entirely rather than merely drifting a few lines (see that entry's
+Summary for the specific citations and where each now resolves).
+`grep -n` for the quoted anchor text to find its current line.
 
 ### 2026-06-18
 
@@ -323,14 +324,18 @@ domain amendment matches the live `CONTEXT_URL` in `scripts/mif_convert.py`.
 
 What did drift, severely, is the raw line-number citations themselves —
 exactly the problem this retrofit exists to fix. The `SPECIFICATION.md` §6
-callout moved from L624-L629 to L672-L677 (48 lines).
-`scripts/mif_convert.py` drifted even further: the old `L201-L213` citation
-for the round-trip assertion landed inside `jsonld_to_md()`'s
-passthrough-key list — unrelated code — and the old `L294-L297` citation
-for the CLI subparser registrations landed inside `cmd_to_markdown()`'s
-body, also unrelated. Both are concrete demonstrations of exactly why raw
-line-number citations are dangerous: they still resolved to *something*,
-but that something was no longer what the finding was about. This ADR's own
+callout moved from L624-L629 to L672-L677 (48 lines); the Abstract's
+Markdown-canonical bullet moved from L38-L39 to L39-40 (1 line, cosmetically
+fine but still a raw citation). `scripts/mif_convert.py` drifted far more
+severely: the old `L267-L279` citation for the `emit-jsonld` derive now
+lands inside `cmd_roundtrip()`'s reporting logic, the old `L201-L213`
+citation for the round-trip assertion now lands inside `jsonld_to_md()`'s
+passthrough-key list, and the old `L294-L297` citation for the CLI
+subparser registrations now lands inside `cmd_to_markdown()`'s body — all
+three unrelated code, none of it what the original finding cited. These are
+concrete demonstrations of exactly why raw line-number citations are
+dangerous: they still resolved to *something*, but that something was no
+longer what the finding was about. This ADR's own
 `## More Information` `**Source:**` line carried the identical stale
 `L38-L39`/`L624-L629` citations outside the Audit table itself — corrected
 in this same PR alongside the table, since it's the same defect in the same


### PR DESCRIPTION
Closes #247. Batch 2 of 4 for #245 (the retrofit Story under #241).

## What

Re-verifies and re-anchors the Audit tables (both historical and new dated entries) of ADR-001, ADR-005, and ADR-011. Applies the corrected retrofit scope batch 1's Copilot review (PR #253) established: historical entries get converted too, not just the newly-added one — matching ADR-012/PR #242's own actual precedent, which this batch's initial draft had deviated from before it was caught.

## Real discrepancies found and handled per ADR

- **ADR-001**: fixed inline — Option 4's namespace hint bullet was missing the underscore prefix (`semantic/*` instead of `_semantic/*`), contradicting both SPECIFICATION.md's own table and ADR-005 (listed in this ADR's own `related:` frontmatter). One-line mechanical fix.
- **ADR-005**: all four ontology-content findings' source moved to `modeled-information-format/ontologies`; re-verified directly against that repo's current `main` (swept all 29 `*.ontology.jsonld` files, 164 `suggest_namespace` values, zero non-underscore-prefixed exceptions). Fixed inline: a missing bidirectional `related:` link to ADR-018. Folded into [#251](https://github.com/modeled-information-format/MIF/issues/251) (shared with ADR-002's identical defect from batch 1) rather than fixed inline: two stale ADR-003 references predating ADR-017's supersession of ADR-003 — editorial-scope wording.
- **ADR-011**: no discrepancy in the Audit table's own findings, but its More Information Source line carried the same stale raw-line citations the Audit table itself was being retrofitted away from — fixed in the same pass.

## Testing

- `python3 scripts/check_adr_audit_citations.py --base origin/main --head HEAD` — clean.
- A dedicated verification agent independently re-checked every anchor and every "compliant" claim in this diff against real file/repo content (including a live checkout of the `ontologies` repo) before this PR was opened — one minor prose touch-up found and fixed (a redundant line-number reference in ADR-011's Summary, sitting alongside its own already-durable quoted-text anchor).