### PR TITLE
fix(schema): let memoryType satisfy conceptType's required check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Temporal consistency + properties construct regression suite
         run: python -m pytest scripts/test_temporal_and_properties.py -q
 
+      - name: conceptType/memoryType alias regression suite
+        run: python -m pytest scripts/test_concept_type_alias.py -q
+
   schema-validation:
     name: Validate JSON-LD Projection Against Schema
     runs-on: ubuntu-latest

--- a/public/schema/1.3.0/container.schema.json
+++ b/public/schema/1.3.0/container.schema.json
@@ -123,7 +123,7 @@
           ]
         },
         "payload": {
-          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType required; see ADR-021 Decision point 1). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
+          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType or memoryType required; see ADR-021 Decision point 1 and issue #274). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType-or-memoryType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
           "type": "object"
         }
       },
@@ -139,8 +139,9 @@
           "then": {
             "properties": {
               "payload": {
-                "required": [
-                  "conceptType"
+                "anyOf": [
+                  { "required": ["conceptType"] },
+                  { "required": ["memoryType"] }
                 ]
               }
             }

--- a/public/schema/1.3.0/mif.schema.json
+++ b/public/schema/1.3.0/mif.schema.json
@@ -4,7 +4,11 @@
   "title": "MIF — Modeled Information Format (v1.0)",
   "description": "JSON Schema for validating the derived JSON-LD projection of a MIF v1.0 concept",
   "type": "object",
-  "required": ["@context", "@type", "@id", "conceptType", "content", "created"],
+  "required": ["@context", "@type", "@id", "content", "created"],
+  "anyOf": [
+    { "required": ["conceptType"] },
+    { "required": ["memoryType"] }
+  ],
   "properties": {
     "@context": {
       "description": "JSON-LD context",

--- a/public/schema/container.schema.json
+++ b/public/schema/container.schema.json
@@ -123,7 +123,7 @@
           ]
         },
         "payload": {
-          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType required; see ADR-021 Decision point 1). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
+          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType or memoryType required; see ADR-021 Decision point 1 and issue #274). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType-or-memoryType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
           "type": "object"
         }
       },
@@ -139,8 +139,9 @@
           "then": {
             "properties": {
               "payload": {
-                "required": [
-                  "conceptType"
+                "anyOf": [
+                  { "required": ["conceptType"] },
+                  { "required": ["memoryType"] }
                 ]
               }
             }

--- a/public/schema/latest/container.schema.json
+++ b/public/schema/latest/container.schema.json
@@ -123,7 +123,7 @@
           ]
         },
         "payload": {
-          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType required; see ADR-021 Decision point 1). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
+          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType or memoryType required; see ADR-021 Decision point 1 and issue #274). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType-or-memoryType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
           "type": "object"
         }
       },
@@ -139,8 +139,9 @@
           "then": {
             "properties": {
               "payload": {
-                "required": [
-                  "conceptType"
+                "anyOf": [
+                  { "required": ["conceptType"] },
+                  { "required": ["memoryType"] }
                 ]
               }
             }

--- a/public/schema/latest/mif.schema.json
+++ b/public/schema/latest/mif.schema.json
@@ -4,7 +4,11 @@
   "title": "MIF — Modeled Information Format (v1.0)",
   "description": "JSON Schema for validating the derived JSON-LD projection of a MIF v1.0 concept",
   "type": "object",
-  "required": ["@context", "@type", "@id", "conceptType", "content", "created"],
+  "required": ["@context", "@type", "@id", "content", "created"],
+  "anyOf": [
+    { "required": ["conceptType"] },
+    { "required": ["memoryType"] }
+  ],
   "properties": {
     "@context": {
       "description": "JSON-LD context",

--- a/public/schema/mif.schema.json
+++ b/public/schema/mif.schema.json
@@ -4,7 +4,11 @@
   "title": "MIF — Modeled Information Format (v1.0)",
   "description": "JSON Schema for validating the derived JSON-LD projection of a MIF v1.0 concept",
   "type": "object",
-  "required": ["@context", "@type", "@id", "conceptType", "content", "created"],
+  "required": ["@context", "@type", "@id", "content", "created"],
+  "anyOf": [
+    { "required": ["conceptType"] },
+    { "required": ["memoryType"] }
+  ],
   "properties": {
     "@context": {
       "description": "JSON-LD context",

--- a/public/schema/v1/container.schema.json
+++ b/public/schema/v1/container.schema.json
@@ -123,7 +123,7 @@
           ]
         },
         "payload": {
-          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType required; see ADR-021 Decision point 1). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
+          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType or memoryType required; see ADR-021 Decision point 1 and issue #274). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType-or-memoryType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
           "type": "object"
         }
       },
@@ -139,8 +139,9 @@
           "then": {
             "properties": {
               "payload": {
-                "required": [
-                  "conceptType"
+                "anyOf": [
+                  { "required": ["conceptType"] },
+                  { "required": ["memoryType"] }
                 ]
               }
             }

--- a/public/schema/v1/mif.schema.json
+++ b/public/schema/v1/mif.schema.json
@@ -4,7 +4,11 @@
   "title": "MIF — Modeled Information Format (v1.0)",
   "description": "JSON Schema for validating the derived JSON-LD projection of a MIF v1.0 concept",
   "type": "object",
-  "required": ["@context", "@type", "@id", "conceptType", "content", "created"],
+  "required": ["@context", "@type", "@id", "content", "created"],
+  "anyOf": [
+    { "required": ["conceptType"] },
+    { "required": ["memoryType"] }
+  ],
   "properties": {
     "@context": {
       "description": "JSON-LD context",

--- a/schema/container.schema.json
+++ b/schema/container.schema.json
@@ -123,7 +123,7 @@
           ]
         },
         "payload": {
-          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType required; see ADR-021 Decision point 1). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
+          "description": "For kind:memory, MUST validate against https://mif-spec.dev/schema/mif.schema.json (conceptType or memoryType required; see ADR-021 Decision point 1 and issue #274). For kind:document, MUST validate against https://mif-spec.dev/schema/mif.schema.json#/$defs/DocumentReference (ADR-014 / ADR-021 Decision point 2) via schema/document-reference.schema.json. This schema does not duplicate either definition beyond the two minimal kind-discrimination anchors asserted in the allOf below (payload.conceptType-or-memoryType required for kind:memory; payload.@type const for kind:document -- keep those in sync with mif.schema.json if its requirements ever change); scripts/validate_container.py dispatches on `kind` and validates payload against the correct external schema.",
           "type": "object"
         }
       },
@@ -139,8 +139,9 @@
           "then": {
             "properties": {
               "payload": {
-                "required": [
-                  "conceptType"
+                "anyOf": [
+                  { "required": ["conceptType"] },
+                  { "required": ["memoryType"] }
                 ]
               }
             }

--- a/schema/mif.schema.json
+++ b/schema/mif.schema.json
@@ -4,7 +4,11 @@
   "title": "MIF — Modeled Information Format (v1.0)",
   "description": "JSON Schema for validating the derived JSON-LD projection of a MIF v1.0 concept",
   "type": "object",
-  "required": ["@context", "@type", "@id", "conceptType", "content", "created"],
+  "required": ["@context", "@type", "@id", "content", "created"],
+  "anyOf": [
+    { "required": ["conceptType"] },
+    { "required": ["memoryType"] }
+  ],
   "properties": {
     "@context": {
       "description": "JSON-LD context",

--- a/scripts/test_concept_type_alias.py
+++ b/scripts/test_concept_type_alias.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Regression test for issue #274: `memoryType` is documented (README.md,
+docs/SCHEMA-REFERENCE.md, ns/README.md, ADR-001's compliance audit) as a
+deprecated v0.1 alias for `conceptType`, "retained for backward
+compatibility" -- but `schema/mif.schema.json`'s flat `required` list only
+ever accepted `conceptType`, so a document carrying just the legacy
+`memoryType` field always failed validation regardless of age. Fixed by
+replacing the flat `conceptType` requirement with a top-level
+`anyOf: [{required: [conceptType]}, {required: [memoryType]}]`, mirroring
+the same pattern `DocumentReference` already uses for its own `url`/`id`
+alternative.
+
+The same duplicate `conceptType`-required anchor exists in
+`schema/container.schema.json`'s `$defs.Record` (documented at that file's
+own `payload` description as needing to be "kept in sync with
+mif.schema.json if its requirements ever change") -- fixed the same way,
+plus the versioned/aliased mirrors under `public/schema/` that a local
+`/code-review` pass found were left stale (a repeat of issue #184: canonical
+schema changed, `latest`/`v1` aliases left behind), which would have failed
+this repo's own required `schema-check.yml` mirror-alias gate.
+
+Run: ``python -m pytest scripts/test_concept_type_alias.py -q`` from the repo root.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_DIR = ROOT / "schema"
+PUBLIC_SCHEMA_DIR = ROOT / "public" / "schema"
+
+MIF_SCHEMA = json.loads((SCHEMA_DIR / "mif.schema.json").read_text())
+CONTAINER_SCHEMA = json.loads((SCHEMA_DIR / "container.schema.json").read_text())
+RECORD_SCHEMA = CONTAINER_SCHEMA["$defs"]["Record"]
+
+BASE_PAYLOAD = {
+    "@context": "https://mif-spec.dev/schema/context.jsonld",
+    "@type": "Memory",
+    "@id": "urn:mif:11111111-1111-4111-8111-111111111111",
+    "content": "GB300 NVL72 compute nodes MUST meet NVQual and NVCert.",
+    "created": "2026-06-25T00:00:00Z",
+}
+
+
+def _mif_validator() -> jsonschema.Draft202012Validator:
+    return jsonschema.Draft202012Validator(MIF_SCHEMA)
+
+
+def _record_validator() -> jsonschema.Draft202012Validator:
+    return jsonschema.Draft202012Validator(RECORD_SCHEMA)
+
+
+# --------------------------------------------------------------------------- #
+# schema/mif.schema.json: the per-unit Memory payload.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"conceptType": "semantic"},
+        {"memoryType": "semantic"},
+        {"conceptType": "semantic", "memoryType": "semantic"},
+    ],
+    ids=["conceptType-alone", "memoryType-alone", "both-present"],
+)
+def test_concept_type_or_memory_type_satisfies_required(extra):
+    _mif_validator().validate({**BASE_PAYLOAD, **extra})
+
+
+def test_neither_concept_type_nor_memory_type_is_invalid():
+    with pytest.raises(jsonschema.ValidationError):
+        _mif_validator().validate(dict(BASE_PAYLOAD))
+
+
+def test_memory_type_does_not_bypass_other_required_fields():
+    """The anyOf only substitutes for conceptType -- it must not mask an
+    unrelated missing required field (e.g. `created`)."""
+    payload = {**BASE_PAYLOAD, "memoryType": "semantic"}
+    del payload["created"]
+    with pytest.raises(jsonschema.ValidationError):
+        _mif_validator().validate(payload)
+
+
+def test_memory_type_out_of_enum_is_still_rejected():
+    """memoryType must still honor the triad enum -- the anyOf only changes
+    which field can satisfy `required`, not what values are acceptable."""
+    with pytest.raises(jsonschema.ValidationError):
+        _mif_validator().validate({**BASE_PAYLOAD, "memoryType": "not-a-real-value"})
+
+
+# --------------------------------------------------------------------------- #
+# schema/container.schema.json: the Container Profile envelope's kind:memory
+# discrimination anchor (duplicates mif.schema.json's requirement by design;
+# must be kept in lockstep -- this is the path scripts/validate_container.py
+# actually exercises for *.corpus.json envelopes).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"conceptType": "semantic"},
+        {"memoryType": "semantic"},
+    ],
+    ids=["conceptType-alone", "memoryType-alone"],
+)
+def test_container_memory_record_accepts_concept_type_or_memory_type(extra):
+    record = {"kind": "memory", "payload": {**BASE_PAYLOAD, **extra}}
+    _record_validator().validate(record)
+
+
+def test_container_memory_record_without_either_is_invalid():
+    record = {"kind": "memory", "payload": dict(BASE_PAYLOAD)}
+    with pytest.raises(jsonschema.ValidationError):
+        _record_validator().validate(record)
+
+
+# --------------------------------------------------------------------------- #
+# Mirror consistency: the canonical root (schema/, public/schema/) and the
+# "live" versioned mirror that public/schema/index.json's `latest`/`v1`
+# aliases currently point at must be byte-identical for mif.schema.json and
+# container.schema.json -- same invariant schema-check.yml's own
+# mirror-alias gate enforces (see issue #184: canonical changed, `latest`
+# left stale, gate caught it). A frozen, already-released version (anything
+# NOT the alias target) is intentionally NOT compared here.
+# --------------------------------------------------------------------------- #
+def _live_mirror_version() -> str:
+    index = json.loads((PUBLIC_SCHEMA_DIR / "index.json").read_text())
+    return index["aliases"]["latest"]
+
+
+@pytest.mark.parametrize("schema_name", ["mif.schema.json", "container.schema.json"])
+def test_canonical_root_matches_public_mirror(schema_name):
+    assert (SCHEMA_DIR / schema_name).read_text() == (
+        PUBLIC_SCHEMA_DIR / schema_name
+    ).read_text()
+
+
+@pytest.mark.parametrize("schema_name", ["mif.schema.json", "container.schema.json"])
+@pytest.mark.parametrize("alias", ["latest", "v1"])
+def test_live_alias_mirror_matches_canonical_root(schema_name, alias):
+    live_version = _live_mirror_version()
+    canonical = (PUBLIC_SCHEMA_DIR / schema_name).read_text()
+    assert canonical == (PUBLIC_SCHEMA_DIR / alias / schema_name).read_text()
+    assert canonical == (PUBLIC_SCHEMA_DIR / live_version / schema_name).read_text()


### PR DESCRIPTION
Closes #274.

## Problem

`schema/mif.schema.json`'s `required` list only ever accepted `conceptType`, unconditionally — despite `README.md`, `docs/SCHEMA-REFERENCE.md`, `ns/README.md`, and `ADR-001`'s compliance audit all describing `memoryType` as a deprecated v0.1 alias for `conceptType`, "retained for backward compatibility." A document carrying only the legacy `memoryType` field always failed validation regardless of age — the documented promise was never actually implemented.

This surfaced concretely in PR #205, where an example using `memoryType` per that documented framing failed CI.

## Fix

- `schema/mif.schema.json` (+ `public/schema/mif.schema.json`): replaced the flat `conceptType` requirement with a top-level `anyOf: [{required:[conceptType]}, {required:[memoryType]}]`, mirroring the existing `DocumentReference` `$defs` entry's own `url`/`id` `anyOf` pattern already in the same file.
- `schema/container.schema.json` (+ its mirror): the Container Profile envelope schema has its own duplicate `conceptType`-required anchor for `kind:memory` records (documented as needing to stay in sync with `mif.schema.json`) — fixed the same way, so a legacy `memoryType`-only record inside a `*.corpus.json` envelope is no longer rejected at the envelope level after passing the per-unit schema.
- Propagated both fixes to every schema mirror that is currently "live" — `public/schema/1.3.0/`, `latest/`, and `v1/`, which `public/schema/index.json`'s aliases currently point at and which were confirmed (via diff) to be byte-identical to the pre-fix canonical root, not a frozen prior release. Older frozen versions (`1.2.2`, `1.2.1`, `1.2.0`, `1.0.0`, `0.1.0`) are untouched.
- Added `scripts/test_concept_type_alias.py` (15 cases) as a permanent regression gate, wired into `.github/workflows/validate.yml`: `conceptType`-alone/`memoryType`-alone/both/neither across both schemas, mirror-consistency checks, and negative cases confirming the `anyOf` doesn't mask an unrelated missing required field or bypass the triad enum.

## Verification

Re-ran every existing local gate against the change: `okf_validate.py` (15 concepts, PASS), `mif_convert.py roundtrip` (lossless, PASS), `scripts/validate_container.py` (PASS), ajv `compile` on all 5 copies of both schemas (all valid), full `emit-jsonld` + ajv `validate` over all 15 examples (all valid), `test_subtype_of.py` and `test_temporal_and_properties.py` (unaffected, still pass).

## Test plan

- [x] `python -m pytest scripts/test_concept_type_alias.py -v` — 15 passed
- [x] `python scripts/okf_validate.py examples profiles/ai-memory/examples docs/examples/memories` — PASS
- [x] `python scripts/mif_convert.py roundtrip examples profiles/ai-memory/examples docs/examples/memories` — PASS
- [x] `python scripts/validate_container.py` — PASS
- [x] ajv `compile` on `schema/` and all `public/schema/` mirrors for both `mif.schema.json` and `container.schema.json` — all valid
